### PR TITLE
fix: restore zero-dependency Python 3.7 typing

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -234,6 +234,14 @@ runs:
           --platform "$platform" \
           dist/*.whl
 
+    - name: Test zero-backport Python 3.7 wheel
+      if: inputs.python-version == '3.7'
+      shell: bash
+      run: |
+        if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
+          python scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
+        fi
+
     - name: Test wheel
       if: inputs.test-wheel == 'true'
       shell: bash

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -458,6 +458,25 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
+      - name: Checkout immutable distribution verification tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .workflow-tools
+          sparse-checkout: |
+            compatibility
+            scripts/ci
+          persist-credentials: false
+      - name: Validate complete Core distribution set before publication
+        env:
+          RELEASE_VERSION: ${{ inputs.release-tag-name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${RELEASE_VERSION#v}"
+          python .workflow-tools/scripts/ci/check_release_distribution_set.py \
+            --dist-dir dist \
+            --version "$RELEASE_VERSION"
       - name: Upload wheels to GitHub Release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -213,11 +213,12 @@ jobs:
           --platform any
           dist/*.whl
         shell: bash
-      - name: Provision Python 3.7 smoke dependencies
+      - name: Test zero-backport Python 3.7 wheel
         shell: bash
         run: |
-          TYPING_EXTENSIONS_VERSION="$(python -c 'import json; print(json.load(open(".workflow-tools/compatibility/python.json", encoding="utf-8"))["test_toolchain"]["typing_extensions"])')"
-          python -m pip install --disable-pip-version-check "typing-extensions==${TYPING_EXTENSIONS_VERSION}"
+          if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
+            python .workflow-tools/scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
+          fi
       - name: Test py37-lite wheel
         shell: bash
         run: |
@@ -274,11 +275,12 @@ jobs:
           --profile native_py37
           --platform linux-x86_64
           dist/*.whl
-      - name: Provision Python 3.7 smoke dependencies
+      - name: Test zero-backport Python 3.7 wheel
         shell: bash
         run: |
-          TYPING_EXTENSIONS_VERSION="$(python -c 'import json; print(json.load(open(".workflow-tools/compatibility/python.json", encoding="utf-8"))["test_toolchain"]["typing_extensions"])')"
-          python -m pip install --disable-pip-version-check "typing-extensions==${TYPING_EXTENSIONS_VERSION}"
+          if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
+            python .workflow-tools/scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
+          fi
       - name: Test native Python 3.7 wheel with workflow smoke
         shell: bash
         run: |
@@ -322,11 +324,12 @@ jobs:
           --profile native_py37
           --platform windows-x86_64
           dist/*.whl
-      - name: Provision Python 3.7 smoke dependencies
+      - name: Test zero-backport Python 3.7 wheel
         shell: bash
         run: |
-          TYPING_EXTENSIONS_VERSION="$(python -c 'import json; print(json.load(open(".workflow-tools/compatibility/python.json", encoding="utf-8"))["test_toolchain"]["typing_extensions"])')"
-          python -m pip install --disable-pip-version-check "typing-extensions==${TYPING_EXTENSIONS_VERSION}"
+          if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
+            python .workflow-tools/scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
+          fi
       - name: Test native Python 3.7 wheel with workflow smoke
         shell: bash
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -213,23 +213,13 @@ jobs:
           --platform any
           dist/*.whl
         shell: bash
-      - name: Test zero-backport Python 3.7 wheel
-        shell: bash
-        run: |
-          if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
-            python .workflow-tools/scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
-          fi
       - name: Test py37-lite wheel
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout-ref || github.ref }}
         shell: bash
         run: |
-          python -m pip install --force-reinstall --no-deps dist/*.whl
-          if [[ -f compatibility/python.json ]]; then
-            python .workflow-tools/scripts/ci/smoke_python37_runtime.py --profile lite_py37
-          else
-            # Historical tags predate the public API contract exercised by the
-            # current smoke. Keep release backfills install/import compatible.
-            python -c "import dcc_mcp_core"
-          fi
+          python .workflow-tools/scripts/ci/python37_wheel_smoke.py \
+            --wheel 'dist/*.whl' --profile lite_py37 --checkout-ref "$CHECKOUT_REF"
       - name: Upload py37-lite wheel artifact
         uses: actions/upload-artifact@v7
         with:
@@ -275,21 +265,13 @@ jobs:
           --profile native_py37
           --platform linux-x86_64
           dist/*.whl
-      - name: Test zero-backport Python 3.7 wheel
-        shell: bash
-        run: |
-          if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
-            python .workflow-tools/scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
-          fi
       - name: Test native Python 3.7 wheel with workflow smoke
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout-ref || github.ref }}
         shell: bash
         run: |
-          python -m pip install --force-reinstall --no-deps dist/*.whl
-          if [[ -f compatibility/python.json ]]; then
-            python .workflow-tools/scripts/ci/smoke_python37_runtime.py --profile native_py37
-          else
-            python -c "import dcc_mcp_core"
-          fi
+          python .workflow-tools/scripts/ci/python37_wheel_smoke.py \
+            --wheel 'dist/*.whl' --profile native_py37 --checkout-ref "$CHECKOUT_REF"
   windows-py37:
     needs: [classify-release-assets]
     if: >-
@@ -324,21 +306,13 @@ jobs:
           --profile native_py37
           --platform windows-x86_64
           dist/*.whl
-      - name: Test zero-backport Python 3.7 wheel
-        shell: bash
-        run: |
-          if [[ -f tests/test_issue_2388_zero_typing_extensions.py ]]; then
-            python .workflow-tools/scripts/ci/smoke_zero_typing_extensions.py --wheel 'dist/*.whl'
-          fi
       - name: Test native Python 3.7 wheel with workflow smoke
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout-ref || github.ref }}
         shell: bash
         run: |
-          python -m pip install --force-reinstall --no-deps dist/*.whl
-          if [[ -f compatibility/python.json ]]; then
-            python .workflow-tools/scripts/ci/smoke_python37_runtime.py --profile native_py37
-          else
-            python -c "import dcc_mcp_core"
-          fi
+          python .workflow-tools/scripts/ci/python37_wheel_smoke.py \
+            --wheel 'dist/*.whl' --profile native_py37 --checkout-ref "$CHECKOUT_REF"
   macos:
     needs: [classify-release-assets]
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,8 +659,18 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .workflow-tools
           sparse-checkout: |
+            compatibility
             scripts/ci
           persist-credentials: false
+
+      - name: Validate complete Core distribution set before PyPI
+        env:
+          RELEASE_VERSION: ${{ needs.release-please.outputs.version }}
+        shell: bash
+        run: >-
+          python .workflow-tools/scripts/ci/check_release_distribution_set.py
+          --dist-dir dist
+          --version "$RELEASE_VERSION"
 
       - name: Check PyPI project size budget
         shell: bash

--- a/compatibility/python.json
+++ b/compatibility/python.json
@@ -55,6 +55,12 @@
     "dcc-mcp-core": {
       "pyproject": "pyproject.toml",
       "support_profile": "lts",
+      "forbidden_runtime_dependencies": [
+        {
+          "name": "typing-extensions",
+          "from_version": "0.20.22"
+        }
+      ],
       "wheel_resources": [
         {
           "member": "dcc_mcp_core/schemas/adapter-install-sop-v1.schema.json",

--- a/docs/guide/agents-reference.md
+++ b/docs/guide/agents-reference.md
@@ -748,8 +748,8 @@ freeze. Public adapter imports belong to ownership-oriented namespaces such as
 - **Don't overlap `search-hint` keywords between infrastructure and domain skills** — overlapping keywords make `search_skills()` return ambiguous results
 - Don't use removed transport APIs: `FramedChannel`, `connect_ipc()`, `IpcListener`, `TransportManager`, `CircuitBreaker`, `ConnectionPool` — removed in v0.14 (#251). Use `IpcChannelAdapter` / `DccLinkFrame` instead
 - Don't add Python runtime dependencies without an accepted compatibility or
-  capability boundary. Python 3.7 uses the pinned `typing_extensions` backport;
-  optional capabilities belong in extras such as `bridge` or `semantic`.
+  capability boundary. Python 3.7 uses Core's bounded private `_typing` subset;
+  optional capabilities and test-only backports belong in explicit extras.
 - Don't manually bump versions or edit `CHANGELOG.md` — Release Please handles this
 - Don't hardcode API keys, tokens, or passwords — use environment variables
 - Don't use `docs/` prefix in branch names — causes `refs/heads/docs/...` conflicts

--- a/docs/guide/maya2022-support.md
+++ b/docs/guide/maya2022-support.md
@@ -77,9 +77,9 @@ Repository rulesets should require the exact aggregate job name
   shipped Python modules.
 - Do not evaluate modern annotations on Python 3.7 without a compatibility
   adapter. `compile()` alone is not a runtime proof.
-- Use `dcc_mcp_core._typing`, which selects the standard library or the pinned
-  official `typing_extensions` backport, for runtime `Protocol`, `Literal`,
-  and related APIs unavailable from Python 3.7's `typing` module.
+- Use `dcc_mcp_core._typing`, which preserves standard-library identity on
+  Python 3.8+ and provides Core's bounded fail-closed `Protocol`, `Literal`,
+  and `runtime_checkable` subset on Python 3.7 without importing a backport.
 - Do not import `_core` unconditionally on code paths that must support the
   lite profile.
 - New public Python APIs need tests in both the native and lite profiles when

--- a/docs/guide/py37-lite-architecture.md
+++ b/docs/guide/py37-lite-architecture.md
@@ -97,8 +97,9 @@ stores evaluated aliases must use a compatibility layer.
 Python 3.7's `typing` module lacks several runtime APIs used by newer code,
 including `Literal`, `Protocol`, and `runtime_checkable`. The private
 `dcc_mcp_core._typing` boundary selects the standard library on modern Python
-and the pinned official `typing_extensions` backport on Python 3.7. Do not
-implement local typing semantics.
+and a bounded fail-closed Core subset on Python 3.7. It never imports
+`typing_extensions`; production callers must not create a second compatibility
+path.
 
 ## Source rules
 

--- a/docs/guide/skills.md
+++ b/docs/guide/skills.md
@@ -417,9 +417,10 @@ Supported types (stdlib only): `bool`, `int`, `float`, `str`, `bytes`,
 `Literal[...]`, `Enum`, `datetime.datetime`, `datetime.date`,
 `pathlib.Path`, `uuid.UUID`, `@dataclass`, `TypedDict`. On Python 3.7
 (Maya 2022), spell containers and unions with `typing.List`, `typing.Dict`,
-`typing.Tuple`, `typing.Optional`, and `typing.Union`; `Literal` and
-`TypedDict` require `typing_extensions` in the skill author's environment.
-The core package still imports without third-party Python library dependencies. Unsupported
+`typing.Tuple`, `typing.Optional`, and `typing.Union`. Core-owned runtime code
+uses the private `_typing.Literal` subset; skill authors who choose external
+`TypedDict` or typing backports must install them explicitly or provide an
+explicit schema. The core package still imports without third-party Python library dependencies. Unsupported
 types raise `TypeError` with a clear escape hatch: pass an explicit
 `input_schema=...` dict or use pydantic's `MyModel.model_json_schema()`.
 

--- a/docs/guide/what-is-dcc-mcp-core.md
+++ b/docs/guide/what-is-dcc-mcp-core.md
@@ -6,7 +6,7 @@
 - **MCP-only IDE clients** → the gateway's small, static MCP workflow (`search`, `describe`, `load_skill`, `call`).
 - **Traditional callers** (cURL, CI, any HTTP client) → a full **`/v1/*` REST API** on every per-DCC server and on the gateway facade.
 
-The core is Rust, compiled to a Python extension via [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin). Python 3.8+ needs no typing backport; Python 3.7 installs the pinned `typing_extensions` compatibility dependency. The companion `dcc-mcp-server` wheel supplies the packaged gateway daemon binary.
+The core is Rust, compiled to a Python extension via [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin). Python 3.8+ uses standard-library typing objects directly; Python 3.7 uses a bounded internal compatibility subset without installing or importing a typing backport. The companion `dcc-mcp-server` wheel supplies the packaged gateway daemon binary.
 
 ---
 

--- a/docs/zh/guide/agents-reference.md
+++ b/docs/zh/guide/agents-reference.md
@@ -433,7 +433,7 @@ json_str = result.to_json()    # JSON 字符串
 - **不要在 domain skill `description` 中省略"Not for X"句** — 代理需要显式反例以避免选择错误的 skill
 - **不要在 infrastructure 和 domain skill 之间重叠 `search-hint` 关键词** — 重叠关键词使 `search_skills()` 返回歧义结果
 - 不要使用已移除的传输 API：`FramedChannel`、`connect_ipc()`、`IpcListener`、`TransportManager`、`CircuitBreaker`、`ConnectionPool` — 在 v0.14 (#251) 中移除。改用 `IpcChannelAdapter` / `DccLinkFrame`
-- 不要添加 Python 运行时依赖 — 项目设计为零依赖
+- 不要添加 Python 运行时依赖 — Python 3.7 由 Core 私有 `_typing` 有界兼容层支持；测试 backport 只能放在显式 extra 中
 - 不要手动更新版本号或编辑 `CHANGELOG.md` — Release Please 负责处理
 - 不要硬编码 API 密钥、令牌或密码 — 使用环境变量
 - 不要在分支名中使用 `docs/` 前缀 — 会导致 `refs/heads/docs/...` 冲突

--- a/docs/zh/guide/faq.md
+++ b/docs/zh/guide/faq.md
@@ -51,7 +51,7 @@ Python 3.7–3.14 都有 CI 覆盖。Python 3.7 具备原生 wheel、运行时�
 
 ### 是否有 Python 库运行时依赖？
 
-**依赖保持最小。** 核心逻辑编译进 Rust 扩展；Python 3.7 额外使用固定版本的官方 `typing_extensions` backport。默认包还依赖配套的 `dcc-mcp-server` wheel，让 `DccServerBase` 可以从打包二进制启动 gateway daemon，而不依赖 `PATH`。
+**没有第三方 Python 库运行依赖。** Python 3.8+ 直接使用标准库 typing；Python 3.7 使用 Core 内部有界兼容层，不安装或导入 `typing_extensions`。默认包仍依赖配套的 `dcc-mcp-server` wheel，让 `DccServerBase` 可以从打包二进制启动 gateway daemon，而不依赖 `PATH`。
 
 ## 安装
 

--- a/docs/zh/guide/maya2022-support.md
+++ b/docs/zh/guide/maya2022-support.md
@@ -70,9 +70,10 @@ Maya 2022 / CPython 3.7
 - 发布代码不能使用 assignment expression、仅限位置参数、debug f-string、
   `match` 等 Python 3.8+ 语法。
 - `compile()` 通过不等于运行时兼容；不能在 3.7 上直接求值现代注解。
-- 对 Python 3.7 `typing` 中不存在的 `Protocol`、`Literal` 等运行时 API，
-  使用 `dcc_mcp_core._typing`；它选择标准库或固定版本的官方
-  `typing_extensions` backport，不要自行实现 typing 语义。
+- 对 Python 3.7 `typing` 中不存在的 `Protocol`、`Literal`、
+  `runtime_checkable`，使用唯一的 `dcc_mcp_core._typing` 边界；它在
+  Python 3.8+ 保持标准库对象 identity，在 3.7 提供有界、失败关闭的内部子集，
+  不导入 backport。
 - 需要支持 lite 档位的代码不能无条件导入 `_core`。
 - 新增跨 Rust/Python 边界的公开 API 时，应覆盖原生和 lite 两种档位。
 

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -240,7 +240,7 @@ register_tools(server, [spec], dcc_name="maya")
 
 若有返回类型标注，会作为 `outputSchema`，MCP 2025-06-18 的客户端即可用它校验 `structuredContent`。未类型化的 handler 抛 `TypeError`，不会静默回退成宽松的 `{"type": "object"}`（修掉 #588 同代的陷阱）。
 
-支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。Python 3.7 中请用 `typing.List`、`typing.Dict`、`typing.Tuple`、`typing.Optional`、`typing.Union` 来书写容器与联合类型；`Literal` 与 `TypedDict` 需要由 skill 作者环境提供 `typing_extensions`。核心包自身仍不依赖第三方 Python 库。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
+支持的类型（全标准库）：`bool`、`int`、`float`、`str`、`bytes`、`None`、`list[X]`、`tuple[X, ...]`、定长 `tuple[A, B, ...]`、`dict[str, V]`、`Optional[X]` / `X | None`、`Union[A, B]`、`Literal[...]`、`Enum`、`datetime.datetime`、`datetime.date`、`pathlib.Path`、`uuid.UUID`、`@dataclass`、`TypedDict`。Python 3.7 中请用 `typing.List`、`typing.Dict`、`typing.Tuple`、`typing.Optional`、`typing.Union` 来书写容器与联合类型；Core 自有运行代码使用私有 `_typing.Literal` 子集。Skill 作者若选择外部 `TypedDict` 或 typing backport，必须显式安装它们，或直接提供 schema。核心包自身仍不依赖第三方 Python 库。不支持的类型会抛 `TypeError` 并附一条明确的"逃生通道"：显式传 `input_schema=...` dict 或用 pydantic 的 `MyModel.model_json_schema()`。
 
 ::: tip 为什么不用 pydantic？
 我们刻意保持 0 依赖。仅为此特性引入 `pydantic` 会拉进 3MB wheel 再加 `pydantic-core`，对只想写几个 dataclass handler 的作者成本过高。对于已经在用 pydantic 的调用方，派生出的 shape 与 pydantic 的约定一致（`title`、`$defs`、`$ref`、`anyOf`、`required`），因此换成 `MyModel.model_json_schema()` 是即插即用的。

--- a/docs/zh/guide/what-is-dcc-mcp-core.md
+++ b/docs/zh/guide/what-is-dcc-mcp-core.md
@@ -6,7 +6,7 @@
 - **MCP-only IDE 客户端** → 使用 gateway 的少量固定 MCP 工作流（`search`、`describe`、`load_skill`、`call`）。
 - **传统调用方** →（cURL / CI / 任意 HTTP 客户端）通过**完整的 `/v1/*` REST 服务**。
 
-底层是 Rust，通过 [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin) 编译成一个 Python 扩展模块。Python 3.8+ 不需要 typing backport；Python 3.7 会安装固定版本的 `typing_extensions` 兼容依赖。配套的 `dcc-mcp-server` wheel 提供打包后的 gateway daemon 二进制。
+底层是 Rust，通过 [PyO3](https://pyo3.rs/) + [maturin](https://github.com/PyO3/maturin) 编译成一个 Python 扩展模块。Python 3.8+ 直接使用标准库 typing 对象；Python 3.7 使用 Core 内部的有界兼容子集，不安装也不导入 typing backport。配套的 `dcc-mcp-server` wheel 提供打包后的 gateway daemon 二进制。
 
 ---
 
@@ -63,7 +63,7 @@ flowchart LR
 - **多 DCC 网关汇聚** —— 文件型服务注册表 + TCP 心跳探测，自动剔除 3 连失败的实例、清理 ghost 行，基于 `crate_version → adapter_version → adapter_dcc` 的三级选举仲裁。
 - **Tool Slug 契约** —— `<dcc>.<id8>.<tool>` 三段 slug 是唯一的全局寻址方式，网关据此把 REST `/v1/call` 路由到正确的后端。
 - **Tunnel（#504）** —— `dcc-mcp-tunnel-relay` + `dcc-mcp-tunnel-agent` 两个可执行二进制，让远程 AI 客户端直接访问工作站上的 DCC。
-- **PyO3 绑定** —— Rust 加速的一切从 Python 透明可用；Python 3.7 仅增加固定版本的官方 typing backport，gateway daemon 启动使用配套的 `dcc-mcp-server` wheel。
+- **PyO3 绑定** —— Rust 加速的一切从 Python 透明可用；Python 3.7 使用 Core 内部有界 typing 兼容层，不增加第三方 Python 库运行依赖；gateway daemon 启动使用配套的 `dcc-mcp-server` wheel。
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,6 @@ dependencies = [
     # pure-Python code only and users install dcc-mcp-server separately when
     # their platform provides a compatible binary wheel.
     "dcc-mcp-server>=0.18.17,<1.0.0",
-    # Python 3.7 lacks Protocol, runtime_checkable, and Literal. Use the
-    # standards-compatible backport instead of maintaining local typing semantics.
-    "typing-extensions==4.7.1; python_version<'3.8'",
 ]
 
 [project.scripts]
@@ -57,6 +54,8 @@ test = [
     "pytest-cov>=4.0,<5.0; python_version<'3.8'",
     "pytest-xdist>=3.0; python_version>='3.8'",
     "pytest-xdist==3.5.0; python_version<'3.8'",
+    # Test-only conformance fixture. Production code must never import this backport.
+    "typing-extensions==4.7.1; python_version<'3.8'",
     "rez",
     "zipp>=3.19.1; python_version>='3.8'",  # CVE-2024-5569; fixed releases require Python 3.8+
     # Qt UI inspector live-Qt tests (issue #1332); skipped on Py<3.9 / when missing

--- a/python/dcc_mcp_core/_typing.py
+++ b/python/dcc_mcp_core/_typing.py
@@ -1,14 +1,108 @@
-"""Standard typing APIs with the official Python 3.7 backport."""
+"""Bounded zero-dependency typing compatibility for Python 3.7."""
 
 from __future__ import annotations
+
+import inspect
+import math
 
 try:
     from typing import Literal
     from typing import Protocol
     from typing import runtime_checkable
 except ImportError:  # pragma: no cover - Python 3.7 only
-    from typing_extensions import Literal
-    from typing_extensions import Protocol
-    from typing_extensions import runtime_checkable
+    _MISSING = object()
+    _PROTOCOL_INTERNALS = frozenset(
+        {
+            "__annotations__",
+            "__class__",
+            "__dict__",
+            "__doc__",
+            "__module__",
+            "__new__",
+            "__orig_bases__",
+            "__slots__",
+            "__subclasshook__",
+            "__weakref__",
+            "_is_protocol",
+            "_is_runtime_protocol",
+        }
+    )
+
+    def _protocol_members(protocol):
+        members = set()
+        callable_members = set()
+        for base in protocol.__mro__:
+            if not getattr(base, "_is_protocol", False) or base is Protocol:
+                continue
+            members.update(inspect.getattr_static(base, "__annotations__", ()))
+            for name, value in base.__dict__.items():
+                if name in _PROTOCOL_INTERNALS or name.startswith("_abc_"):
+                    continue
+                if callable(value) or isinstance(value, (classmethod, property, staticmethod)):
+                    members.add(name)
+                if callable(value) or isinstance(value, (classmethod, staticmethod)):
+                    callable_members.add(name)
+        return members, callable_members
+
+    class _ProtocolMeta(type):
+        """Minimal, static structural checks for Core's Python 3.7 protocols."""
+
+        def __new__(mcls, name, bases, namespace):
+            cls = super().__new__(mcls, name, bases, namespace)
+            cls._is_protocol = name == "Protocol" or any(getattr(base, "_is_protocol", False) for base in bases)
+            cls._is_runtime_protocol = False
+            return cls
+
+        def __instancecheck__(cls, instance):
+            if not cls.__dict__.get("_is_runtime_protocol", False):
+                raise TypeError("Instance checks require @runtime_checkable")
+            members, callable_members = _protocol_members(cls)
+            for name in members:
+                value = inspect.getattr_static(instance, name, _MISSING)
+                if value is _MISSING:
+                    return False
+                if name in callable_members and not (callable(value) or isinstance(value, (classmethod, staticmethod))):
+                    return False
+            return True
+
+        def __subclasscheck__(cls, subclass):
+            raise TypeError("issubclass() is not supported by the Python 3.7 Protocol subset")
+
+    class Protocol(metaclass=_ProtocolMeta):  # type: ignore[no-redef]
+        """Structural Protocol subset required by Core on Python 3.7."""
+
+    def runtime_checkable(cls):  # type: ignore[misc]
+        """Enable bounded runtime instance checks for a fallback Protocol."""
+        if not isinstance(cls, _ProtocolMeta) or not getattr(cls, "_is_protocol", False):
+            raise TypeError("@runtime_checkable can be applied only to protocol classes")
+        cls._is_runtime_protocol = True
+        return cls
+
+    class _LiteralMeta(type):
+        """Build aliases for non-empty JSON-preserving scalar literals."""
+
+        def __getitem__(cls, item):
+            args = item if isinstance(item, tuple) else (item,)
+            if not args:
+                raise TypeError("Literal requires at least one value")
+            for value in args:
+                if value is None:
+                    continue
+                if type(value) not in (bool, float, int, str):
+                    raise TypeError("Literal values must be JSON-preserving scalars")
+                if type(value) is float and not math.isfinite(value):
+                    raise TypeError("Literal values must be JSON-preserving scalars")
+            return type(
+                "_LiteralAlias",
+                (),
+                {
+                    "__origin__": cls,
+                    "__args__": args,
+                },
+            )
+
+    class Literal(metaclass=_LiteralMeta):  # type: ignore[no-redef]
+        """Runtime-introspectable Literal subset required by Core on Python 3.7."""
+
 
 __all__ = ["Literal", "Protocol", "runtime_checkable"]

--- a/python/dcc_mcp_core/_typing.py
+++ b/python/dcc_mcp_core/_typing.py
@@ -49,9 +49,14 @@ except ImportError:  # pragma: no cover - Python 3.7 only
 
         def __new__(mcls, name, bases, namespace):
             cls = super().__new__(mcls, name, bases, namespace)
-            cls._is_protocol = name == "Protocol" or any(getattr(base, "_is_protocol", False) for base in bases)
+            cls._is_protocol = name == "Protocol" or Protocol in bases
             cls._is_runtime_protocol = False
             return cls
+
+        def __call__(cls, *args, **kwargs):
+            if cls.__dict__.get("_is_protocol", False):
+                raise TypeError("Protocols cannot be instantiated")
+            return super().__call__(*args, **kwargs)
 
         def __instancecheck__(cls, instance):
             if not cls.__dict__.get("_is_runtime_protocol", False):
@@ -73,7 +78,7 @@ except ImportError:  # pragma: no cover - Python 3.7 only
 
     def runtime_checkable(cls):  # type: ignore[misc]
         """Enable bounded runtime instance checks for a fallback Protocol."""
-        if not isinstance(cls, _ProtocolMeta) or not getattr(cls, "_is_protocol", False):
+        if not isinstance(cls, _ProtocolMeta) or not cls.__dict__.get("_is_protocol", False):
             raise TypeError("@runtime_checkable can be applied only to protocol classes")
         cls._is_runtime_protocol = True
         return cls

--- a/python/dcc_mcp_core/_typing.py
+++ b/python/dcc_mcp_core/_typing.py
@@ -11,6 +11,7 @@ try:
     from typing import runtime_checkable
 except ImportError:  # pragma: no cover - Python 3.7 only
     _MISSING = object()
+    _PROTOCOL_ROOT = None
     _PROTOCOL_INTERNALS = frozenset(
         {
             "__annotations__",
@@ -32,14 +33,13 @@ except ImportError:  # pragma: no cover - Python 3.7 only
         members = set()
         callable_members = set()
         for base in protocol.__mro__:
-            if not getattr(base, "_is_protocol", False) or base is Protocol:
+            if not getattr(base, "_is_protocol", False) or base is _PROTOCOL_ROOT:
                 continue
             members.update(inspect.getattr_static(base, "__annotations__", ()))
             for name, value in base.__dict__.items():
                 if name in _PROTOCOL_INTERNALS or name.startswith("_abc_"):
                     continue
-                if callable(value) or isinstance(value, (classmethod, property, staticmethod)):
-                    members.add(name)
+                members.add(name)
                 if callable(value) or isinstance(value, (classmethod, staticmethod)):
                     callable_members.add(name)
         return members, callable_members
@@ -48,10 +48,13 @@ except ImportError:  # pragma: no cover - Python 3.7 only
         """Minimal, static structural checks for Core's Python 3.7 protocols."""
 
         def __new__(mcls, name, bases, namespace):
-            declares_protocol = name == "Protocol" or Protocol in bases
-            if name != "Protocol" and Protocol in bases:
+            bootstrapping = _PROTOCOL_ROOT is None
+            declares_protocol = bootstrapping or any(base is _PROTOCOL_ROOT for base in bases)
+            if not bootstrapping and declares_protocol:
                 invalid_bases = [
-                    base for base in bases if base is not Protocol and not base.__dict__.get("_is_protocol", False)
+                    base
+                    for base in bases
+                    if base is not _PROTOCOL_ROOT and not base.__dict__.get("_is_protocol", False)
                 ]
                 if invalid_bases:
                     raise TypeError("Protocols can only inherit from other protocols, got non-protocol base")
@@ -86,6 +89,8 @@ except ImportError:  # pragma: no cover - Python 3.7 only
 
     class Protocol(metaclass=_ProtocolMeta):  # type: ignore[no-redef]
         """Structural Protocol subset required by Core on Python 3.7."""
+
+    _PROTOCOL_ROOT = Protocol
 
     def runtime_checkable(cls):  # type: ignore[misc]
         """Enable bounded runtime instance checks for a fallback Protocol."""

--- a/python/dcc_mcp_core/_typing.py
+++ b/python/dcc_mcp_core/_typing.py
@@ -48,8 +48,15 @@ except ImportError:  # pragma: no cover - Python 3.7 only
         """Minimal, static structural checks for Core's Python 3.7 protocols."""
 
         def __new__(mcls, name, bases, namespace):
+            declares_protocol = name == "Protocol" or Protocol in bases
+            if name != "Protocol" and Protocol in bases:
+                invalid_bases = [
+                    base for base in bases if base is not Protocol and not base.__dict__.get("_is_protocol", False)
+                ]
+                if invalid_bases:
+                    raise TypeError("Protocols can only inherit from other protocols, got non-protocol base")
             cls = super().__new__(mcls, name, bases, namespace)
-            cls._is_protocol = name == "Protocol" or Protocol in bases
+            cls._is_protocol = declares_protocol
             cls._is_runtime_protocol = False
             return cls
 

--- a/python/dcc_mcp_core/_typing.py
+++ b/python/dcc_mcp_core/_typing.py
@@ -66,6 +66,8 @@ except ImportError:  # pragma: no cover - Python 3.7 only
             return super().__call__(*args, **kwargs)
 
         def __instancecheck__(cls, instance):
+            if not cls.__dict__.get("_is_protocol", False):
+                return super().__instancecheck__(instance)
             if not cls.__dict__.get("_is_runtime_protocol", False):
                 raise TypeError("Instance checks require @runtime_checkable")
             members, callable_members = _protocol_members(cls)
@@ -78,6 +80,8 @@ except ImportError:  # pragma: no cover - Python 3.7 only
             return True
 
         def __subclasscheck__(cls, subclass):
+            if not cls.__dict__.get("_is_protocol", False):
+                return super().__subclasscheck__(subclass)
             raise TypeError("issubclass() is not supported by the Python 3.7 Protocol subset")
 
     class Protocol(metaclass=_ProtocolMeta):  # type: ignore[no-redef]

--- a/python/dcc_mcp_core/batch.py
+++ b/python/dcc_mcp_core/batch.py
@@ -64,6 +64,7 @@ from typing import Callable
 import uuid
 
 from dcc_mcp_core import json_dumps
+from dcc_mcp_core._typing import Literal as _CompatLiteral
 from dcc_mcp_core.schema import _SCRIPT_ANNOTATION_MODULES
 
 logger = logging.getLogger(__name__)
@@ -398,11 +399,6 @@ class EvalContext:
         import builtins
         import typing as typing_module
 
-        try:
-            import typing_extensions
-        except ImportError:  # pragma: no cover - Python 3.7 wheel declares the backport
-            typing_extensions = None
-
         safe: dict[str, Any] = {}
         for name in dir(builtins):
             if name not in self._BLOCKED_BUILTINS:
@@ -411,8 +407,7 @@ class EvalContext:
         annotation_symbols = {
             name: name
             for name in ("Annotated", "Any", "Dict", "List", "Literal", "Optional", "Tuple", "Union")
-            if getattr(typing_module, name, None) is not None
-            or (getattr(typing_extensions, name, None) if typing_extensions is not None else None) is not None
+            if getattr(typing_module, name, None) is not None or (name == "Literal" and _CompatLiteral is not None)
         }
         typing_proxy = _SandboxNamespace(annotation_symbols)
 

--- a/python/dcc_mcp_core/batch.py
+++ b/python/dcc_mcp_core/batch.py
@@ -64,7 +64,6 @@ from typing import Callable
 import uuid
 
 from dcc_mcp_core import json_dumps
-from dcc_mcp_core._typing import Literal as _CompatLiteral
 from dcc_mcp_core.schema import _SCRIPT_ANNOTATION_MODULES
 
 logger = logging.getLogger(__name__)
@@ -397,17 +396,16 @@ class EvalContext:
 
     def _make_builtins(self) -> dict[str, Any]:
         import builtins
-        import typing as typing_module
 
         safe: dict[str, Any] = {}
         for name in dir(builtins):
             if name not in self._BLOCKED_BUILTINS:
                 safe[name] = getattr(builtins, name)
 
+        # Both execution paths postpone annotations. These are inert names for
+        # the schema-supported subset, not runtime typing objects or backports.
         annotation_symbols = {
-            name: name
-            for name in ("Annotated", "Any", "Dict", "List", "Literal", "Optional", "Tuple", "Union")
-            if getattr(typing_module, name, None) is not None or (name == "Literal" and _CompatLiteral is not None)
+            name: name for name in ("Annotated", "Any", "Dict", "List", "Literal", "Optional", "Tuple", "Union")
         }
         typing_proxy = _SandboxNamespace(annotation_symbols)
 

--- a/python/dcc_mcp_core/schema.py
+++ b/python/dcc_mcp_core/schema.py
@@ -33,6 +33,7 @@ from dataclasses import fields as dataclass_fields
 from dataclasses import is_dataclass
 import datetime
 import enum
+import importlib.util
 import inspect
 import json
 import pathlib
@@ -44,12 +45,16 @@ from typing import Callable
 from typing import get_type_hints as _typing_get_type_hints
 import uuid
 
-_LITERAL_TYPE = getattr(typing, "Literal", None)
-if _LITERAL_TYPE is None:  # pragma: no cover - Python 3.7 compatibility
-    try:
-        from typing_extensions import Literal as _LITERAL_TYPE
-    except ImportError:
-        _LITERAL_TYPE = None
+try:
+    from dcc_mcp_core._typing import Literal as _LITERAL_TYPE
+except ImportError:  # pragma: no cover - standalone adapter bundle loading
+    _typing_path = pathlib.Path(__file__).with_name("_typing.py")
+    _typing_spec = importlib.util.spec_from_file_location("_dcc_mcp_core_local_typing", _typing_path)
+    if _typing_spec is None or _typing_spec.loader is None:
+        raise ImportError(f"cannot load local typing compatibility boundary from {_typing_path}") from None
+    _typing_module = importlib.util.module_from_spec(_typing_spec)
+    _typing_spec.loader.exec_module(_typing_module)
+    _LITERAL_TYPE = _typing_module.Literal
 
 try:
     from typing import get_args
@@ -82,12 +87,8 @@ def _require_json(value: Any, error: str, *, scalars: bool = False) -> Any:
 
 
 def _literal_origins() -> tuple[Any, ...]:
-    """Return known Literal origins by identity without importing packages."""
+    """Return Core's local Literal origins by identity."""
     candidates = [_LITERAL_TYPE]
-    for module_name in ("typing_extensions", "dcc_mcp_core._typing"):
-        module = sys.modules.get(module_name)
-        if module is not None:
-            candidates.append(getattr(module, "Literal", None))
 
     origins: list[Any] = []
     for candidate in candidates:

--- a/scripts/build_py37_pure_wheel.py
+++ b/scripts/build_py37_pure_wheel.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PYTHON_ROOT = ROOT / "python"
 PACKAGE_DIR = PYTHON_ROOT / "dcc_mcp_core"
 DIST = ROOT / "dist"
+_NATIVE_SUFFIXES = frozenset({".dll", ".dylib", ".pdb", ".pyd", ".so"})
 
 
 def _ensure_wheel() -> None:
@@ -54,6 +55,11 @@ def _read_console_scripts() -> dict[str, str]:
     return dict(re.findall(r'^([^\s=]+)\s*=\s*"([^"]+)"\s*$', match.group(1), re.MULTILINE))
 
 
+def _is_lite_payload_file(path: Path) -> bool:
+    """Exclude development/native build residue from the pure-Python wheel."""
+    return path.is_file() and "__pycache__" not in path.parts and path.suffix.lower() not in _NATIVE_SUFFIXES
+
+
 def main() -> int:
     """Assemble a pure-Python wheel from ``python/dcc_mcp_core``."""
     _ensure_wheel()
@@ -84,9 +90,7 @@ def main() -> int:
 
     with WheelFile(str(wheel_path), "w") as wf:
         for file_path in sorted(PACKAGE_DIR.rglob("*")):
-            if not file_path.is_file():
-                continue
-            if "__pycache__" in file_path.parts:
+            if not _is_lite_payload_file(file_path):
                 continue
             arcname = file_path.relative_to(PYTHON_ROOT).as_posix()
             wf.write(str(file_path), arcname)

--- a/scripts/ci/archive_payload_policy.py
+++ b/scripts/ci/archive_payload_policy.py
@@ -1,0 +1,59 @@
+"""Shared fail-closed policy for Python distribution archive members."""
+
+from __future__ import annotations
+
+import re
+
+_METADATA_SUFFIXES = (".data", ".dist-info", ".egg-info")
+
+
+def normalize_archive_member(name: str) -> str:
+    """Return a platform-independent relative archive path or reject it."""
+    if not isinstance(name, str) or not name or "\x00" in name:
+        raise ValueError(f"unsafe archive member {name!r}")
+    portable = name.replace("\\", "/")
+    if portable.startswith("/") or re.match(r"^[A-Za-z]:", portable):
+        raise ValueError(f"unsafe archive member {name!r}")
+    parts = []
+    for part in portable.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            raise ValueError(f"unsafe archive member {name!r}")
+        parts.append(part)
+    if not parts:
+        raise ValueError(f"unsafe archive member {name!r}")
+    return "/".join(parts)
+
+
+def _project_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _is_typing_extensions_component(component: str) -> bool:
+    folded = component.casefold()
+    if folded.endswith(".py") and _project_name(folded[:-3]) == "typing-extensions":
+        return True
+    if _project_name(folded) == "typing-extensions":
+        return True
+    for suffix in _METADATA_SUFFIXES:
+        if not folded.endswith(suffix):
+            continue
+        distribution = _project_name(folded[: -len(suffix)])
+        if distribution == "typing-extensions" or distribution.startswith("typing-extensions-"):
+            return True
+    return False
+
+
+def archive_member_errors(names) -> list[str]:
+    """Reject unsafe paths and any normalized typing_extensions payload."""
+    errors = []
+    for name in names:
+        try:
+            normalized = normalize_archive_member(name)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if any(_is_typing_extensions_component(part) for part in normalized.split("/")):
+            errors.append(f"archive contains forbidden typing_extensions payload {name!r}")
+    return sorted(set(errors))

--- a/scripts/ci/archive_payload_policy.py
+++ b/scripts/ci/archive_payload_policy.py
@@ -3,22 +3,51 @@
 from __future__ import annotations
 
 import re
+import stat
+import unicodedata
 
 _METADATA_SUFFIXES = (".data", ".dist-info", ".egg-info")
+_WINDOWS_RESERVED = frozenset(
+    {"aux", "con", "nul", "prn"} | {f"com{index}" for index in range(1, 10)} | {f"lpt{index}" for index in range(1, 10)}
+)
+
+
+def _member_name(member) -> str:
+    if isinstance(member, str):
+        return member
+    filename = getattr(member, "filename", None)
+    if isinstance(filename, str):
+        return filename
+    name = getattr(member, "name", None)
+    if isinstance(name, str):
+        return name
+    raise ValueError(f"unsafe archive member {member!r}")
+
+
+def _unsafe_component(component: str) -> bool:
+    if component.endswith((".", " ")) or ":" in component:
+        return True
+    if any(ord(character) < 32 or ord(character) == 127 for character in component):
+        return True
+    stem = component.split(".", 1)[0].casefold()
+    return stem in _WINDOWS_RESERVED
 
 
 def normalize_archive_member(name: str) -> str:
     """Return a platform-independent relative archive path or reject it."""
     if not isinstance(name, str) or not name or "\x00" in name:
         raise ValueError(f"unsafe archive member {name!r}")
-    portable = name.replace("\\", "/")
-    if portable.startswith("/") or re.match(r"^[A-Za-z]:", portable):
+    try:
+        portable = unicodedata.normalize("NFKC", name.replace("\\", "/"))
+    except UnicodeError as exc:
+        raise ValueError(f"unsafe archive member {name!r}") from exc
+    if portable.startswith("/") or "//" in portable or re.match(r"^[A-Za-z]:", portable):
         raise ValueError(f"unsafe archive member {name!r}")
     parts = []
     for part in portable.split("/"):
         if part in ("", "."):
             continue
-        if part == "..":
+        if part == ".." or _unsafe_component(part):
             raise ValueError(f"unsafe archive member {name!r}")
         parts.append(part)
     if not parts:
@@ -27,7 +56,7 @@ def normalize_archive_member(name: str) -> str:
 
 
 def _project_name(value: str) -> str:
-    return re.sub(r"[-_.]+", "-", value).lower()
+    return re.sub(r"[-_.]+", "-", unicodedata.normalize("NFKC", value).casefold())
 
 
 def _is_typing_extensions_component(component: str) -> bool:
@@ -45,15 +74,63 @@ def _is_typing_extensions_component(component: str) -> bool:
     return False
 
 
-def archive_member_errors(names) -> list[str]:
-    """Reject unsafe paths and any normalized typing_extensions payload."""
-    errors = []
-    for name in names:
+def _contains_typing_extensions_alias(name: str) -> bool:
+    try:
+        portable = unicodedata.normalize("NFKC", name.replace("\\", "/"))
+    except UnicodeError:
+        return False
+    components = []
+    for part in portable.split("/"):
+        components.extend(part.split(":"))
+    return any(_is_typing_extensions_component(part.rstrip(". ")) for part in components if part)
+
+
+def _member_type_error(member, name: str) -> str | None:
+    external_attr = getattr(member, "external_attr", None)
+    if isinstance(external_attr, int):
+        mode = (external_attr >> 16) & 0xFFFF
+        if mode and stat.S_ISLNK(mode):
+            return f"archive contains forbidden symlink member {name!r}"
+
+    is_symbolic_link = getattr(member, "issym", None)
+    is_hard_link = getattr(member, "islnk", None)
+    if callable(is_symbolic_link) and callable(is_hard_link) and (is_symbolic_link() or is_hard_link()):
+        target = getattr(member, "linkname", "")
         try:
+            normalize_archive_member(target)
+        except ValueError:
+            return f"archive contains forbidden link member {name!r} with unsafe target {target!r}"
+        return f"archive contains forbidden link member {name!r}"
+    is_file = getattr(member, "isfile", None)
+    is_directory = getattr(member, "isdir", None)
+    if callable(is_file) and callable(is_directory) and not (is_file() or is_directory()):
+        return f"archive contains forbidden special member {name!r}"
+    return None
+
+
+def archive_member_errors(members) -> list[str]:
+    """Reject unsafe, linked, duplicate, or typing_extensions archive members."""
+    errors = []
+    seen = {}
+    for member in members:
+        name = None
+        try:
+            name = _member_name(member)
             normalized = normalize_archive_member(name)
         except ValueError as exc:
             errors.append(str(exc))
+            if isinstance(name, str) and _contains_typing_extensions_alias(name):
+                errors.append(f"archive contains forbidden typing_extensions payload {name!r}")
             continue
-        if any(_is_typing_extensions_component(part) for part in normalized.split("/")):
+        member_type_error = _member_type_error(member, name)
+        if member_type_error is not None:
+            errors.append(member_type_error)
+        portable_key = normalized.casefold()
+        previous = seen.get(portable_key)
+        if previous is not None:
+            errors.append(f"archive contains duplicate portable member paths {previous!r} and {name!r}")
+        else:
+            seen[portable_key] = name
+        if _contains_typing_extensions_alias(normalized):
             errors.append(f"archive contains forbidden typing_extensions payload {name!r}")
     return sorted(set(errors))

--- a/scripts/ci/archive_payload_policy.py
+++ b/scripts/ci/archive_payload_policy.py
@@ -25,7 +25,7 @@ def _member_name(member) -> str:
 
 
 def _unsafe_component(component: str) -> bool:
-    if component.endswith((".", " ")) or ":" in component:
+    if component.endswith((".", " ")) or any(character in '<>:"|?*' for character in component):
         return True
     if any(ord(character) < 32 or ord(character) == 127 for character in component):
         return True
@@ -61,8 +61,13 @@ def _project_name(value: str) -> str:
 
 def _is_typing_extensions_component(component: str) -> bool:
     folded = component.casefold()
-    if folded.endswith(".py") and _project_name(folded[:-3]) == "typing-extensions":
-        return True
+    if folded.endswith((".py", ".pyc")):
+        module = folded.rsplit(".", 1)[0]
+        if folded.endswith(".pyc"):
+            # CPython caches retain the module name before the cache/opt tag.
+            module = re.sub(r"\.cpython-[0-9]+(?:\.opt-[a-z0-9]+)?$", "", module)
+        if _project_name(module) == "typing-extensions":
+            return True
     if _project_name(folded) == "typing-extensions":
         return True
     for suffix in _METADATA_SUFFIXES:
@@ -91,6 +96,9 @@ def _member_type_error(member, name: str) -> str | None:
         mode = (external_attr >> 16) & 0xFFFF
         if mode and stat.S_ISLNK(mode):
             return f"archive contains forbidden symlink member {name!r}"
+        file_type = stat.S_IFMT(mode)
+        if file_type not in (0, stat.S_IFREG, stat.S_IFDIR):
+            return f"archive contains forbidden special member {name!r}"
 
     is_symbolic_link = getattr(member, "issym", None)
     is_hard_link = getattr(member, "islnk", None)
@@ -109,9 +117,10 @@ def _member_type_error(member, name: str) -> str | None:
 
 
 def archive_member_errors(members) -> list[str]:
-    """Reject unsafe, linked, duplicate, or typing_extensions archive members."""
+    """Reject unsafe, linked, conflicting, duplicate, or backport members."""
     errors = []
     seen = {}
+    directories = {}
     for member in members:
         name = None
         try:
@@ -131,6 +140,18 @@ def archive_member_errors(members) -> list[str]:
             errors.append(f"archive contains duplicate portable member paths {previous!r} and {name!r}")
         else:
             seen[portable_key] = name
+        is_directory = getattr(member, "is_dir", None) or getattr(member, "isdir", None)
+        member_is_directory = is_directory() if callable(is_directory) else name.endswith(("/", "\\"))
+        parts = portable_key.split("/")
+        for depth in range(1, len(parts) + 1):
+            path = "/".join(parts[:depth])
+            # Every ancestor is an implied directory. An explicit directory
+            # may confirm it later, but a regular file can never occupy it.
+            requires_directory = depth < len(parts) or member_is_directory
+            if path in directories and directories[path] != requires_directory:
+                errors.append(f"archive contains file/directory conflict at {path!r} from member {name!r}")
+            else:
+                directories[path] = requires_directory
         if _contains_typing_extensions_alias(normalized):
             errors.append(f"archive contains forbidden typing_extensions payload {name!r}")
     return sorted(set(errors))

--- a/scripts/ci/check_python_support.py
+++ b/scripts/ci/check_python_support.py
@@ -479,8 +479,11 @@ def collect_backfill_tooling_errors(root: Path) -> list[str]:
             errors.append(f"{relative}: {job_name} must build source before fetching and running workflow tooling")
     for job_name in ("py37-lite", "linux-py37", "windows-py37"):
         block = _workflow_job_block(text, job_name)
-        if "if [[ -f compatibility/python.json ]]" not in block:
-            errors.append(f"{relative}: {job_name} must retain the pre-contract backfill smoke path")
+        if (
+            ".workflow-tools/scripts/ci/python37_wheel_smoke.py" not in block
+            or '--checkout-ref "$CHECKOUT_REF"' not in block
+        ):
+            errors.append(f"{relative}: {job_name} must use the version/ref-bound historical wheel smoke")
     return errors
 
 

--- a/scripts/ci/check_python_support.py
+++ b/scripts/ci/check_python_support.py
@@ -88,6 +88,7 @@ def expected_fragments(contract: Mapping[str, Any]) -> dict[str, list[str]]:
         ".github/actions/build-wheel/action.yml": [
             "check_python_wheel.py",
             "smoke_python37_runtime.py --profile native_py37",
+            "smoke_zero_typing_extensions.py",
         ],
     }
     for distribution in contract["distributions"].values():

--- a/scripts/ci/check_python_wheel.py
+++ b/scripts/ci/check_python_wheel.py
@@ -63,6 +63,39 @@ def _release_tuple(version: str) -> tuple[int, int, int] | None:
     return tuple(int(part) for part in match.groups())
 
 
+def _requirement_name(requirement: str) -> str:
+    """Return a normalized distribution name from one Requires-Dist value."""
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
+    if match is None:
+        return ""
+    return match.group(1).lower().replace("_", "-")
+
+
+def _is_default_requirement(requirement: str) -> bool:
+    """Conservatively distinguish an extra-only requirement from a default one."""
+    marker = requirement.partition(";")[2]
+    extra_equality = re.search(r"\bextra\s*==\s*(['\"])[^'\"]+\1", marker, re.IGNORECASE)
+    return extra_equality is None or re.search(r"\bor\b", marker, re.IGNORECASE) is not None
+
+
+def forbidden_runtime_dependency_errors(metadata: Any, distribution: dict[str, Any]) -> list[str]:
+    """Return active forbidden default dependencies found in package metadata."""
+    version = _release_tuple(str(metadata.get("Version", "")))
+    requirements = metadata.get_all("Requires-Dist") or []
+    names = {
+        _requirement_name(str(requirement)) for requirement in requirements if _is_default_requirement(str(requirement))
+    }
+    errors = []
+    for rule in distribution.get("forbidden_runtime_dependencies", []):
+        starts_at = _release_tuple(rule["from_version"])
+        if version is None or starts_at is None or version < starts_at:
+            continue
+        normalized = rule["name"].lower().replace("_", "-")
+        if normalized in names:
+            errors.append(f"forbidden runtime dependency {normalized!r} is present")
+    return errors
+
+
 def _core_ui_control_contract_errors(archive: zipfile.ZipFile, names: list[str]) -> list[str]:
     """Validate the post-0.19.63 Python/skill UI Control naming cutover."""
     errors: list[str] = []
@@ -141,6 +174,7 @@ def validate_wheel(
                 errors.extend(_core_ui_control_contract_errors(archive, names))
             distribution_contract = contract["distributions"][expected_distribution]
             errors.extend(_wheel_resource_errors(archive, distribution_contract.get("wheel_resources", [])))
+            errors.extend(forbidden_runtime_dependency_errors(metadata, distribution_contract))
     except (OSError, ValueError, zipfile.BadZipFile, UnicodeDecodeError) as exc:
         return [f"cannot inspect wheel: {exc}"]
 

--- a/scripts/ci/check_python_wheel.py
+++ b/scripts/ci/check_python_wheel.py
@@ -13,10 +13,12 @@ from typing import Any
 import zipfile
 
 try:
+    from .archive_payload_policy import archive_member_errors
     from .python_support_contract import load_contract
     from .python_support_contract import minimum_python_spec
 except ImportError:  # pragma: no cover - direct script execution
     sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from archive_payload_policy import archive_member_errors
     from python_support_contract import load_contract
     from python_support_contract import minimum_python_spec
 
@@ -161,6 +163,7 @@ def validate_wheel(
     try:
         with zipfile.ZipFile(str(path)) as archive:
             names = archive.namelist()
+            errors.extend(archive_member_errors(names))
             has_extension = _contains_extension(names, profile_contract.get("extension_module"))
             metadata = Parser().parsestr(_read_single_member(archive, ".dist-info/METADATA"))
             wheel_metadata = Parser().parsestr(_read_single_member(archive, ".dist-info/WHEEL"))
@@ -176,7 +179,7 @@ def validate_wheel(
             errors.extend(_wheel_resource_errors(archive, distribution_contract.get("wheel_resources", [])))
             errors.extend(forbidden_runtime_dependency_errors(metadata, distribution_contract))
     except (OSError, ValueError, zipfile.BadZipFile, UnicodeDecodeError) as exc:
-        return [f"cannot inspect wheel: {exc}"]
+        return [*errors, f"cannot inspect wheel: {exc}"]
 
     actual_distribution = str(metadata.get("Name", "")).lower().replace("_", "-")
     if actual_distribution != expected_distribution:

--- a/scripts/ci/check_python_wheel.py
+++ b/scripts/ci/check_python_wheel.py
@@ -14,11 +14,13 @@ import zipfile
 
 try:
     from .archive_payload_policy import archive_member_errors
+    from .dependency_marker_policy import is_default_requirement as _is_default_requirement
     from .python_support_contract import load_contract
     from .python_support_contract import minimum_python_spec
 except ImportError:  # pragma: no cover - direct script execution
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from archive_payload_policy import archive_member_errors
+    from dependency_marker_policy import is_default_requirement as _is_default_requirement
     from python_support_contract import load_contract
     from python_support_contract import minimum_python_spec
 
@@ -71,13 +73,6 @@ def _requirement_name(requirement: str) -> str:
     if match is None:
         return ""
     return re.sub(r"[-_.]+", "-", match.group(1)).lower()
-
-
-def _is_default_requirement(requirement: str) -> bool:
-    """Conservatively distinguish an extra-only requirement from a default one."""
-    marker = requirement.partition(";")[2]
-    extra_equality = re.search(r"\bextra\s*==\s*(['\"])[^'\"]+\1", marker, re.IGNORECASE)
-    return extra_equality is None or re.search(r"\bor\b", marker, re.IGNORECASE) is not None
 
 
 def forbidden_runtime_dependency_errors(metadata: Any, distribution: dict[str, Any]) -> list[str]:

--- a/scripts/ci/check_python_wheel.py
+++ b/scripts/ci/check_python_wheel.py
@@ -70,7 +70,7 @@ def _requirement_name(requirement: str) -> str:
     match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
     if match is None:
         return ""
-    return match.group(1).lower().replace("_", "-")
+    return re.sub(r"[-_.]+", "-", match.group(1)).lower()
 
 
 def _is_default_requirement(requirement: str) -> bool:
@@ -92,7 +92,7 @@ def forbidden_runtime_dependency_errors(metadata: Any, distribution: dict[str, A
         starts_at = _release_tuple(rule["from_version"])
         if version is None or starts_at is None or version < starts_at:
             continue
-        normalized = rule["name"].lower().replace("_", "-")
+        normalized = re.sub(r"[-_.]+", "-", rule["name"]).lower()
         if normalized in names:
             errors.append(f"forbidden runtime dependency {normalized!r} is present")
     return errors
@@ -163,7 +163,7 @@ def validate_wheel(
     try:
         with zipfile.ZipFile(str(path)) as archive:
             names = archive.namelist()
-            errors.extend(archive_member_errors(names))
+            errors.extend(archive_member_errors(archive.infolist()))
             has_extension = _contains_extension(names, profile_contract.get("extension_module"))
             metadata = Parser().parsestr(_read_single_member(archive, ".dist-info/METADATA"))
             wheel_metadata = Parser().parsestr(_read_single_member(archive, ".dist-info/WHEEL"))

--- a/scripts/ci/check_release_distribution_set.py
+++ b/scripts/ci/check_release_distribution_set.py
@@ -15,14 +15,12 @@ import zipfile
 
 try:
     from .archive_payload_policy import archive_member_errors
-    from .archive_payload_policy import normalize_archive_member
     from .check_python_wheel import forbidden_runtime_dependency_errors
     from .check_python_wheel import validate_wheel
     from .python_support_contract import load_contract
 except ImportError:  # pragma: no cover - direct script execution
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from archive_payload_policy import archive_member_errors
-    from archive_payload_policy import normalize_archive_member
     from check_python_wheel import forbidden_runtime_dependency_errors
     from check_python_wheel import validate_wheel
     from python_support_contract import load_contract
@@ -130,10 +128,11 @@ def _validate_sdist(path: Path, version: str, contract: dict | None = None) -> N
             payload_errors = archive_member_errors(members)
             if payload_errors:
                 raise DistributionSetError(f"{path.name}: " + "; ".join(payload_errors))
-            normalized_names = [normalize_archive_member(name) for name in names]
-            if normalized_names.count(pkg_info_name) != 1:
+            # Consumers open literal TAR paths; portable normalization above
+            # only rejects aliases/conflicts, never supplies missing files.
+            if names.count(pkg_info_name) != 1:
                 raise DistributionSetError(f"sdist must contain exactly one {pkg_info_name!r}")
-            invalid_names = [name for name in normalized_names if name != root and not name.startswith(f"{root}/")]
+            invalid_names = [name for name in names if name != root and not name.startswith(f"{root}/")]
             if invalid_names:
                 raise DistributionSetError(f"sdist contains paths outside {root!r}: {invalid_names[:3]}")
             pkg_info = ""
@@ -144,7 +143,7 @@ def _validate_sdist(path: Path, version: str, contract: dict | None = None) -> N
                 if stream is None:
                     raise DistributionSetError(f"sdist member {member.name!r} is unreadable")
                 data = stream.read()
-                if normalize_archive_member(member.name) == pkg_info_name:
+                if member.name == pkg_info_name:
                     pkg_info = data.decode("utf-8")
             _validate_metadata(pkg_info, version, path.name)
             active_contract = contract if contract is not None else load_contract()

--- a/scripts/ci/check_release_distribution_set.py
+++ b/scripts/ci/check_release_distribution_set.py
@@ -14,11 +14,15 @@ import tarfile
 import zipfile
 
 try:
+    from .archive_payload_policy import archive_member_errors
+    from .archive_payload_policy import normalize_archive_member
     from .check_python_wheel import forbidden_runtime_dependency_errors
     from .check_python_wheel import validate_wheel
     from .python_support_contract import load_contract
 except ImportError:  # pragma: no cover - direct script execution
     sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from archive_payload_policy import archive_member_errors
+    from archive_payload_policy import normalize_archive_member
     from check_python_wheel import forbidden_runtime_dependency_errors
     from check_python_wheel import validate_wheel
     from python_support_contract import load_contract
@@ -98,6 +102,9 @@ def _validate_wheels(dist_dir: Path, version: str, wheel_names: set[str]) -> Non
                 corrupt_member = archive.testzip()
                 if corrupt_member is not None:
                     raise DistributionSetError(f"{filename}: corrupt ZIP member {corrupt_member!r}")
+                payload_errors = archive_member_errors(archive.namelist())
+                if payload_errors:
+                    raise DistributionSetError(f"{filename}: " + "; ".join(payload_errors))
                 _validate_metadata(_single_metadata(archive), version, filename)
         except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
             raise DistributionSetError(f"{filename}: cannot inspect wheel: {exc}") from exc
@@ -120,11 +127,13 @@ def _validate_sdist(path: Path, version: str, contract: dict | None = None) -> N
         with tarfile.open(path, "r:gz") as archive:
             members = archive.getmembers()
             names = [member.name for member in members]
-            if names.count(pkg_info_name) != 1:
+            payload_errors = archive_member_errors(names)
+            if payload_errors:
+                raise DistributionSetError(f"{path.name}: " + "; ".join(payload_errors))
+            normalized_names = [normalize_archive_member(name) for name in names]
+            if normalized_names.count(pkg_info_name) != 1:
                 raise DistributionSetError(f"sdist must contain exactly one {pkg_info_name!r}")
-            invalid_names = [
-                name for name in names if name != root and (not name.startswith(f"{root}/") or ".." in Path(name).parts)
-            ]
+            invalid_names = [name for name in normalized_names if name != root and not name.startswith(f"{root}/")]
             if invalid_names:
                 raise DistributionSetError(f"sdist contains paths outside {root!r}: {invalid_names[:3]}")
             pkg_info = ""
@@ -135,7 +144,7 @@ def _validate_sdist(path: Path, version: str, contract: dict | None = None) -> N
                 if stream is None:
                     raise DistributionSetError(f"sdist member {member.name!r} is unreadable")
                 data = stream.read()
-                if member.name == pkg_info_name:
+                if normalize_archive_member(member.name) == pkg_info_name:
                     pkg_info = data.decode("utf-8")
             _validate_metadata(pkg_info, version, path.name)
             active_contract = contract if contract is not None else load_contract()

--- a/scripts/ci/check_release_distribution_set.py
+++ b/scripts/ci/check_release_distribution_set.py
@@ -14,10 +14,12 @@ import tarfile
 import zipfile
 
 try:
+    from .check_python_wheel import forbidden_runtime_dependency_errors
     from .check_python_wheel import validate_wheel
     from .python_support_contract import load_contract
 except ImportError:  # pragma: no cover - direct script execution
     sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from check_python_wheel import forbidden_runtime_dependency_errors
     from check_python_wheel import validate_wheel
     from python_support_contract import load_contract
 
@@ -111,7 +113,7 @@ def _validate_wheels(dist_dir: Path, version: str, wheel_names: set[str]) -> Non
         )
 
 
-def _validate_sdist(path: Path, version: str) -> None:
+def _validate_sdist(path: Path, version: str, contract: dict | None = None) -> None:
     root = f"dcc_mcp_core-{version}"
     pkg_info_name = f"{root}/PKG-INFO"
     try:
@@ -136,6 +138,11 @@ def _validate_sdist(path: Path, version: str) -> None:
                 if member.name == pkg_info_name:
                     pkg_info = data.decode("utf-8")
             _validate_metadata(pkg_info, version, path.name)
+            active_contract = contract if contract is not None else load_contract()
+            distribution = active_contract.get("distributions", {}).get("dcc-mcp-core", {})
+            dependency_errors = forbidden_runtime_dependency_errors(Parser().parsestr(pkg_info), distribution)
+            if dependency_errors:
+                raise DistributionSetError(f"{path.name}: " + "; ".join(dependency_errors))
     except (OSError, UnicodeDecodeError, tarfile.TarError) as exc:
         raise DistributionSetError(f"{path.name}: cannot inspect sdist: {exc}") from exc
 
@@ -207,7 +214,7 @@ def verify_distribution_set(payload: dict, dist_dir: Path, version: str) -> dict
     if set(downloaded) != {*wheel_names, sdist_name}:
         raise DistributionSetError("Core Release must contain six wheels and one exact-version sdist")
     _validate_wheels(dist_dir, version, wheel_names)
-    _validate_sdist(dist_dir / sdist_name, version)
+    _validate_sdist(dist_dir / sdist_name, version, load_contract())
     return {
         "asset_count": len(downloaded),
         "total_bytes": sum(path.stat().st_size for path in downloaded.values()),

--- a/scripts/ci/check_release_distribution_set.py
+++ b/scripts/ci/check_release_distribution_set.py
@@ -102,7 +102,7 @@ def _validate_wheels(dist_dir: Path, version: str, wheel_names: set[str]) -> Non
                 corrupt_member = archive.testzip()
                 if corrupt_member is not None:
                     raise DistributionSetError(f"{filename}: corrupt ZIP member {corrupt_member!r}")
-                payload_errors = archive_member_errors(archive.namelist())
+                payload_errors = archive_member_errors(archive.infolist())
                 if payload_errors:
                     raise DistributionSetError(f"{filename}: " + "; ".join(payload_errors))
                 _validate_metadata(_single_metadata(archive), version, filename)
@@ -127,7 +127,7 @@ def _validate_sdist(path: Path, version: str, contract: dict | None = None) -> N
         with tarfile.open(path, "r:gz") as archive:
             members = archive.getmembers()
             names = [member.name for member in members]
-            payload_errors = archive_member_errors(names)
+            payload_errors = archive_member_errors(members)
             if payload_errors:
                 raise DistributionSetError(f"{path.name}: " + "; ".join(payload_errors))
             normalized_names = [normalize_archive_member(name) for name in names]
@@ -191,6 +191,31 @@ def classify_distribution_assets(payload: dict, version: str) -> str:
     return "reuse"
 
 
+def validate_distribution_directory(dist_dir: Path, version: str) -> dict[str, int]:
+    """Validate a freshly built seven-file Core distribution set before publication."""
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)", version):
+        raise DistributionSetError(f"invalid release version {version!r}")
+    if not dist_dir.is_dir():
+        raise DistributionSetError(f"distribution directory does not exist: {dist_dir}")
+    paths = [path for path in dist_dir.iterdir() if path.is_file()]
+    if any(path.is_symlink() for path in paths):
+        raise DistributionSetError("distribution directory contains a symbolic link")
+    downloaded = {path.name: path for path in paths}
+    if len(downloaded) != len(paths):
+        raise DistributionSetError("distribution directory contains duplicate filenames")
+
+    sdist_name = f"dcc_mcp_core-{version}.tar.gz"
+    wheel_names = {name for name in downloaded if name.endswith(".whl")}
+    if set(downloaded) != {*wheel_names, sdist_name}:
+        raise DistributionSetError("Core distribution set must contain six wheels and one exact-version sdist")
+    _validate_wheels(dist_dir, version, wheel_names)
+    _validate_sdist(dist_dir / sdist_name, version, load_contract())
+    return {
+        "asset_count": len(downloaded),
+        "total_bytes": sum(path.stat().st_size for path in downloaded.values()),
+    }
+
+
 def verify_distribution_set(payload: dict, dist_dir: Path, version: str) -> dict[str, int]:
     """Verify the exact seven-file Core distribution set and return evidence."""
     if not re.fullmatch(r"\d+\.\d+\.\d+(?:[A-Za-z0-9.+-]*)", version):
@@ -218,32 +243,25 @@ def verify_distribution_set(payload: dict, dist_dir: Path, version: str) -> dict
         if actual_digest != digest.split(":", 1)[1].lower():
             raise DistributionSetError(f"{name}: digest mismatch with GitHub Release metadata")
 
-    sdist_name = f"dcc_mcp_core-{version}.tar.gz"
-    wheel_names = {name for name in downloaded if name.endswith(".whl")}
-    if set(downloaded) != {*wheel_names, sdist_name}:
-        raise DistributionSetError("Core Release must contain six wheels and one exact-version sdist")
-    _validate_wheels(dist_dir, version, wheel_names)
-    _validate_sdist(dist_dir / sdist_name, version, load_contract())
-    return {
-        "asset_count": len(downloaded),
-        "total_bytes": sum(path.stat().st_size for path in downloaded.values()),
-    }
+    return validate_distribution_directory(dist_dir, version)
 
 
 def main(argv: list[str] | None = None) -> int:
     """Validate Release asset metadata and downloaded distributions."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--assets-json", type=Path, required=True)
+    parser.add_argument("--assets-json", type=Path)
     parser.add_argument("--dist-dir", type=Path)
     parser.add_argument("--version", required=True)
     parser.add_argument("--classify-assets", action="store_true")
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args(argv)
-    try:
-        payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise DistributionSetError(f"cannot read GitHub Release asset JSON: {exc}") from exc
     if args.classify_assets:
+        if args.assets_json is None:
+            raise DistributionSetError("--assets-json is required with --classify-assets")
+        try:
+            payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DistributionSetError(f"cannot read GitHub Release asset JSON: {exc}") from exc
         mode = classify_distribution_assets(payload, args.version)
         if args.github_output is not None:
             with args.github_output.open("a", encoding="utf-8", newline="\n") as stream:
@@ -251,7 +269,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Core release asset backfill mode: {mode}")
         return 0
     if args.dist_dir is None:
-        raise DistributionSetError("--dist-dir is required unless --classify-assets is set")
+        raise DistributionSetError("--dist-dir is required")
+    if args.assets_json is None:
+        evidence = validate_distribution_directory(args.dist_dir, args.version)
+        print(f"Validated {evidence['asset_count']} fresh Core distribution(s), {evidence['total_bytes']} byte(s)")
+        return 0
+    try:
+        payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DistributionSetError(f"cannot read GitHub Release asset JSON: {exc}") from exc
     evidence = verify_distribution_set(payload, args.dist_dir, args.version)
     print(f"Verified {evidence['asset_count']} immutable Core distribution(s), {evidence['total_bytes']} byte(s)")
     return 0

--- a/scripts/ci/dependency_marker_policy.py
+++ b/scripts/ci/dependency_marker_policy.py
@@ -1,0 +1,111 @@
+"""Conservative, stdlib-only proof that a requirement is extra-only.
+
+This is not an environment-marker evaluator. Non-extra comparisons are
+unknown (possibly true); only an actual ``extra == nonempty-string`` token
+comparison proves false for the default empty extra. Unknown syntax fails
+closed. Quoted values never become marker variables or boolean operators.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TOKEN = re.compile(r"""\s*(?:('[^'\\\r\n]*'|"[^"\\\r\n]*")|([A-Za-z_][A-Za-z_0-9]*)|(===|==|!=|~=|<=|>=|<|>|\(|\)))""")
+_VARIABLES = frozenset(
+    (
+        "python_version",
+        "python_full_version",
+        "os_name",
+        "sys_platform",
+        "platform_release",
+        "platform_system",
+        "platform_version",
+        "platform_machine",
+        "platform_python_implementation",
+        "implementation_name",
+        "implementation_version",
+        "extra",
+    )
+)
+_OPERATORS = frozenset(("===", "==", "!=", "~=", "<=", ">=", "<", ">", "in", "not in"))
+
+
+class _DefaultPossibility:
+    def __init__(self, marker: str) -> None:
+        self.tokens = []
+        position = 0
+        while position < len(marker):
+            match = _TOKEN.match(marker, position)
+            if match is None:
+                raise ValueError("unsupported marker token")
+            quoted, word, operator = match.groups()
+            self.tokens.append(("string", quoted[1:-1]) if quoted is not None else ("token", word or operator))
+            position = match.end()
+        self.position = 0
+
+    def take(self):
+        if self.position == len(self.tokens):
+            raise ValueError("incomplete marker")
+        token = self.tokens[self.position]
+        self.position += 1
+        return token
+
+    def accept(self, value: str) -> bool:
+        if self.position < len(self.tokens) and self.tokens[self.position] == ("token", value):
+            self.position += 1
+            return True
+        return False
+
+    def expression(self, depth: int = 0) -> bool:
+        if depth > 32:
+            raise ValueError("marker nesting limit")
+        possible = self.conjunction(depth)
+        while self.accept("or"):
+            right = self.conjunction(depth)
+            possible = possible or right
+        return possible
+
+    def conjunction(self, depth: int) -> bool:
+        possible = self.atom(depth)
+        while self.accept("and"):
+            right = self.atom(depth)
+            possible = possible and right
+        return possible
+
+    def operand(self):
+        token = self.take()
+        if token[0] != "string" and token[1] not in _VARIABLES:
+            raise ValueError("unsupported marker variable")
+        return token
+
+    def atom(self, depth: int) -> bool:
+        if self.accept("("):
+            possible = self.expression(depth + 1)
+            if not self.accept(")"):
+                raise ValueError("unclosed marker group")
+            return possible
+        left = self.operand()
+        kind, operator = self.take()
+        if operator == "not" and self.accept("in"):
+            operator = "not in"
+        if kind != "token" or operator not in _OPERATORS:
+            raise ValueError("unsupported marker operator")
+        right = self.operand()
+        if operator == "==":
+            for variable, value in ((left, right), (right, left)):
+                if variable == ("token", "extra") and value[0] == "string" and value[1]:
+                    return False
+        return True
+
+
+def is_default_requirement(requirement: str) -> bool:
+    """Return True unless the complete marker proves default-inactive."""
+    marker = requirement.partition(";")[2].strip()
+    if not marker or len(marker) > 8192:
+        return True
+    try:
+        parser = _DefaultPossibility(marker)
+        possible = parser.expression()
+        return possible or parser.position != len(parser.tokens)
+    except ValueError:
+        return True

--- a/scripts/ci/python37_wheel_smoke.py
+++ b/scripts/ci/python37_wheel_smoke.py
@@ -1,0 +1,99 @@
+"""Run current zero-backport or verified immutable historical wheel smokes."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import Parser
+from pathlib import Path
+import re
+import subprocess
+import sys
+import zipfile
+
+try:
+    from .python_support_contract import load_contract
+    from .smoke_zero_typing_extensions import _single_wheel
+except ImportError:  # pragma: no cover - direct script execution
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from python_support_contract import load_contract
+    from smoke_zero_typing_extensions import _single_wheel
+
+
+def historical_release(checkout_ref: str, version: str, head: str, tag: str, cutoff: str) -> bool:
+    """Allow declared dependencies only on a matching pre-cutover release tag."""
+    match = re.fullmatch(r"(?:refs/tags/)?v(\d+\.\d+\.\d+)", checkout_ref)
+    if match is None or tuple(map(int, match[1].split("."))) >= tuple(map(int, cutoff.split("."))):
+        return False
+    if version != match[1] or not re.fullmatch(r"[0-9a-f]{40}", head) or head != tag:
+        raise ValueError("historical checkout tag, commit and wheel version must match")
+    return True
+
+
+def smoke_wheel(wheel: Path, profile: str, historical: bool, has_contract: bool = True) -> None:
+    """Install the wheel with its applicable dependency policy, then exercise it."""
+    scripts = Path(__file__).resolve().parent
+    if not historical:
+        # Never infer exemption from source text or the presence of a test file.
+        subprocess.run(
+            [sys.executable, str(scripts / "smoke_zero_typing_extensions.py"), "--wheel", str(wheel)], check=True
+        )
+    install = [sys.executable, "-m", "pip", "install", "--force-reinstall"]
+    if not historical:
+        install.append("--no-deps")
+    # For historical tags pip prepares only dependencies declared by that wheel.
+    # No backport is bundled, injected into metadata, or installed for current code.
+    subprocess.run([*install, str(wheel)], check=True)
+    if historical and not has_contract:
+        subprocess.run([sys.executable, "-I", "-c", "import dcc_mcp_core"], check=True)
+    else:
+        subprocess.run(
+            [sys.executable, "-I", str(scripts / "smoke_python37_runtime.py"), "--profile", profile], check=True
+        )
+
+
+def main() -> int:
+    """Bind the selected tag and installed wheel to the workflow-owned policy."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel", required=True)
+    parser.add_argument("--profile", choices=("lite_py37", "native_py37"), required=True)
+    parser.add_argument("--checkout-ref", default="")
+    args = parser.parse_args()
+    checkout_ref = args.checkout_ref
+    if checkout_ref.startswith("refs/tags/"):
+        checkout_ref = checkout_ref[len("refs/tags/") :]
+    wheel = _single_wheel(args.wheel)
+    with zipfile.ZipFile(str(wheel)) as archive:
+        names = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+        if len(names) != 1:
+            raise ValueError("wheel must contain exactly one METADATA file")
+        version = Parser().parsestr(archive.read(names[0]).decode("utf-8"))["Version"]
+    rules = load_contract()["distributions"]["dcc-mcp-core"]["forbidden_runtime_dependencies"]
+    cutoff = next(rule["from_version"] for rule in rules if rule["name"] == "typing-extensions")
+    historical = False
+    has_contract = True
+    if re.fullmatch(r"v\d+\.\d+\.\d+", checkout_ref):
+        head = subprocess.check_output(["git", "rev-parse", "HEAD"], universal_newlines=True).strip()
+        tag = subprocess.check_output(
+            ["git", "rev-parse", "--verify", "refs/tags/" + checkout_ref + "^{commit}"],
+            universal_newlines=True,
+        ).strip()
+        historical = historical_release(checkout_ref, version, head, tag, cutoff)
+        if historical:
+            # Query the verified immutable tree, not a removable local file.
+            has_contract = (
+                subprocess.run(
+                    ["git", "cat-file", "-e", tag + ":compatibility/python.json"],
+                    capture_output=True,
+                ).returncode
+                == 0
+            )
+    print(
+        "Python 3.7 wheel policy: " + ("historical declared dependencies" if historical else "zero backport"),
+        flush=True,
+    )
+    smoke_wheel(wheel, args.profile, historical, has_contract)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/python_support_contract.py
+++ b/scripts/ci/python_support_contract.py
@@ -114,6 +114,16 @@ def validate_contract(contract: dict[str, Any]) -> None:
                 raise ContractError(f"distribution {name} wheel resource sha256 must be lowercase hex")
             if not resource["canonical_url"].startswith("https://"):
                 raise ContractError(f"distribution {name} wheel resource canonical_url must use HTTPS")
+        forbidden_dependencies = row.get("forbidden_runtime_dependencies", [])
+        if not isinstance(forbidden_dependencies, list) or not all(
+            isinstance(dependency, dict) for dependency in forbidden_dependencies
+        ):
+            raise ContractError(f"distribution {name} forbidden_runtime_dependencies must be a list of objects")
+        for dependency in forbidden_dependencies:
+            if not isinstance(dependency.get("name"), str) or not dependency["name"]:
+                raise ContractError(f"distribution {name} forbidden runtime dependency name must be non-empty")
+            if not isinstance(dependency.get("from_version"), str) or not dependency["from_version"]:
+                raise ContractError(f"distribution {name} forbidden runtime dependency version must be non-empty")
 
     semantic = optional_dependencies.get("semantic", {})
     if semantic.get("owner_distribution") != "dcc-mcp-core":

--- a/scripts/ci/smoke_zero_typing_extensions.py
+++ b/scripts/ci/smoke_zero_typing_extensions.py
@@ -129,6 +129,20 @@ def _verify_protocol(Protocol, runtime_checkable) -> None:
             raise RuntimeError("fallback protocol declaration was instantiable")
     if getattr(_ConcreteRunner, "_is_protocol", True) or _ConcreteRunner().run() != 1:
         raise RuntimeError("fallback protocol misclassified a concrete subclass")
+
+    class _ChildRunner(_ConcreteRunner):
+        pass
+
+    for candidate, target, expected in (
+        (object, _ConcreteRunner, False),
+        (_ConcreteRunner, _ConcreteRunner, True),
+        (_ChildRunner, _ConcreteRunner, True),
+        (_ConcreteRunner, _ChildRunner, False),
+        (object, _ChildRunner, False),
+        (_DescriptorRunner, _ConcreteRunner, False),
+    ):
+        if isinstance(candidate(), target) is not expected or issubclass(candidate, target) is not expected:
+            raise RuntimeError("fallback concrete subclass lost nominal type checks")
     try:
         runtime_checkable(_ConcreteRunner)
     except TypeError:

--- a/scripts/ci/smoke_zero_typing_extensions.py
+++ b/scripts/ci/smoke_zero_typing_extensions.py
@@ -1,0 +1,196 @@
+"""Prove a Python 3.7 Core wheel runs without site-packages or typing backports."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import Parser
+import importlib
+import math
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import typing
+import zipfile
+
+
+class _BlockTypingExtensions:
+    """Reject accidental backport imports inside the isolated child."""
+
+    @staticmethod
+    def find_spec(fullname, path=None, target=None):
+        if fullname == "typing_extensions":
+            raise ModuleNotFoundError("typing_extensions is intentionally absent")
+        return None
+
+
+def _is_default_requirement(requirement: str) -> bool:
+    marker = requirement.partition(";")[2]
+    extra_equality = re.search(r"\bextra\s*==\s*(['\"])[^'\"]+\1", marker, re.IGNORECASE)
+    return extra_equality is None or re.search(r"\bor\b", marker, re.IGNORECASE) is not None
+
+
+def _single_wheel(raw: str) -> Path:
+    path = Path(raw)
+    matches = sorted(path.parent.glob(path.name))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one wheel matching {raw!r}, found {len(matches)}")
+    return matches[0].resolve()
+
+
+def _check_wheel_archive(wheel: Path, root: Path) -> None:
+    with zipfile.ZipFile(str(wheel)) as archive:
+        names = archive.namelist()
+        metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
+        if len(metadata_names) != 1:
+            raise RuntimeError("wheel must contain exactly one METADATA file")
+        metadata = Parser().parsestr(archive.read(metadata_names[0]).decode("utf-8"))
+        requirements = metadata.get_all("Requires-Dist") or []
+        if any(
+            str(requirement).lower().replace("_", "-").startswith("typing-extensions")
+            and _is_default_requirement(str(requirement))
+            for requirement in requirements
+        ):
+            raise RuntimeError("wheel metadata contains typing-extensions")
+        if any("typing_extensions" in Path(name).parts for name in names):
+            raise RuntimeError("wheel contains a typing_extensions package")
+        archive.extractall(str(root))
+
+
+def _run_isolated_child(root: Path) -> None:
+    command = [
+        sys.executable,
+        "-I",
+        "-S",
+        str(Path(__file__).resolve()),
+        "--isolated-root",
+        str(root),
+    ]
+    subprocess.run(command, check=True)
+
+
+def _verify_protocol(Protocol, runtime_checkable) -> None:
+    @runtime_checkable
+    class _SizedRunner(Protocol):
+        name: str
+
+        def __len__(self) -> int: ...
+
+        def run(self) -> int: ...
+
+    class _DescriptorRunner:
+        @property
+        def name(self):
+            raise AssertionError("property must not execute")
+
+        def __len__(self):
+            return 1
+
+        def run(self):
+            return 1
+
+    class _DynamicRunner:
+        def __getattr__(self, name):
+            raise AssertionError("__getattr__ must not execute")
+
+        def __len__(self):
+            return 1
+
+        def run(self):
+            return 1
+
+    if not isinstance(_DescriptorRunner(), _SizedRunner):
+        raise RuntimeError("static protocol check rejected a valid descriptor-backed object")
+    if isinstance(_DynamicRunner(), _SizedRunner):
+        raise RuntimeError("static protocol check accepted a dynamic-only object")
+    try:
+        issubclass(_DescriptorRunner, _SizedRunner)
+    except TypeError:
+        pass
+    else:
+        raise RuntimeError("unsupported fallback issubclass semantics did not fail closed")
+
+
+def _verify_isolated_root(root: Path) -> None:
+    if sys.version_info[:2] != (3, 7):
+        raise RuntimeError("isolated zero-backport smoke requires CPython 3.7")
+    if any("site-packages" in entry.lower() for entry in sys.path):
+        raise RuntimeError("isolated smoke unexpectedly includes site-packages")
+    sys.path.insert(0, str(root))
+    sys.meta_path.insert(0, _BlockTypingExtensions())
+
+    from dcc_mcp_core._typing import Literal
+    from dcc_mcp_core._typing import Protocol
+    from dcc_mcp_core._typing import runtime_checkable
+    from dcc_mcp_core.batch import EvalContext
+    from dcc_mcp_core.schema import derive_schema
+
+    _verify_protocol(Protocol, runtime_checkable)
+    alias = Literal["fbx", "usd", 1, True, None, -0.5]
+    if alias.__origin__ is not Literal or alias.__args__ != ("fbx", "usd", 1, True, None, -0.5):
+        raise RuntimeError("fallback Literal lost its origin or arguments")
+
+    class _Options:
+        pass
+
+    _Options.__annotations__ = {"format": Literal["fbx", "usd"]}
+
+    if typing.get_type_hints(_Options)["format"].__args__ != ("fbx", "usd"):
+        raise RuntimeError("fallback Literal does not round-trip through get_type_hints")
+    if derive_schema(Literal["fbx", "usd"]) != {"enum": ["fbx", "usd"], "type": "string"}:
+        raise RuntimeError("fallback Literal schema derivation failed")
+    for value in (b"x", object(), math.nan, math.inf):
+        try:
+            Literal[value]
+        except TypeError:
+            pass
+        else:
+            raise RuntimeError("fallback Literal accepted an unsupported value")
+    sandbox_builtins = EvalContext(None)._make_builtins()
+    if sandbox_builtins["__import__"]("typing").Literal != "Literal":
+        raise RuntimeError("batch annotation sandbox omitted the local Literal")
+
+    callers = (
+        "dcc_mcp_core._server._inprocess_contracts",
+        "dcc_mcp_core._server.callable_dispatcher",
+        "dcc_mcp_core._server.host_pump",
+        "dcc_mcp_core.agent_memory",
+        "dcc_mcp_core.cancellation",
+        "dcc_mcp_core.host._protocols",
+        "dcc_mcp_core.skill_index._protocol",
+        "dcc_mcp_core.skill_index._vector",
+        "dcc_mcp_core.vector_embedder",
+    )
+    for module_name in callers:
+        importlib.import_module(module_name)
+    if "typing_extensions" in sys.modules:
+        raise RuntimeError("isolated runtime imported typing_extensions")
+
+
+def main(argv=None) -> int:
+    """Run the archive parent or isolated runtime child."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wheel")
+    parser.add_argument("--isolated-root")
+    args = parser.parse_args(argv)
+    try:
+        if args.isolated_root:
+            _verify_isolated_root(Path(args.isolated_root))
+        elif args.wheel:
+            wheel = _single_wheel(args.wheel)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                _check_wheel_archive(wheel, root)
+                _run_isolated_child(root)
+        else:
+            raise RuntimeError("--wheel or --isolated-root is required")
+    except Exception as exc:
+        sys.stderr.write(f"zero-typing-extensions-smoke: {exc}\n")
+        return 1
+    sys.stdout.write("zero-typing-extensions-smoke: OK\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/smoke_zero_typing_extensions.py
+++ b/scripts/ci/smoke_zero_typing_extensions.py
@@ -48,7 +48,7 @@ def _single_wheel(raw: str) -> Path:
 def _check_wheel_archive(wheel: Path, root: Path) -> None:
     with zipfile.ZipFile(str(wheel)) as archive:
         names = archive.namelist()
-        payload_errors = archive_member_errors(names)
+        payload_errors = archive_member_errors(archive.infolist())
         if payload_errors:
             raise RuntimeError("; ".join(payload_errors))
         metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
@@ -57,7 +57,7 @@ def _check_wheel_archive(wheel: Path, root: Path) -> None:
         metadata = Parser().parsestr(archive.read(metadata_names[0]).decode("utf-8"))
         requirements = metadata.get_all("Requires-Dist") or []
         if any(
-            str(requirement).lower().replace("_", "-").startswith("typing-extensions")
+            re.sub(r"[-_.]+", "-", str(requirement).lower()).startswith("typing-extensions")
             and _is_default_requirement(str(requirement))
             for requirement in requirements
         ):

--- a/scripts/ci/smoke_zero_typing_extensions.py
+++ b/scripts/ci/smoke_zero_typing_extensions.py
@@ -14,6 +14,12 @@ import tempfile
 import typing
 import zipfile
 
+try:
+    from .archive_payload_policy import archive_member_errors
+except ImportError:  # pragma: no cover - direct script execution
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from archive_payload_policy import archive_member_errors
+
 
 class _BlockTypingExtensions:
     """Reject accidental backport imports inside the isolated child."""
@@ -42,6 +48,9 @@ def _single_wheel(raw: str) -> Path:
 def _check_wheel_archive(wheel: Path, root: Path) -> None:
     with zipfile.ZipFile(str(wheel)) as archive:
         names = archive.namelist()
+        payload_errors = archive_member_errors(names)
+        if payload_errors:
+            raise RuntimeError("; ".join(payload_errors))
         metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
         if len(metadata_names) != 1:
             raise RuntimeError("wheel must contain exactly one METADATA file")
@@ -53,8 +62,6 @@ def _check_wheel_archive(wheel: Path, root: Path) -> None:
             for requirement in requirements
         ):
             raise RuntimeError("wheel metadata contains typing-extensions")
-        if any("typing_extensions" in Path(name).parts for name in names):
-            raise RuntimeError("wheel contains a typing_extensions package")
         archive.extractall(str(root))
 
 
@@ -100,10 +107,34 @@ def _verify_protocol(Protocol, runtime_checkable) -> None:
         def run(self):
             return 1
 
+    class _ConcreteRunner(_SizedRunner):
+        name = "runner"
+
+        def __len__(self):
+            return 1
+
+        def run(self):
+            return 1
+
     if not isinstance(_DescriptorRunner(), _SizedRunner):
         raise RuntimeError("static protocol check rejected a valid descriptor-backed object")
     if isinstance(_DynamicRunner(), _SizedRunner):
         raise RuntimeError("static protocol check accepted a dynamic-only object")
+    for protocol in (Protocol, _SizedRunner):
+        try:
+            protocol()
+        except TypeError:
+            pass
+        else:
+            raise RuntimeError("fallback protocol declaration was instantiable")
+    if getattr(_ConcreteRunner, "_is_protocol", True) or _ConcreteRunner().run() != 1:
+        raise RuntimeError("fallback protocol misclassified a concrete subclass")
+    try:
+        runtime_checkable(_ConcreteRunner)
+    except TypeError:
+        pass
+    else:
+        raise RuntimeError("fallback runtime_checkable accepted a concrete subclass")
     try:
         issubclass(_DescriptorRunner, _SizedRunner)
     except TypeError:

--- a/scripts/ci/smoke_zero_typing_extensions.py
+++ b/scripts/ci/smoke_zero_typing_extensions.py
@@ -16,9 +16,11 @@ import zipfile
 
 try:
     from .archive_payload_policy import archive_member_errors
+    from .dependency_marker_policy import is_default_requirement as _is_default_requirement
 except ImportError:  # pragma: no cover - direct script execution
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     from archive_payload_policy import archive_member_errors
+    from dependency_marker_policy import is_default_requirement as _is_default_requirement
 
 
 class _BlockTypingExtensions:
@@ -29,12 +31,6 @@ class _BlockTypingExtensions:
         if fullname == "typing_extensions":
             raise ModuleNotFoundError("typing_extensions is intentionally absent")
         return None
-
-
-def _is_default_requirement(requirement: str) -> bool:
-    marker = requirement.partition(";")[2]
-    extra_equality = re.search(r"\bextra\s*==\s*(['\"])[^'\"]+\1", marker, re.IGNORECASE)
-    return extra_equality is None or re.search(r"\bor\b", marker, re.IGNORECASE) is not None
 
 
 def _single_wheel(raw: str) -> Path:
@@ -156,6 +152,36 @@ def _verify_protocol(Protocol, runtime_checkable) -> None:
     else:
         raise RuntimeError("unsupported fallback issubclass semantics did not fail closed")
 
+    concrete = type("Protocol", (_SizedRunner,), {"name": "runner", "__len__": lambda self: 1, "run": lambda self: 1})
+    child = type("Protocol", (concrete,), {})
+    if concrete._is_protocol or child._is_protocol or concrete().run() != 1:
+        raise RuntimeError("fallback class name changed concrete classification")
+    if not isinstance(child(), concrete) or not issubclass(child, concrete) or isinstance(object(), concrete):
+        raise RuntimeError("fallback named concrete class lost nominal checks")
+    for bases in ((_DescriptorRunner, Protocol), (Protocol, _DescriptorRunner)):
+        try:
+            type("Protocol", bases, {})
+        except TypeError:
+            pass
+        else:
+            raise RuntimeError("fallback class name bypassed protocol base restrictions")
+
+    @runtime_checkable
+    class _VersionedRunner(Protocol):
+        revision = 1
+
+        def run(self) -> int: ...
+
+    class _RevisionDescriptor:
+        def __get__(self, instance, owner):
+            raise AssertionError("default data descriptor must not execute")
+
+    class _VersionedObject(_DescriptorRunner):
+        revision = _RevisionDescriptor()
+
+    if isinstance(_DynamicRunner(), _VersionedRunner) or not isinstance(_VersionedObject(), _VersionedRunner):
+        raise RuntimeError("fallback default data member lost its static presence requirement")
+
 
 def _verify_isolated_root(root: Path) -> None:
     if sys.version_info[:2] != (3, 7):
@@ -195,6 +221,7 @@ def _verify_isolated_root(root: Path) -> None:
     sandbox_builtins = EvalContext(None)._make_builtins()
     if sandbox_builtins["__import__"]("typing").Literal != "Literal":
         raise RuntimeError("batch annotation sandbox omitted the local Literal")
+    _verify_annotation_execution()
 
     callers = (
         "dcc_mcp_core._server._inprocess_contracts",
@@ -211,6 +238,53 @@ def _verify_isolated_root(root: Path) -> None:
         importlib.import_module(module_name)
     if "typing_extensions" in sys.modules:
         raise RuntimeError("isolated runtime imported typing_extensions")
+
+
+def _verify_annotation_execution() -> None:
+    """Schema-valid annotations must survive materialization and sandbox execution."""
+    from dcc_mcp_core.dcc_api_executor import DccApiExecutor
+    from dcc_mcp_core.script_execution import normalize_file_backed_script_execution_params
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        executor = DccApiExecutor("3dsmax", dispatcher=None, script_materialization_root=root)
+        for module in ("typing", "typing_extensions"):
+            for annotation, value, schema_type in (
+                ("Annotated[int, 'units']", 7, "integer"),
+                ("Literal['fbx', 'usd']", "fbx", "string"),
+                ("List[int]", [1, 2], "array"),
+            ):
+                symbol = annotation.split("[", 1)[0]
+                source = f"from {module} import {symbol}\ndef main(value: {annotation}):\n    return value\n"
+                prepared = normalize_file_backed_script_execution_params(
+                    {"code": source, "params": {"value": value}},
+                    dcc_type="3dsmax",
+                    instance_id="annotation-contract",
+                    session_id="offline",
+                    materialization_root=root,
+                )
+                if prepared.parameters_schema["properties"]["value"]["type"] != schema_type:
+                    raise RuntimeError("script lost its parameter schema")
+                result = executor.execute_params({"file_path": prepared.file_path, "params": {"value": value}})
+                if not result["success"] or result["output"] != value:
+                    raise RuntimeError(f"materialized annotation script failed: {result}")
+            for body, error in (
+                ("return Annotated(int)", "not callable"),
+                ("return Annotated.__class__", "reflective"),
+                ("import os\n    return value", "sandbox import"),
+                ("from typing_extensions import get_type_hints\n    return value", "cannot import name"),
+            ):
+                source = f"from {module} import Annotated\ndef main(value: Annotated[int, 'units']):\n    {body}\n"
+                prepared = normalize_file_backed_script_execution_params(
+                    {"code": source, "params": {"value": 7}},
+                    dcc_type="3dsmax",
+                    instance_id="annotation-contract",
+                    session_id="offline",
+                    materialization_root=root,
+                )
+                result = executor.execute_params({"file_path": prepared.file_path, "params": {"value": 7}})
+                if result["success"] or error not in result["error"]:
+                    raise RuntimeError(f"materialized annotation script weakened sandbox restrictions: {result}")
 
 
 def main(argv=None) -> int:

--- a/tests/test_archive_publication_policy.py
+++ b/tests/test_archive_publication_policy.py
@@ -1,0 +1,419 @@
+"""Real archive regressions through the unmodified prepublication CLI.
+
+Native fixture entries are inert placeholders for archive validation, not
+evidence of a working native extension. Runtime smoke uses built wheels.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+import py_compile
+import stat
+import subprocess
+import sys
+import tarfile
+import zipfile
+
+import pytest
+from scripts.ci.check_python_wheel import validate_wheel
+from scripts.ci.check_release_distribution_set import DistributionSetError
+from scripts.ci.check_release_distribution_set import _validate_sdist
+from scripts.ci.python_support_contract import load_contract
+from scripts.ci.smoke_zero_typing_extensions import _check_wheel_archive
+
+from test_python_wheel_contract import _write_wheel
+
+_ROOT = Path(__file__).resolve().parents[1]
+_VERSION = "0.20.22"
+_SDIST_ROOT = f"dcc_mcp_core-{_VERSION}"
+_WHEEL_TAGS = (
+    "cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64",
+    "cp37-cp37m-win_amd64",
+    "cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64",
+    "cp38-abi3-win_amd64",
+    "cp38-abi3-macosx_10_12_universal2",
+    "py3-none-any",
+)
+
+
+def _zip_entry(name: str, data: bytes = b"fixture\n", directory: bool = False):
+    member = zipfile.ZipInfo(name)
+    member.create_system = 3
+    member.external_attr = ((stat.S_IFDIR if directory else stat.S_IFREG) | 0o755) << 16
+    if directory:
+        member.external_attr |= 0x10
+    return member, b"" if directory else data
+
+
+def _write_sdist(path: Path, entries=(), requirement: str = "") -> None:
+    metadata = (f"Metadata-Version: 2.1\nName: dcc-mcp-core\nVersion: {_VERSION}\nRequires-Python: >=3.7\n").encode()
+    if requirement:
+        metadata += f"Requires-Dist: {requirement}\n".encode()
+    with tarfile.open(path, "w:gz") as archive:
+        for item, data in [_zip_entry("PKG-INFO", metadata), *entries]:
+            member = tarfile.TarInfo(f"{_SDIST_ROOT}/{item.filename}")
+            member.type = tarfile.DIRTYPE if item.is_dir() else tarfile.REGTYPE
+            member.mode = stat.S_IMODE(item.external_attr >> 16)
+            member.size = len(data)
+            archive.addfile(member, None if member.isdir() else io.BytesIO(data))
+
+
+def test_sdist_fixture_preserves_declared_file_and_directory_permissions(tmp_path: Path) -> None:
+    directory, empty = _zip_entry("pkg/resources/", directory=True)
+    resource, data = _zip_entry("pkg/resources/manifest.json")
+    directory.external_attr = (stat.S_IFDIR | 0o750) << 16
+    resource.external_attr = (stat.S_IFREG | 0o640) << 16
+    sdist = tmp_path / "fixture.tar.gz"
+    _write_sdist(sdist, [(directory, empty), (resource, data)])
+    with tarfile.open(sdist) as archive:
+        assert archive.getmember(f"{_SDIST_ROOT}/pkg/resources").mode == 0o750
+        assert archive.getmember(f"{_SDIST_ROOT}/pkg/resources/manifest.json").mode == 0o640
+
+
+def _write_distribution_set(directory: Path, target: str, entries=(), requirement: str = "") -> Path:
+    directory.mkdir()
+    for tag in _WHEEL_TAGS:
+        pure = tag == "py3-none-any"
+        wheel = directory / f"{_SDIST_ROOT}-{tag}.whl"
+        _write_wheel(
+            wheel,
+            pure=pure,
+            with_core=not pure,
+            version=_VERSION,
+            requires_dist=[requirement] if pure and target == "wheel" and requirement else None,
+        )
+        if pure and target == "wheel":
+            with zipfile.ZipFile(wheel, "a") as archive:
+                for item, data in entries:
+                    archive.writestr(item, data)
+    sdist = directory / f"{_SDIST_ROOT}.tar.gz"
+    _write_sdist(sdist, entries if target == "sdist" else (), requirement if target == "sdist" else "")
+    return sdist if target == "sdist" else directory / f"{_SDIST_ROOT}-py3-none-any.whl"
+
+
+def _publication_cli(directory: Path):
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_ROOT / "scripts/ci/check_release_distribution_set.py"),
+            "--dist-dir",
+            str(directory),
+            "--version",
+            _VERSION,
+        ],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _assert_consumers_reject(tmp_path: Path, target: str, entries, reason: str) -> None:
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, target, entries)
+    # Run the exact CLI used before publishing, with all six wheel contracts
+    # and the sdist present. No validator or contract loader is patched.
+    result = _publication_cli(directory)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert reason in result.stderr
+    if target == "wheel":
+        errors = validate_wheel(artifact, "lite_py37", "any", load_contract(_ROOT))
+        assert any(reason in error for error in errors), errors
+        with pytest.raises(RuntimeError, match=reason):
+            _check_wheel_archive(artifact, tmp_path / "blocked-extraction")
+        assert not (tmp_path / "blocked-extraction").exists()
+    else:
+        with pytest.raises(DistributionSetError, match=reason):
+            _validate_sdist(artifact, _VERSION, load_contract(_ROOT))
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+def test_complete_prepublication_cli_accepts_clean_set(tmp_path: Path, target: str) -> None:
+    _write_distribution_set(tmp_path / "dist", target)
+    result = _publication_cli(tmp_path / "dist")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert "Validated 7 fresh Core distribution(s)" in result.stdout
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+def test_quoted_extra_text_cannot_hide_default_dependency(tmp_path: Path, target: str) -> None:
+    requirement = 'typing-extensions==4.7.1; python_version < "3.8" and os_name != "extra == \'test\'"'
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, target, requirement=requirement)
+    result = _publication_cli(directory)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "forbidden runtime dependency" in result.stderr
+    if target == "wheel":
+        errors = validate_wheel(artifact, "lite_py37", "any", load_contract(_ROOT))
+        assert any("forbidden runtime dependency" in error for error in errors), errors
+        with pytest.raises(RuntimeError, match="metadata contains typing-extensions"):
+            _check_wheel_archive(artifact, tmp_path / "blocked")
+        assert not (tmp_path / "blocked").exists()
+    else:
+        with pytest.raises(DistributionSetError, match="forbidden runtime dependency"):
+            _validate_sdist(artifact, _VERSION, load_contract(_ROOT))
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "python_version < '3.8' and extra == 'test'",
+        "(extra == 'test' or 'dev' == extra) and os_name != \"extra == 'other'\"",
+    ],
+)
+def test_real_extra_only_requirements_remain_publishable(tmp_path: Path, target: str, marker: str) -> None:
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, target, requirement="typing-extensions==4.7.1; " + marker)
+    result = _publication_cli(directory)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    if target == "wheel":
+        assert validate_wheel(artifact, "lite_py37", "any", load_contract(_ROOT)) == []
+        _check_wheel_archive(artifact, tmp_path / "extracted")
+    else:
+        _validate_sdist(artifact, _VERSION, load_contract(_ROOT))
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("character", list('?*<>|"'))
+def test_all_consumers_reject_windows_extraction_aliases(tmp_path: Path, target: str, character: str) -> None:
+    _assert_consumers_reject(tmp_path, target, [_zip_entry(f"typing{character}extensions.py")], "unsafe archive member")
+
+
+@pytest.mark.parametrize("kind", [stat.S_IFIFO, stat.S_IFCHR, stat.S_IFBLK, stat.S_IFSOCK, 0o150000])
+def test_all_wheel_consumers_reject_unix_special_member_types(tmp_path: Path, kind: int) -> None:
+    member, data = _zip_entry("dcc_mcp_core/special")
+    member.external_attr = (kind | 0o600) << 16
+    _assert_consumers_reject(tmp_path, "wheel", [(member, data)], "forbidden special member")
+    with zipfile.ZipFile(tmp_path / "dist" / f"{_SDIST_ROOT}-py3-none-any.whl") as archive:
+        assert stat.S_IFMT(archive.getinfo(member.filename).external_attr >> 16) == kind
+
+
+@pytest.mark.parametrize("kind", [0, stat.S_IFREG])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_regular_and_permission_only_zip_modes_remain_publishable(tmp_path: Path, kind: int, reverse: bool) -> None:
+    member, data = _zip_entry("pkg/resources/file.json")
+    member.external_attr = (kind | 0o644) << 16
+    entries = [_zip_entry("pkg/resources/", directory=True), (member, data)]
+    if reverse:
+        entries.reverse()
+    artifact = _write_distribution_set(tmp_path / "dist", "wheel", entries)
+    result = _publication_cli(tmp_path / "dist")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert validate_wheel(artifact, "lite_py37", "any", load_contract(_ROOT)) == []
+    _check_wheel_archive(artifact, tmp_path / "extracted")
+    assert (tmp_path / "extracted/pkg/resources/file.json").read_bytes() == data
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Requires real Windows ZipFile extraction semantics")
+@pytest.mark.parametrize("character", list('?*<>|"'))
+def test_windows_zip_alias_really_extracts_as_importable_backport_name(tmp_path: Path, character: str) -> None:
+    wheel = tmp_path / "alias.zip"
+    item, data = _zip_entry(f"typing{character}extensions.py", b"fixture_marker = 2388\n")
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(item, data)
+    extracted = tmp_path / "extracted"
+    with zipfile.ZipFile(wheel) as archive:
+        assert archive.infolist()[0].filename == item.filename
+        archive.extractall(extracted)
+    assert (extracted / "typing_extensions.py").read_bytes() == data
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            "import sys; sys.path.insert(0, sys.argv[1]); import typing_extensions as t; "
+            "assert t.fixture_marker == 2388; print(t.__file__)",
+            str(extracted),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert str(extracted / "typing_extensions.py") in result.stdout
+
+
+def _source_free_bytecode(tmp_path: Path) -> bytes:
+    source = tmp_path / "compile-input.py"
+    source.write_text("fixture_marker = 2388\n", encoding="utf-8")
+    bytecode = tmp_path / "compile-output.pyc"
+    py_compile.compile(str(source), cfile=str(bytecode), dfile="typing_extensions.py", doraise=True)
+    return bytecode.read_bytes()
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("optimization", [0, 1, 2])
+def test_all_consumers_reject_cpython_tagged_backport_cache(tmp_path: Path, target: str, optimization: int) -> None:
+    source = tmp_path / "typing_extensions.py"
+    source.write_text("fixture_marker = 2388\n", encoding="utf-8")
+    bytecode = Path(py_compile.compile(str(source), optimize=optimization, doraise=True))
+    assert bytecode.parent.name == "__pycache__"
+    _assert_consumers_reject(
+        tmp_path,
+        target,
+        [_zip_entry(f"vendor/__pycache__/{bytecode.name}", bytecode.read_bytes())],
+        "typing_extensions payload",
+    )
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("tag", ["37", "38", "39", "310", "311", "312", "313", "314"])
+def test_backport_cache_tags_remain_forbidden_across_supported_cpython_versions(
+    tmp_path: Path, target: str, tag: str
+) -> None:
+    _assert_consumers_reject(
+        tmp_path,
+        target,
+        [_zip_entry(f"vendor/__pycache__/typing_extensions.cpython-{tag}.opt-2.pyc")],
+        "typing_extensions payload",
+    )
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Typing.Extensions.CPYTHON-37.PYC",
+        "typing\uff3fextensions.cpython-37.opt-1.pyc",
+        "typing-extensions.cpython-314.opt-2.pyc",
+    ],
+)
+def test_backport_cache_tags_preserve_portable_alias_rejection(tmp_path: Path, target: str, name: str) -> None:
+    _assert_consumers_reject(tmp_path, target, [_zip_entry(f"vendor/__pycache__/{name}")], "typing_extensions payload")
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("optimization", [0, 1, 2])
+@pytest.mark.parametrize("module", ["typing", "typing_extensions_helpers", "my_typing_extensions"])
+def test_ordinary_and_similarly_named_cpython_caches_remain_publishable(
+    tmp_path: Path, target: str, optimization: int, module: str
+) -> None:
+    source = tmp_path / f"{module}.py"
+    source.write_text('"""Fixture module."""\nfixture_debug = __debug__\n', encoding="utf-8")
+    bytecode = Path(py_compile.compile(str(source), optimize=optimization, doraise=True))
+    data = bytecode.read_bytes()
+    name = f"vendor/__pycache__/{bytecode.name}"
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, target, [_zip_entry(name, data)])
+    result = _publication_cli(directory)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    if target == "wheel":
+        assert validate_wheel(artifact, "lite_py37", "any", load_contract(_ROOT)) == []
+        _check_wheel_archive(artifact, tmp_path / "extracted")
+        assert (tmp_path / "extracted" / name).read_bytes() == data
+    else:
+        _validate_sdist(artifact, _VERSION, load_contract(_ROOT))
+        with tarfile.open(artifact) as archive:
+            assert archive.extractfile(f"{_SDIST_ROOT}/{name}").read() == data
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize(
+    "name",
+    ["typing_extensions.cpython-37.py", "typing_extensions.cpython-37.pyc.txt", "typing_extensions_notes.pyc"],
+)
+def test_cache_tag_rule_does_not_match_unrelated_filename_suffixes(tmp_path: Path, target: str, name: str) -> None:
+    _write_distribution_set(tmp_path / "dist", target, [_zip_entry(name)])
+    result = _publication_cli(tmp_path / "dist")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize(
+    "name", ["typing_extensions.pyc", "Typing.Extensions.PYC", "vendor/typing\uff3fextensions.pyc"]
+)
+def test_all_consumers_reject_source_free_backport_bytecode(tmp_path: Path, target: str, name: str) -> None:
+    _assert_consumers_reject(
+        tmp_path, target, [_zip_entry(name, _source_free_bytecode(tmp_path))], "typing_extensions payload"
+    )
+
+
+def test_source_free_zip_module_is_importable_without_source_or_site_packages(tmp_path: Path) -> None:
+    wheel = tmp_path / "bytecode.zip"
+    item, data = _zip_entry("typing_extensions.pyc", _source_free_bytecode(tmp_path))
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(item, data)
+    extracted = tmp_path / "source-free"
+    with zipfile.ZipFile(wheel) as archive:
+        archive.extractall(extracted)
+    assert [path.name for path in extracted.iterdir()] == ["typing_extensions.pyc"]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            "import sys; sys.path.insert(0, sys.argv[1]); import typing_extensions as t; "
+            "assert t.fixture_marker == 2388; assert t.__file__.endswith('.pyc'); print(t.__file__)",
+            str(extracted),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert str(extracted / "typing_extensions.pyc") in result.stdout
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "ancestor,child,directory",
+    [
+        ("pkg/resources", "pkg/resources/manifest.json", False),
+        ("pkg", "pkg/resources/nested/manifest.json", False),
+        ("pkg/RESOURCES", "pkg/resources/manifest.json", False),
+        ("pkg/resources", "pkg/\uff52esources/manifest.json", False),
+        ("pkg/resources", "pkg/resources/", True),
+    ],
+)
+def test_all_consumers_reject_conflicting_archive_topology(
+    tmp_path: Path, target: str, reverse: bool, ancestor: str, child: str, directory: bool
+) -> None:
+    entries = [_zip_entry(ancestor), _zip_entry(child, directory=directory)]
+    _assert_consumers_reject(
+        tmp_path, target, list(reversed(entries)) if reverse else entries, "file/directory conflict"
+    )
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_valid_explicit_and_implied_directory_topology_is_publishable_and_extractable(
+    tmp_path: Path, target: str, reverse: bool
+) -> None:
+    entries = [_zip_entry("pkg/resources/", directory=True), _zip_entry("pkg/resources/manifest.json")]
+    if reverse:
+        entries.reverse()
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, target, entries)
+    result = _publication_cli(directory)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    extracted = tmp_path / "extracted"
+    if target == "wheel":
+        _check_wheel_archive(artifact, extracted)
+        resource = extracted / "pkg/resources/manifest.json"
+    else:
+        with tarfile.open(artifact) as archive:
+            archive.extractall(extracted)
+        resource = extracted / _SDIST_ROOT / "pkg/resources/manifest.json"
+    assert resource.read_bytes() == b"fixture\n"
+
+
+@pytest.mark.parametrize("target", ["wheel", "sdist"])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_conflicting_topology_really_fails_archive_extraction(tmp_path: Path, target: str, reverse: bool) -> None:
+    entries = [_zip_entry("pkg/resources"), _zip_entry("pkg/resources/manifest.json")]
+    if reverse:
+        entries.reverse()
+    artifact = _write_distribution_set(tmp_path / "dist", target, entries)
+    with pytest.raises(OSError):
+        if target == "wheel":
+            with zipfile.ZipFile(artifact) as archive:
+                archive.extractall(tmp_path / "extracted")
+        else:
+            with tarfile.open(artifact) as archive:
+                archive.extractall(tmp_path / "extracted")

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -124,7 +124,7 @@ def test_release_wheels_are_uploaded_once_after_every_build() -> None:
     }
 
 
-def test_python37_runtime_smokes_run_without_provisioning_typing_extensions() -> None:
+def test_python37_runtime_smokes_share_version_and_ref_bound_dependency_preparation() -> None:
     smoke_steps = {
         "py37-lite": "Test py37-lite wheel",
         "linux-py37": "Test native Python 3.7 wheel with workflow smoke",
@@ -133,10 +133,11 @@ def test_python37_runtime_smokes_run_without_provisioning_typing_extensions() ->
 
     for job_id, smoke_step_name in smoke_steps.items():
         steps = _jobs()[job_id]["steps"]
-        assert all(step.get("name") != "Provision Python 3.7 smoke dependencies" for step in steps)
         smoke_index = next(index for index, step in enumerate(steps) if step.get("name") == smoke_step_name)
-        isolated_index = next(
-            index for index, step in enumerate(steps) if step.get("name") == "Test zero-backport Python 3.7 wheel"
-        )
-        assert isolated_index < smoke_index
-        assert "smoke_zero_typing_extensions.py" in steps[isolated_index]["run"]
+        smoke = steps[smoke_index]
+        assert "python37_wheel_smoke.py" in smoke["run"]
+        assert '--checkout-ref "$CHECKOUT_REF"' in smoke["run"]
+        assert smoke["env"]["CHECKOUT_REF"] == "${{ inputs.checkout-ref || github.ref }}"
+        assert "--profile " + ("lite_py37" if job_id == "py37-lite" else "native_py37") in smoke["run"]
+        assert "if [[ -f" not in smoke["run"]
+        assert all("test_issue_2388_zero_typing_extensions.py" not in step.get("run", "") for step in steps)

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -111,7 +111,7 @@ def test_release_wheels_are_uploaded_once_after_every_build() -> None:
     }
 
 
-def test_python37_runtime_smokes_provision_workflow_owned_typing_extensions() -> None:
+def test_python37_runtime_smokes_run_without_provisioning_typing_extensions() -> None:
     smoke_steps = {
         "py37-lite": "Test py37-lite wheel",
         "linux-py37": "Test native Python 3.7 wheel with workflow smoke",
@@ -120,15 +120,10 @@ def test_python37_runtime_smokes_provision_workflow_owned_typing_extensions() ->
 
     for job_id, smoke_step_name in smoke_steps.items():
         steps = _jobs()[job_id]["steps"]
-        provision_index, provision = next(
-            (index, step)
-            for index, step in enumerate(steps)
-            if step.get("name") == "Provision Python 3.7 smoke dependencies"
-        )
+        assert all(step.get("name") != "Provision Python 3.7 smoke dependencies" for step in steps)
         smoke_index = next(index for index, step in enumerate(steps) if step.get("name") == smoke_step_name)
-
-        assert provision_index < smoke_index
-        command = provision["run"]
-        assert ".workflow-tools/compatibility/python.json" in command
-        assert '["test_toolchain"]["typing_extensions"]' in command
-        assert '"typing-extensions==${TYPING_EXTENSIONS_VERSION}"' in command
+        isolated_index = next(
+            index for index, step in enumerate(steps) if step.get("name") == "Test zero-backport Python 3.7 wheel"
+        )
+        assert isolated_index < smoke_index
+        assert "smoke_zero_typing_extensions.py" in steps[isolated_index]["run"]

--- a/tests/test_build_wheels_workflow.py
+++ b/tests/test_build_wheels_workflow.py
@@ -101,7 +101,20 @@ def test_release_wheels_are_uploaded_once_after_every_build() -> None:
         "merge-multiple": True,
     }
 
-    upload = publish["steps"][1]
+    validate_index = next(
+        index
+        for index, step in enumerate(publish["steps"])
+        if "check_release_distribution_set.py" in step.get("run", "")
+    )
+    upload_index = next(
+        index for index, step in enumerate(publish["steps"]) if step.get("uses") == "softprops/action-gh-release@v3"
+    )
+    assert validate_index < upload_index
+    validation = publish["steps"][validate_index]
+    assert "--dist-dir dist" in validation["run"]
+    assert "--version" in validation["run"]
+
+    upload = publish["steps"][upload_index]
     assert upload["uses"] == "softprops/action-gh-release@v3"
     assert upload["with"] == {
         "tag_name": "${{ inputs.release-tag-name }}",

--- a/tests/test_dependency_marker_policy.py
+++ b/tests/test_dependency_marker_policy.py
@@ -1,0 +1,57 @@
+"""Default-dependency proofs use tokens, never text inside quoted values."""
+
+from __future__ import annotations
+
+import pytest
+from scripts.ci.check_python_wheel import _is_default_requirement
+from scripts.ci.dependency_marker_policy import is_default_requirement
+from scripts.ci.smoke_zero_typing_extensions import _is_default_requirement as smoke_policy
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "",
+        "python_version < '3.8'",
+        "extra == ''",
+        "extra != 'test'",
+        "os_name != \"extra == 'test'\"",
+        "'extra' == 'test'",
+        "extra == 'test' or python_version < '3.8'",
+        "extra == 'test' or extra == ''",
+        "extra == 'test' garbage",
+        "extra == 'test' and",
+        "(extra == 'test'",
+        "extra == 'test')",
+        "unknown == 'value' and extra == 'test'",
+        "extra === 'test'",
+        "extra in 'test'",
+        "extra not in 'test'",
+        "extra == 'test' and os_name == 'bad\\escape'",
+        "(" * 33 + "extra == 'test'" + ")" * 33,
+        "extra == '" + "x" * 8192 + "'",
+    ],
+)
+def test_unproven_or_malformed_markers_fail_closed(marker: str) -> None:
+    assert is_default_requirement("typing-extensions; " + marker)
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "extra == 'test'",
+        "'test' == extra",
+        'extra == "dev"',
+        "python_version < '3.8' and extra == 'test'",
+        "extra == 'test' or extra == 'dev'",
+        "(extra == 'test' or extra == 'dev') and os_name != 'or'",
+        "extra == 'test' and (python_version < '3.8' or os_name == 'nt')",
+    ],
+)
+def test_complete_extra_constraints_prove_default_inactive(marker: str) -> None:
+    assert not is_default_requirement("typing-extensions; " + marker)
+
+
+def test_archive_consumers_share_the_exact_policy() -> None:
+    assert _is_default_requirement is is_default_requirement
+    assert smoke_policy is is_default_requirement

--- a/tests/test_issue_2388_zero_typing_extensions.py
+++ b/tests/test_issue_2388_zero_typing_extensions.py
@@ -135,6 +135,17 @@ class TypingCompatibilityTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "only to protocol classes"):
             compat.runtime_checkable(ConcreteRunner)
 
+    def test_python37_protocol_declaration_rejects_every_non_protocol_base(self):
+        compat = _load_simulated_python37_typing()
+
+        class NonProtocolBase:
+            pass
+
+        with self.assertRaisesRegex(TypeError, "non-protocol"):
+
+            class InvalidProtocol(NonProtocolBase, compat.Protocol):
+                def run(self) -> int: ...
+
     def test_python37_literal_accepts_only_nonempty_json_preserving_scalars(self):
         compat = _load_simulated_python37_typing()
 

--- a/tests/test_issue_2388_zero_typing_extensions.py
+++ b/tests/test_issue_2388_zero_typing_extensions.py
@@ -135,6 +135,57 @@ class TypingCompatibilityTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "only to protocol classes"):
             compat.runtime_checkable(ConcreteRunner)
 
+    def test_python37_concrete_protocol_descendants_use_nominal_type_checks(self):
+        compat = _load_simulated_python37_typing()
+
+        for runtime_enabled in (False, True):
+
+            class RunnerProtocol(compat.Protocol):
+                def run(self) -> int: ...
+
+            if runtime_enabled:
+                compat.runtime_checkable(RunnerProtocol)
+
+            class ConcreteRunner(RunnerProtocol):
+                def run(self) -> int:
+                    return 1
+
+            class ChildRunner(ConcreteRunner):
+                pass
+
+            class GrandchildRunner(ChildRunner):
+                pass
+
+            class SiblingRunner(RunnerProtocol):
+                def run(self) -> int:
+                    return 1
+
+            class StructuralRunner:
+                def run(self) -> int:
+                    return 1
+
+            cases = (
+                (object, ConcreteRunner, False),
+                (ConcreteRunner, ConcreteRunner, True),
+                (ChildRunner, ConcreteRunner, True),
+                (GrandchildRunner, ConcreteRunner, True),
+                (GrandchildRunner, ChildRunner, True),
+                (ChildRunner, ChildRunner, True),
+                (ConcreteRunner, ChildRunner, False),
+                (object, ChildRunner, False),
+                (SiblingRunner, ConcreteRunner, False),
+                (StructuralRunner, ConcreteRunner, False),
+            )
+            for candidate, target, expected in cases:
+                for check, value in ((isinstance, candidate()), (issubclass, candidate)):
+                    with self.subTest(
+                        runtime_enabled=runtime_enabled,
+                        check=check.__name__,
+                        candidate=candidate.__name__,
+                        target=target.__name__,
+                    ):
+                        self.assertIs(check(value, target), expected)
+
     def test_python37_protocol_declaration_rejects_every_non_protocol_base(self):
         compat = _load_simulated_python37_typing()
 

--- a/tests/test_issue_2388_zero_typing_extensions.py
+++ b/tests/test_issue_2388_zero_typing_extensions.py
@@ -113,6 +113,28 @@ class TypingCompatibilityTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "issubclass"):
             issubclass(Plain, compat.runtime_checkable(Undecorated))
 
+    def test_python37_protocol_declarations_reject_instantiation_and_concrete_decorator_misuse(self):
+        compat = _load_simulated_python37_typing()
+
+        class DeclaredProtocol(compat.Protocol):
+            def run(self) -> int: ...
+
+        class ConcreteRunner(DeclaredProtocol):
+            def run(self) -> int:
+                return 1
+
+        with self.assertRaisesRegex(TypeError, "Protocols cannot be instantiated"):
+            compat.Protocol()
+        with self.assertRaisesRegex(TypeError, "Protocols cannot be instantiated"):
+            DeclaredProtocol()
+
+        self.assertTrue(DeclaredProtocol._is_protocol)
+        self.assertFalse(ConcreteRunner._is_protocol)
+        self.assertEqual(ConcreteRunner().run(), 1)
+        self.assertIs(compat.runtime_checkable(DeclaredProtocol), DeclaredProtocol)
+        with self.assertRaisesRegex(TypeError, "only to protocol classes"):
+            compat.runtime_checkable(ConcreteRunner)
+
     def test_python37_literal_accepts_only_nonempty_json_preserving_scalars(self):
         compat = _load_simulated_python37_typing()
 

--- a/tests/test_issue_2388_zero_typing_extensions.py
+++ b/tests/test_issue_2388_zero_typing_extensions.py
@@ -1,0 +1,179 @@
+"""Regression contract for the zero-dependency Python 3.7 typing boundary."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import math
+from pathlib import Path
+import sys
+import typing
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TYPING_MODULE = REPO_ROOT / "python" / "dcc_mcp_core" / "_typing.py"
+PYTHON_PACKAGE = REPO_ROOT / "python" / "dcc_mcp_core"
+
+
+class _BlockTypingExtensions:
+    """Fail if the compatibility boundary tries to import the backport."""
+
+    @staticmethod
+    def find_spec(fullname, path=None, target=None):
+        if fullname == "typing_extensions":
+            raise ModuleNotFoundError("typing_extensions is intentionally absent")
+        return None
+
+
+def _load_simulated_python37_typing():
+    """Load ``_typing`` with the three Python 3.8 typing APIs hidden."""
+    names = ("Literal", "Protocol", "runtime_checkable")
+    saved = {name: getattr(typing, name) for name in names if hasattr(typing, name)}
+    blocker = _BlockTypingExtensions()
+    sys.meta_path.insert(0, blocker)
+    try:
+        for name in names:
+            if hasattr(typing, name):
+                delattr(typing, name)
+        spec = importlib.util.spec_from_file_location("_issue_2388_typing", TYPING_MODULE)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.meta_path.remove(blocker)
+        for name, value in saved.items():
+            setattr(typing, name, value)
+
+
+class TypingCompatibilityTests(unittest.TestCase):
+    @unittest.skipIf(sys.version_info < (3, 8), "stdlib typing APIs begin in Python 3.8")
+    def test_modern_interpreters_export_stdlib_objects_by_identity(self):
+        spec = importlib.util.spec_from_file_location("_issue_2388_modern_typing", TYPING_MODULE)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        self.assertIs(module.Literal, typing.Literal)
+        self.assertIs(module.Protocol, typing.Protocol)
+        self.assertIs(module.runtime_checkable, typing.runtime_checkable)
+
+    def test_python37_protocol_checks_are_static_and_cover_dunder_members(self):
+        compat = _load_simulated_python37_typing()
+
+        @compat.runtime_checkable
+        class SizedRunner(compat.Protocol):
+            name: str
+
+            def __len__(self) -> int: ...
+
+            def run(self) -> int: ...
+
+        class DescriptorBackedRunner:
+            @property
+            def name(self):
+                raise AssertionError("property must not execute")
+
+            def __len__(self):
+                return 1
+
+            def run(self):
+                return 1
+
+        class DynamicOnlyRunner:
+            def __getattr__(self, name):
+                raise AssertionError("__getattr__ must not execute")
+
+            def __len__(self):
+                return 1
+
+            def run(self):
+                return 1
+
+        class BrokenRunner(DescriptorBackedRunner):
+            run = None
+
+        self.assertIsInstance(DescriptorBackedRunner(), SizedRunner)
+        self.assertNotIsInstance(DynamicOnlyRunner(), SizedRunner)
+        self.assertNotIsInstance(BrokenRunner(), SizedRunner)
+
+    def test_python37_protocol_unsupported_semantics_fail_closed(self):
+        compat = _load_simulated_python37_typing()
+
+        class Undecorated(compat.Protocol):
+            value: str
+
+        class Plain:
+            value = "x"
+
+        with self.assertRaisesRegex(TypeError, "runtime_checkable"):
+            isinstance(Plain(), Undecorated)
+        with self.assertRaises(TypeError):
+            compat.runtime_checkable(Plain)
+        with self.assertRaisesRegex(TypeError, "issubclass"):
+            issubclass(Plain, compat.runtime_checkable(Undecorated))
+
+    def test_python37_literal_accepts_only_nonempty_json_preserving_scalars(self):
+        compat = _load_simulated_python37_typing()
+
+        alias = compat.Literal["fbx", 1, True, None, -0.5]
+        self.assertIs(alias.__origin__, compat.Literal)
+        self.assertEqual(alias.__args__, ("fbx", 1, True, None, -0.5))
+
+        class CapabilityInt(int):
+            def open(self):
+                return None
+
+        rejected = (
+            (),
+            b"fbx",
+            ((1, 2),),
+            ([1],),
+            ({"value": 1},),
+            (...,),
+            (object(),),
+            (CapabilityInt(1),),
+            (math.nan,),
+            (math.inf,),
+        )
+        for item in rejected:
+            with self.subTest(item=repr(item)), self.assertRaises(TypeError):
+                compat.Literal[item]
+
+
+class PackagingBoundaryTests(unittest.TestCase):
+    def test_default_dependencies_do_not_include_typing_extensions(self):
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        dependency_block = pyproject.split("dependencies = [", 1)[1].split("]", 1)[0]
+        self.assertNotIn("typing-extensions", dependency_block.lower())
+        self.assertNotIn("typing_extensions", dependency_block.lower())
+
+    def test_production_python_never_imports_typing_extensions(self):
+        violations = []
+        for path in sorted(PYTHON_PACKAGE.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import) and any(alias.name == "typing_extensions" for alias in node.names):
+                    violations.append(path.relative_to(REPO_ROOT).as_posix())
+                if isinstance(node, ast.ImportFrom) and node.module == "typing_extensions":
+                    violations.append(path.relative_to(REPO_ROOT).as_posix())
+        self.assertEqual(violations, [])
+
+    def test_production_protocol_literal_callers_use_the_single_local_boundary(self):
+        direct_imports = []
+        protected_names = {"Literal", "Protocol", "runtime_checkable"}
+        for path in sorted(PYTHON_PACKAGE.rglob("*.py")):
+            if path == TYPING_MODULE:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                imported = protected_names.intersection(alias.name for alias in node.names)
+                if imported and node.module != "dcc_mcp_core._typing":
+                    direct_imports.append((path.relative_to(REPO_ROOT).as_posix(), sorted(imported)))
+        self.assertEqual(direct_imports, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue_2388_zero_typing_extensions.py
+++ b/tests/test_issue_2388_zero_typing_extensions.py
@@ -197,6 +197,87 @@ class TypingCompatibilityTests(unittest.TestCase):
             class InvalidProtocol(NonProtocolBase, compat.Protocol):
                 def run(self) -> int: ...
 
+    def test_python37_class_name_cannot_change_protocol_classification(self):
+        compat = _load_simulated_python37_typing()
+
+        class Runner(compat.Protocol):
+            def run(self) -> int: ...
+
+        for name in ("Protocol", "ConcreteRunner"):
+            with self.subTest(name=name):
+                concrete = type(name, (Runner,), {"run": lambda self: 7})
+                child = type(name, (concrete,), {})
+                self.assertFalse(concrete._is_protocol)
+                self.assertFalse(child._is_protocol)
+                self.assertEqual(concrete().run(), 7)
+                self.assertIsInstance(child(), concrete)
+                self.assertTrue(issubclass(child, concrete))
+                self.assertNotIsInstance(object(), concrete)
+                self.assertFalse(issubclass(object, concrete))
+                with self.assertRaises(TypeError):
+                    compat.runtime_checkable(concrete)
+
+    def test_python37_named_protocol_declarations_preserve_base_restrictions(self):
+        compat = _load_simulated_python37_typing()
+
+        class NonProtocol:
+            pass
+
+        for name in ("Protocol", "RunnerProtocol"):
+            with self.subTest(name=name):
+                declared = type(name, (compat.Protocol,), {"__annotations__": {}, "run": lambda self: None})
+                self.assertTrue(declared._is_protocol)
+                with self.assertRaises(TypeError):
+                    declared()
+                with self.assertRaises(TypeError):
+                    isinstance(object(), declared)
+                self.assertIs(compat.runtime_checkable(declared), declared)
+                self.assertNotIsInstance(object(), declared)
+                for bases in ((NonProtocol, compat.Protocol), (compat.Protocol, NonProtocol)):
+                    with self.subTest(bases=bases), self.assertRaisesRegex(TypeError, "non-protocol"):
+                        type(name, bases, {})
+
+    def test_python37_default_data_members_remain_static_requirements(self):
+        compat = _load_simulated_python37_typing()
+
+        class Versioned(compat.Protocol):
+            # Keep the simulated 3.7 namespace independent of newer lazy annotation descriptors.
+            __annotations__ = {}
+            revision = 1
+
+        @compat.runtime_checkable
+        class Runner(Versioned, compat.Protocol):
+            __annotations__ = {}
+
+            def run(self) -> int: ...
+
+        class WithoutRevision:
+            def run(self):
+                return 7
+
+            def __getattr__(self, name):
+                raise AssertionError("dynamic lookup must not execute")
+
+        class WithRevision(WithoutRevision):
+            revision = None
+
+        class HostileDescriptor:
+            def __get__(self, instance, owner):
+                raise AssertionError("descriptor must not execute")
+
+        class DescriptorRevision(WithoutRevision):
+            revision = HostileDescriptor()
+
+        class BrokenMethod(WithRevision):
+            run = None
+
+        self.assertNotIsInstance(WithoutRevision(), Runner)
+        self.assertIsInstance(WithRevision(), Runner)
+        self.assertIsInstance(DescriptorRevision(), Runner)
+        self.assertNotIsInstance(BrokenMethod(), Runner)
+        with self.assertRaisesRegex(TypeError, "issubclass"):
+            issubclass(WithRevision, Runner)
+
     def test_python37_literal_accepts_only_nonempty_json_preserving_scalars(self):
         compat = _load_simulated_python37_typing()
 

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -7,6 +7,7 @@ import re
 from conftest import REPO_ROOT
 
 PYPROJECT = REPO_ROOT / "pyproject.toml"
+UV_LOCK = REPO_ROOT / "uv.lock"
 SERVER_BINARY_DEP = "dcc-mcp-server>=0.18.17,<1.0.0"
 TYPING_DEP = "typing-extensions==4.7.1; python_version<'3.8'"
 
@@ -23,8 +24,17 @@ def test_core_requires_packaged_server_binary_runtime() -> None:
     assert any(dep.startswith(SERVER_BINARY_DEP) for dep in deps)
 
 
-def test_python37_uses_the_official_typing_backport() -> None:
-    assert TYPING_DEP in _project_dependencies()
+def test_python37_default_install_has_no_typing_backport() -> None:
+    assert TYPING_DEP not in _project_dependencies()
+
+
+def test_python37_lockfile_keeps_typing_backport_test_only() -> None:
+    text = UV_LOCK.read_text(encoding="utf-8")
+    start = text.index('[[package]]\nname = "dcc-mcp-core"\n')
+    block = text[start + len("[[package]]") :].split("[[package]]", 1)[0]
+    default_dependencies = block.split("[package.optional-dependencies]", 1)[0]
+    assert 'name = "typing-extensions"' not in default_dependencies
+    assert "name = \"typing-extensions\", marker = \"python_full_version < '3.8' and extra == 'test'\"" in block
 
 
 def test_bridge_extra_declares_a_compatible_websockets_range() -> None:

--- a/tests/test_py37_wheel_builder.py
+++ b/tests/test_py37_wheel_builder.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from scripts.build_py37_pure_wheel import _is_lite_payload_file
 from scripts.build_py37_pure_wheel import _read_console_scripts
 from scripts.build_py37_pure_wheel import _read_runtime_requirements
 
@@ -9,7 +12,7 @@ from scripts.build_py37_pure_wheel import _read_runtime_requirements
 def test_lite_wheel_inherits_project_runtime_dependencies() -> None:
     requirements = _read_runtime_requirements()
     assert "dcc-mcp-server>=0.18.17,<1.0.0" in requirements
-    assert "typing-extensions==4.7.1; python_version<'3.8'" in requirements
+    assert not any(requirement.lower().startswith("typing-extensions") for requirement in requirements)
 
 
 def test_lite_wheel_inherits_project_console_scripts() -> None:
@@ -17,3 +20,15 @@ def test_lite_wheel_inherits_project_console_scripts() -> None:
         "dcc-mcp-install-lifecycle": "dcc_mcp_core.install_lifecycle_cli:main",
         "dcc-mcp-ui-control-server": "dcc_mcp_core.ui_control_server:cli",
     }
+
+
+def test_lite_wheel_excludes_native_build_residue(tmp_path: Path) -> None:
+    package = tmp_path / "dcc_mcp_core"
+    package.mkdir()
+    source = package / "_typing.py"
+    source.write_text("", encoding="utf-8")
+    assert _is_lite_payload_file(source)
+    for name in ("_core.cp312-win_amd64.pyd", "_core.pdb", "helper.dll", "helper.so", "helper.dylib"):
+        residue = package / name
+        residue.write_bytes(b"")
+        assert not _is_lite_payload_file(residue)

--- a/tests/test_python37_wheel_smoke.py
+++ b/tests/test_python37_wheel_smoke.py
@@ -1,0 +1,58 @@
+"""Historical dependency preparation never grants current code an exemption."""
+
+from __future__ import annotations
+
+import pytest
+from scripts.ci.python37_wheel_smoke import historical_release
+from scripts.ci.python37_wheel_smoke import smoke_wheel
+
+_COMMIT = "e8d070fd703164a380895af2d6b4e17b3cb2459c"
+
+
+def test_only_exact_pre_cutover_tag_can_prepare_declared_dependencies() -> None:
+    assert historical_release("v0.20.21", "0.20.21", _COMMIT, _COMMIT, "0.20.22")
+    assert not historical_release("", "0.20.21", _COMMIT, _COMMIT, "0.20.22")
+    assert not historical_release("main", "0.20.21", _COMMIT, _COMMIT, "0.20.22")
+    assert not historical_release("v0.20.22", "0.20.22", _COMMIT, _COMMIT, "0.20.22")
+    assert not historical_release("v1.0.0", "1.0.0", _COMMIT, _COMMIT, "0.20.22")
+    assert historical_release("refs/tags/v0.20.21", "0.20.21", _COMMIT, _COMMIT, "0.20.22")
+    assert not historical_release("refs/heads/v0.20.21", "0.20.21", _COMMIT, _COMMIT, "0.20.22")
+
+
+@pytest.mark.parametrize(
+    "version,head,tag",
+    [
+        ("0.20.20", _COMMIT, _COMMIT),
+        ("0.20.21", "a" * 40, _COMMIT),
+        ("0.20.21", _COMMIT, ""),
+        ("0.20.21", "", ""),
+    ],
+)
+def test_historical_ref_version_or_identity_mismatch_is_rejected(version: str, head: str, tag: str) -> None:
+    with pytest.raises(ValueError, match="historical"):
+        historical_release("v0.20.21", version, head, tag, "0.20.22")
+
+
+@pytest.mark.parametrize("profile", ["lite_py37", "native_py37"])
+@pytest.mark.parametrize("historical", [False, True])
+@pytest.mark.parametrize("has_contract", [False, True])
+def test_install_and_smoke_commands_enforce_the_same_profile_boundary(
+    tmp_path, monkeypatch, profile: str, historical: bool, has_contract: bool
+) -> None:
+    commands = []
+    monkeypatch.setattr(
+        "scripts.ci.python37_wheel_smoke.subprocess.run", lambda command, **kwargs: commands.append(command)
+    )
+    wheel = tmp_path / "dcc_mcp_core-0.20.21-py3-none-any.whl"
+    smoke_wheel(wheel, profile, historical, has_contract)
+    install = next(command for command in commands if "pip" in command)
+    assert ("--no-deps" in install) is not historical
+    assert install[-1] == str(wheel)
+    isolated = [command for command in commands if any("smoke_zero_typing_extensions.py" in part for part in command)]
+    assert bool(isolated) is not historical
+    if not historical:
+        assert commands.index(isolated[0]) < commands.index(install)
+    if historical and not has_contract:
+        assert commands[-1][-2:] == ["-c", "import dcc_mcp_core"]
+    else:
+        assert commands[-1][-2:] == ["--profile", profile]

--- a/tests/test_python_wheel_contract.py
+++ b/tests/test_python_wheel_contract.py
@@ -11,6 +11,7 @@ from scripts.ci.check_python_wheel import _expanded_filename_tags
 from scripts.ci.check_python_wheel import main
 from scripts.ci.check_python_wheel import validate_wheel
 from scripts.ci.python_support_contract import load_contract
+from scripts.ci.smoke_zero_typing_extensions import _is_default_requirement as smoke_is_default_requirement
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _INSTALL_SOP_SCHEMA_SOURCE = "python/dcc_mcp_core/schemas/adapter-install-sop-v1.schema.json"
@@ -35,6 +36,7 @@ def _write_wheel(
     extension_module: str = "dcc_mcp_core/_core",
     ui_control_contract: str = "canonical",
     install_sop_schema_bytes: bytes = _INSTALL_SOP_SCHEMA_GIT_BYTES,
+    requires_dist: list[str] | None = None,
 ) -> None:
     root_is_pure = "true" if pure else "false"
     wheel_tags = tags or sorted(_expanded_filename_tags(path))
@@ -42,7 +44,9 @@ def _write_wheel(
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr(
             f"{dist_info}-{version}.dist-info/METADATA",
-            f"Metadata-Version: 2.1\nName: {distribution}\nVersion: {version}\nRequires-Python: {requires_python}\n",
+            f"Metadata-Version: 2.1\nName: {distribution}\nVersion: {version}\n"
+            f"Requires-Python: {requires_python}\n"
+            + "".join(f"Requires-Dist: {requirement}\n" for requirement in requires_dist or []),
         )
         archive.writestr(
             f"{dist_info}-{version}.dist-info/WHEEL",
@@ -128,6 +132,55 @@ def test_wheel_rejects_requires_python_drift(tmp_path: Path) -> None:
     _write_wheel(wheel, pure=False, with_core=True, requires_python=">=3.8")
     errors = validate_wheel(wheel, "abi3", "windows-x86_64", load_contract(_REPO_ROOT))
     assert any("Requires-Python" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "profile,filename,platform,pure,with_core",
+    [
+        ("native_py37", "dcc_mcp_core-1.0.0-cp37-cp37m-win_amd64.whl", "windows-x86_64", False, True),
+        ("lite_py37", "dcc_mcp_core-1.0.0-py3-none-any.whl", "any", True, False),
+        ("abi3", "dcc_mcp_core-1.0.0-cp38-abi3-win_amd64.whl", "windows-x86_64", False, True),
+    ],
+)
+def test_core_wheels_reject_typing_extensions_runtime_dependency(
+    tmp_path: Path,
+    profile: str,
+    filename: str,
+    platform: str,
+    pure: bool,
+    with_core: bool,
+) -> None:
+    wheel = tmp_path / filename
+    _write_wheel(
+        wheel,
+        pure=pure,
+        with_core=with_core,
+        requires_dist=["typing_extensions==4.7.1; python_version < '3.8'"],
+    )
+
+    errors = validate_wheel(wheel, profile, platform, load_contract(_REPO_ROOT))
+
+    assert any("forbidden runtime dependency 'typing-extensions'" in error for error in errors)
+
+
+def test_core_wheel_allows_explicit_test_only_typing_extensions(tmp_path: Path) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-cp38-abi3-win_amd64.whl"
+    _write_wheel(
+        wheel,
+        pure=False,
+        with_core=True,
+        requires_dist=["typing-extensions==4.7.1; python_version < '3.8' and extra == 'test'"],
+    )
+
+    errors = validate_wheel(wheel, "abi3", "windows-x86_64", load_contract(_REPO_ROOT))
+
+    assert not any("forbidden runtime dependency 'typing-extensions'" in error for error in errors)
+
+
+def test_zero_backport_smoke_fails_closed_for_ambiguous_extra_marker() -> None:
+    assert not smoke_is_default_requirement("typing-extensions; python_version < '3.8' and extra == 'test'")
+    assert smoke_is_default_requirement("typing-extensions; python_version < '3.8'")
+    assert smoke_is_default_requirement("typing-extensions; extra == 'test' or python_version < '3.8'")
 
 
 def test_wheel_rejects_internal_tag_drift(tmp_path: Path) -> None:

--- a/tests/test_python_wheel_contract.py
+++ b/tests/test_python_wheel_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import stat
 import subprocess
 import zipfile
 
@@ -38,7 +39,7 @@ def _write_wheel(
     ui_control_contract: str = "canonical",
     install_sop_schema_bytes: bytes = _INSTALL_SOP_SCHEMA_GIT_BYTES,
     requires_dist: list[str] | None = None,
-    extra_members: list[str] | None = None,
+    extra_members: list[str | zipfile.ZipInfo] | None = None,
 ) -> None:
     root_is_pure = "true" if pure else "false"
     wheel_tags = tags or sorted(_expanded_filename_tags(path))
@@ -146,6 +147,13 @@ def test_wheel_rejects_requires_python_drift(tmp_path: Path) -> None:
         ("abi3", "dcc_mcp_core-1.0.0-cp38-abi3-win_amd64.whl", "windows-x86_64", False, True),
     ],
 )
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "typing_extensions==4.7.1; python_version < '3.8'",
+        "typing.extensions==4.7.1; python_version < '3.8'",
+    ],
+)
 def test_core_wheels_reject_typing_extensions_runtime_dependency(
     tmp_path: Path,
     profile: str,
@@ -153,13 +161,14 @@ def test_core_wheels_reject_typing_extensions_runtime_dependency(
     platform: str,
     pure: bool,
     with_core: bool,
+    requirement: str,
 ) -> None:
     wheel = tmp_path / filename
     _write_wheel(
         wheel,
         pure=pure,
         with_core=with_core,
-        requires_dist=["typing_extensions==4.7.1; python_version < '3.8'"],
+        requires_dist=[requirement],
     )
 
     errors = validate_wheel(wheel, profile, platform, load_contract(_REPO_ROOT))
@@ -210,6 +219,83 @@ def test_wheel_gates_reject_unsafe_archive_member_paths(tmp_path: Path, member: 
     assert any("unsafe archive member" in error for error in errors)
 
     with pytest.raises(RuntimeError, match="unsafe archive member"):
+        _check_wheel_archive(wheel, tmp_path / "isolated")
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "dcc_mcp_core/typing_extensions.py.",
+        "dcc_mcp_core/typing_extensions.py ",
+        "dcc_mcp_core/typing\uff3fextensions.py",
+        "dcc_mcp_core/TYPING_EXTENSIONS.PY",
+    ],
+)
+def test_wheel_gates_reject_portable_typing_extensions_aliases(tmp_path: Path, member: str) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-py3-none-any.whl"
+    _write_wheel(wheel, pure=True, with_core=False, extra_members=[member])
+
+    errors = validate_wheel(wheel, "lite_py37", "any", load_contract(_REPO_ROOT))
+    assert any("typing_extensions payload" in error for error in errors)
+
+    with pytest.raises(RuntimeError, match="typing_extensions payload"):
+        _check_wheel_archive(wheel, tmp_path / "isolated")
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "dcc_mcp_core/CON.py",
+        "dcc_mcp_core/payload.py:typing_extensions.py",
+        "dcc_mcp_core/trailing. /payload.py",
+        "dcc_mcp_core//payload.py",
+    ],
+)
+def test_wheel_gates_reject_windows_unsafe_aliases(tmp_path: Path, member: str) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-py3-none-any.whl"
+    _write_wheel(wheel, pure=True, with_core=False, extra_members=[member])
+
+    errors = validate_wheel(wheel, "lite_py37", "any", load_contract(_REPO_ROOT))
+    assert any("unsafe archive member" in error for error in errors)
+
+    with pytest.raises(RuntimeError, match="unsafe archive member"):
+        _check_wheel_archive(wheel, tmp_path / "isolated")
+
+
+@pytest.mark.parametrize(
+    "members",
+    [
+        ["dcc_mcp_core/duplicate.py", "dcc_mcp_core/./duplicate.py"],
+        ["dcc_mcp_core/Readme.py", "dcc_mcp_core/\uff32\uff25\uff21\uff24\uff2d\uff25.py"],
+    ],
+)
+def test_wheel_gates_reject_duplicate_portable_member_paths(tmp_path: Path, members: list[str]) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-py3-none-any.whl"
+    _write_wheel(
+        wheel,
+        pure=True,
+        with_core=False,
+        extra_members=members,
+    )
+
+    errors = validate_wheel(wheel, "lite_py37", "any", load_contract(_REPO_ROOT))
+    assert any("duplicate" in error.lower() for error in errors)
+
+    with pytest.raises(RuntimeError, match="duplicate"):
+        _check_wheel_archive(wheel, tmp_path / "isolated")
+
+
+def test_wheel_gates_reject_symlink_members(tmp_path: Path) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-py3-none-any.whl"
+    link = zipfile.ZipInfo("dcc_mcp_core/link.py")
+    link.create_system = 3
+    link.external_attr = (stat.S_IFLNK | 0o777) << 16
+    _write_wheel(wheel, pure=True, with_core=False, extra_members=[link])
+
+    errors = validate_wheel(wheel, "lite_py37", "any", load_contract(_REPO_ROOT))
+    assert any("symlink" in error.lower() for error in errors)
+
+    with pytest.raises(RuntimeError, match="symlink"):
         _check_wheel_archive(wheel, tmp_path / "isolated")
 
 

--- a/tests/test_python_wheel_contract.py
+++ b/tests/test_python_wheel_contract.py
@@ -11,6 +11,7 @@ from scripts.ci.check_python_wheel import _expanded_filename_tags
 from scripts.ci.check_python_wheel import main
 from scripts.ci.check_python_wheel import validate_wheel
 from scripts.ci.python_support_contract import load_contract
+from scripts.ci.smoke_zero_typing_extensions import _check_wheel_archive
 from scripts.ci.smoke_zero_typing_extensions import _is_default_requirement as smoke_is_default_requirement
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -37,6 +38,7 @@ def _write_wheel(
     ui_control_contract: str = "canonical",
     install_sop_schema_bytes: bytes = _INSTALL_SOP_SCHEMA_GIT_BYTES,
     requires_dist: list[str] | None = None,
+    extra_members: list[str] | None = None,
 ) -> None:
     root_is_pure = "true" if pure else "false"
     wheel_tags = tags or sorted(_expanded_filename_tags(path))
@@ -81,6 +83,8 @@ def _write_wheel(
             archive.writestr("dcc_mcp_core/skills/app-ui/tools.yaml", "tools: []\n")
         if with_core:
             archive.writestr(f"{extension_module}.pyd", b"native")
+        for member in extra_members or []:
+            archive.writestr(member, b"injected")
 
 
 def test_native_py37_wheel_requires_cp37_tag_and_core(tmp_path: Path) -> None:
@@ -175,6 +179,38 @@ def test_core_wheel_allows_explicit_test_only_typing_extensions(tmp_path: Path) 
     errors = validate_wheel(wheel, "abi3", "windows-x86_64", load_contract(_REPO_ROOT))
 
     assert not any("forbidden runtime dependency 'typing-extensions'" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "typing_extensions.py",
+        "./Typing-Extensions.py",
+        "vendor/typing_extensions/__init__.py",
+        "typing_extensions-4.12.2.dist-info/METADATA",
+    ],
+)
+def test_wheel_gates_reject_normalized_typing_extensions_payloads(tmp_path: Path, member: str) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-py3-none-any.whl"
+    _write_wheel(wheel, pure=True, with_core=False, extra_members=[member])
+
+    errors = validate_wheel(wheel, "lite_py37", "any", load_contract(_REPO_ROOT))
+    assert any("typing_extensions payload" in error for error in errors)
+
+    with pytest.raises(RuntimeError, match="typing_extensions payload"):
+        _check_wheel_archive(wheel, tmp_path / "isolated")
+
+
+@pytest.mark.parametrize("member", ["../typing_extensions.py", "/typing_extensions.py", "C:\\typing_extensions.py"])
+def test_wheel_gates_reject_unsafe_archive_member_paths(tmp_path: Path, member: str) -> None:
+    wheel = tmp_path / "dcc_mcp_core-1.0.0-py3-none-any.whl"
+    _write_wheel(wheel, pure=True, with_core=False, extra_members=[member])
+
+    errors = validate_wheel(wheel, "lite_py37", "any", load_contract(_REPO_ROOT))
+    assert any("unsafe archive member" in error for error in errors)
+
+    with pytest.raises(RuntimeError, match="unsafe archive member"):
+        _check_wheel_archive(wheel, tmp_path / "isolated")
 
 
 def test_zero_backport_smoke_fails_closed_for_ambiguous_extra_marker() -> None:

--- a/tests/test_release_distribution_set.py
+++ b/tests/test_release_distribution_set.py
@@ -71,6 +71,30 @@ def test_sdist_rejects_typing_extensions_runtime_dependency(tmp_path: Path) -> N
         )
 
 
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "dcc_mcp_core-1.0.0/typing_extensions.py",
+        "dcc_mcp_core-1.0.0/./Typing-Extensions.py",
+        "dcc_mcp_core-1.0.0/vendor/typing_extensions/__init__.py",
+        "dcc_mcp_core-1.0.0/typing_extensions-4.12.2.dist-info/METADATA",
+    ],
+)
+def test_sdist_rejects_normalized_typing_extensions_payloads(tmp_path: Path, member_name: str) -> None:
+    sdist = tmp_path / "dcc_mcp_core-1.0.0.tar.gz"
+    pkg_info = b"Metadata-Version: 2.1\nName: dcc-mcp-core\nVersion: 1.0.0\nRequires-Python: >=3.7\n"
+    with tarfile.open(sdist, "w:gz") as archive:
+        metadata = tarfile.TarInfo("dcc_mcp_core-1.0.0/PKG-INFO")
+        metadata.size = len(pkg_info)
+        archive.addfile(metadata, io.BytesIO(pkg_info))
+        injected = tarfile.TarInfo(member_name)
+        injected.size = len(b"injected")
+        archive.addfile(injected, io.BytesIO(b"injected"))
+
+    with pytest.raises(DistributionSetError, match="typing_extensions payload"):
+        _validate_sdist(sdist, "1.0.0", check_release_distribution_set.load_contract())
+
+
 def _metadata_bytes(name: str, version: str, requirements: tuple[str, ...] = ()) -> bytes:
     message = Message()
     message["Metadata-Version"] = "2.1"
@@ -161,6 +185,21 @@ def test_verify_distribution_set_runs_existing_wheel_contract(monkeypatch: pytes
     )
 
     with pytest.raises(DistributionSetError, match="synthetic contract drift"):
+        verify_distribution_set(payload, dist_dir, VERSION)
+
+
+def test_release_distribution_gate_rejects_injected_wheel_payload_before_contract_delegate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    with zipfile.ZipFile(dist_dir / WHEEL_NAMES[-1], "a") as archive:
+        archive.writestr("typing_extensions.py", b"injected")
+    payload = _asset_payload(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    with pytest.raises(DistributionSetError, match="typing_extensions payload"):
         verify_distribution_set(payload, dist_dir, VERSION)
 
 

--- a/tests/test_release_distribution_set.py
+++ b/tests/test_release_distribution_set.py
@@ -14,6 +14,7 @@ import zipfile
 import pytest
 from scripts.ci import check_release_distribution_set
 from scripts.ci.check_release_distribution_set import DistributionSetError
+from scripts.ci.check_release_distribution_set import _validate_sdist
 from scripts.ci.check_release_distribution_set import classify_distribution_assets
 from scripts.ci.check_release_distribution_set import verify_distribution_set
 
@@ -48,11 +49,35 @@ def test_classify_distribution_assets_reuses_complete_core_asset_sets() -> None:
     assert classify_distribution_assets(payload, VERSION) == "reuse"
 
 
-def _metadata_bytes(name: str, version: str) -> bytes:
+def test_sdist_rejects_typing_extensions_runtime_dependency(tmp_path: Path) -> None:
+    sdist = tmp_path / SDIST_NAME
+    pkg_info = _metadata_bytes("dcc-mcp-core", VERSION, ("typing-extensions==4.7.1",))
+    with tarfile.open(sdist, "w:gz") as archive:
+        member = tarfile.TarInfo(f"dcc_mcp_core-{VERSION}/PKG-INFO")
+        member.size = len(pkg_info)
+        archive.addfile(member, io.BytesIO(pkg_info))
+
+    with pytest.raises(DistributionSetError, match="forbidden runtime dependency 'typing-extensions'"):
+        _validate_sdist(
+            sdist,
+            VERSION,
+            {
+                "distributions": {
+                    "dcc-mcp-core": {
+                        "forbidden_runtime_dependencies": [{"name": "typing-extensions", "from_version": "0.20.0"}]
+                    }
+                }
+            },
+        )
+
+
+def _metadata_bytes(name: str, version: str, requirements: tuple[str, ...] = ()) -> bytes:
     message = Message()
     message["Metadata-Version"] = "2.1"
     message["Name"] = name
     message["Version"] = version
+    for requirement in requirements:
+        message["Requires-Dist"] = requirement
     buffer = io.BytesIO()
     BytesGenerator(buffer).flatten(message)
     return buffer.getvalue()

--- a/tests/test_release_distribution_set.py
+++ b/tests/test_release_distribution_set.py
@@ -49,9 +49,10 @@ def test_classify_distribution_assets_reuses_complete_core_asset_sets() -> None:
     assert classify_distribution_assets(payload, VERSION) == "reuse"
 
 
-def test_sdist_rejects_typing_extensions_runtime_dependency(tmp_path: Path) -> None:
+@pytest.mark.parametrize("requirement", ["typing-extensions==4.7.1", "typing.extensions==4.7.1"])
+def test_sdist_rejects_typing_extensions_runtime_dependency(tmp_path: Path, requirement: str) -> None:
     sdist = tmp_path / SDIST_NAME
-    pkg_info = _metadata_bytes("dcc-mcp-core", VERSION, ("typing-extensions==4.7.1",))
+    pkg_info = _metadata_bytes("dcc-mcp-core", VERSION, (requirement,))
     with tarfile.open(sdist, "w:gz") as archive:
         member = tarfile.TarInfo(f"dcc_mcp_core-{VERSION}/PKG-INFO")
         member.size = len(pkg_info)
@@ -78,6 +79,10 @@ def test_sdist_rejects_typing_extensions_runtime_dependency(tmp_path: Path) -> N
         "dcc_mcp_core-1.0.0/./Typing-Extensions.py",
         "dcc_mcp_core-1.0.0/vendor/typing_extensions/__init__.py",
         "dcc_mcp_core-1.0.0/typing_extensions-4.12.2.dist-info/METADATA",
+        "dcc_mcp_core-1.0.0/typing_extensions.py.",
+        "dcc_mcp_core-1.0.0/typing_extensions.py ",
+        "dcc_mcp_core-1.0.0/typing\uff3fextensions.py",
+        "dcc_mcp_core-1.0.0/TYPING_EXTENSIONS.PY",
     ],
 )
 def test_sdist_rejects_normalized_typing_extensions_payloads(tmp_path: Path, member_name: str) -> None:
@@ -92,6 +97,78 @@ def test_sdist_rejects_normalized_typing_extensions_payloads(tmp_path: Path, mem
         archive.addfile(injected, io.BytesIO(b"injected"))
 
     with pytest.raises(DistributionSetError, match="typing_extensions payload"):
+        _validate_sdist(sdist, "1.0.0", check_release_distribution_set.load_contract())
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "dcc_mcp_core-1.0.0/CON.py",
+        "dcc_mcp_core-1.0.0/payload.py:typing_extensions.py",
+        "dcc_mcp_core-1.0.0/trailing. /payload.py",
+        "dcc_mcp_core-1.0.0//payload.py",
+    ],
+)
+def test_sdist_rejects_windows_unsafe_aliases(tmp_path: Path, member_name: str) -> None:
+    sdist = tmp_path / "dcc_mcp_core-1.0.0.tar.gz"
+    pkg_info = _metadata_bytes("dcc-mcp-core", "1.0.0")
+    with tarfile.open(sdist, "w:gz") as archive:
+        metadata = tarfile.TarInfo("dcc_mcp_core-1.0.0/PKG-INFO")
+        metadata.size = len(pkg_info)
+        archive.addfile(metadata, io.BytesIO(pkg_info))
+        injected = tarfile.TarInfo(member_name)
+        injected.size = len(b"injected")
+        archive.addfile(injected, io.BytesIO(b"injected"))
+
+    with pytest.raises(DistributionSetError, match="unsafe archive member"):
+        _validate_sdist(sdist, "1.0.0", check_release_distribution_set.load_contract())
+
+
+def test_sdist_rejects_duplicate_portable_member_paths(tmp_path: Path) -> None:
+    sdist = tmp_path / "dcc_mcp_core-1.0.0.tar.gz"
+    pkg_info = _metadata_bytes("dcc-mcp-core", "1.0.0")
+    with tarfile.open(sdist, "w:gz") as archive:
+        metadata = tarfile.TarInfo("dcc_mcp_core-1.0.0/PKG-INFO")
+        metadata.size = len(pkg_info)
+        archive.addfile(metadata, io.BytesIO(pkg_info))
+        for name in ("dcc_mcp_core-1.0.0/duplicate.py", "dcc_mcp_core-1.0.0/./duplicate.py"):
+            member = tarfile.TarInfo(name)
+            member.size = 1
+            archive.addfile(member, io.BytesIO(b"x"))
+
+    with pytest.raises(DistributionSetError, match="duplicate"):
+        _validate_sdist(sdist, "1.0.0", check_release_distribution_set.load_contract())
+
+
+@pytest.mark.parametrize("link_type", [tarfile.SYMTYPE, tarfile.LNKTYPE])
+def test_sdist_rejects_links_and_traversal_targets(tmp_path: Path, link_type: bytes) -> None:
+    sdist = tmp_path / "dcc_mcp_core-1.0.0.tar.gz"
+    pkg_info = _metadata_bytes("dcc-mcp-core", "1.0.0")
+    with tarfile.open(sdist, "w:gz") as archive:
+        metadata = tarfile.TarInfo("dcc_mcp_core-1.0.0/PKG-INFO")
+        metadata.size = len(pkg_info)
+        archive.addfile(metadata, io.BytesIO(pkg_info))
+        link = tarfile.TarInfo("dcc_mcp_core-1.0.0/pkg/link.py")
+        link.type = link_type
+        link.linkname = "../../typing_extensions.py"
+        archive.addfile(link)
+
+    with pytest.raises(DistributionSetError, match="link"):
+        _validate_sdist(sdist, "1.0.0", check_release_distribution_set.load_contract())
+
+
+def test_sdist_rejects_special_device_members(tmp_path: Path) -> None:
+    sdist = tmp_path / "dcc_mcp_core-1.0.0.tar.gz"
+    pkg_info = _metadata_bytes("dcc-mcp-core", "1.0.0")
+    with tarfile.open(sdist, "w:gz") as archive:
+        metadata = tarfile.TarInfo("dcc_mcp_core-1.0.0/PKG-INFO")
+        metadata.size = len(pkg_info)
+        archive.addfile(metadata, io.BytesIO(pkg_info))
+        fifo = tarfile.TarInfo("dcc_mcp_core-1.0.0/pkg/channel")
+        fifo.type = tarfile.FIFOTYPE
+        archive.addfile(fifo)
+
+    with pytest.raises(DistributionSetError, match="special"):
         _validate_sdist(sdist, "1.0.0", check_release_distribution_set.load_contract())
 
 
@@ -203,6 +280,44 @@ def test_release_distribution_gate_rejects_injected_wheel_payload_before_contrac
         verify_distribution_set(payload, dist_dir, VERSION)
 
 
+def test_release_distribution_gate_rejects_wheel_symlink(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    link = zipfile.ZipInfo("dcc_mcp_core/link.py")
+    link.create_system = 3
+    link.external_attr = 0o120777 << 16
+    with zipfile.ZipFile(dist_dir / WHEEL_NAMES[-1], "a") as archive:
+        archive.writestr(link, b"../../typing_extensions.py")
+    payload = _asset_payload(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    with pytest.raises(DistributionSetError, match="symlink"):
+        verify_distribution_set(payload, dist_dir, VERSION)
+
+
+def test_release_distribution_gate_rejects_sdist_hardlink(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    original = dist_dir / SDIST_NAME
+    replacement = dist_dir / f"{SDIST_NAME}.new"
+    with tarfile.open(original, "r:gz") as source, tarfile.open(replacement, "w:gz") as target:
+        for member in source.getmembers():
+            stream = source.extractfile(member) if member.isfile() else None
+            target.addfile(member, stream)
+        link = tarfile.TarInfo(f"dcc_mcp_core-{VERSION}/pkg/hard.py")
+        link.type = tarfile.LNKTYPE
+        link.linkname = "../../typing_extensions.py"
+        target.addfile(link)
+    replacement.replace(original)
+    payload = _asset_payload(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    with pytest.raises(DistributionSetError, match="link"):
+        verify_distribution_set(payload, dist_dir, VERSION)
+
+
 def test_cli_reads_release_asset_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     dist_dir = tmp_path / "dist"
     _write_fixture_set(dist_dir)
@@ -217,6 +332,17 @@ def test_cli_reads_release_asset_json(monkeypatch: pytest.MonkeyPatch, tmp_path:
         )
         == 0
     )
+
+
+def test_cli_validates_fresh_local_distribution_set_without_release_assets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dist_dir = tmp_path / "dist"
+    _write_fixture_set(dist_dir)
+    monkeypatch.setattr(check_release_distribution_set, "validate_wheel", lambda *_args: [])
+    monkeypatch.setattr(check_release_distribution_set, "load_contract", lambda: {})
+
+    assert check_release_distribution_set.main(["--dist-dir", str(dist_dir), "--version", VERSION]) == 0
 
 
 def test_cli_classifies_missing_assets_for_github_actions(tmp_path: Path) -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -109,6 +109,19 @@ def test_release_workflow_publishes_each_pypi_project_in_its_own_job() -> None:
     assert sum(len(_pypi_steps(job)) for job in jobs.values()) == 3
 
 
+def test_core_pypi_publish_validates_complete_distribution_set_before_upload() -> None:
+    publish = _release_jobs()["publish-core-pypi"]
+    steps = publish["steps"]
+    validate_index = next(
+        index for index, step in enumerate(steps) if "check_release_distribution_set.py" in step.get("run", "")
+    )
+    upload_index = next(index for index, step in enumerate(steps) if step.get("uses") == PYPI_ACTION)
+
+    assert validate_index < upload_index
+    assert "--dist-dir dist" in steps[validate_index]["run"]
+    assert "--version" in steps[validate_index]["run"]
+
+
 def test_release_workflow_keeps_github_release_safety_net_after_pypi_jobs() -> None:
     jobs = _release_jobs()
     safety = jobs["publish-github-release-assets"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,6 @@
 """Tests for dcc_mcp_core.schema — zero-dep type → JSON Schema derivation (#242)."""
 
-# ruff: noqa: UP006, UP045
+# ruff: noqa: UP006, UP037, UP045
 
 from __future__ import annotations
 
@@ -24,12 +24,11 @@ import uuid
 import pytest
 
 try:
-    from typing import Literal
     from typing import TypedDict
 except ImportError:  # pragma: no cover - exercised by the Python 3.7 LTS gate
-    from typing_extensions import Literal
     from typing_extensions import TypedDict
 
+from dcc_mcp_core._typing import Literal
 from dcc_mcp_core.schema import derive_parameters_schema
 from dcc_mcp_core.schema import derive_schema
 from dcc_mcp_core.schema import derive_script_parameters_schema
@@ -211,13 +210,12 @@ class TestUnionAndLiterals:
         with pytest.raises(TypeError, match="Literal values must be JSON scalars"):
             derive_schema(annotation)
 
-    def test_typing_extensions_literal(self) -> None:
+    @pytest.mark.skipif(sys.version_info[:2] != (3, 7), reason="exercises the Python 3.7 boundary")
+    def test_typing_extensions_literal_is_not_an_alternate_runtime_boundary(self) -> None:
         typing_extensions = pytest.importorskip("typing_extensions")
 
-        assert derive_schema(typing_extensions.Literal["fbx", "usd"]) == {
-            "enum": ["fbx", "usd"],
-            "type": "string",
-        }
+        with pytest.raises(TypeError, match="derive_schema: unsupported type"):
+            derive_schema(typing_extensions.Literal["fbx", "usd"])
 
     def test_generic_named_literal_is_not_treated_as_typing_literal(self) -> None:
         item_type = TypeVar("item_type")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -205,8 +205,14 @@ class TestUnionAndLiterals:
         result = derive_schema(Literal["on", 1, True, None])
         assert result["enum"] == ["on", 1, True, None]
 
-    @pytest.mark.parametrize("annotation", [Literal[b"x"], Literal[...]])
-    def test_non_json_literal_values_fail_closed(self, annotation: Any) -> None:
+    @pytest.mark.parametrize("value", [b"x", ...])
+    def test_non_json_literal_values_fail_closed(self, value: Any) -> None:
+        if sys.version_info[:2] == (3, 7):
+            with pytest.raises(TypeError, match="Literal values must be JSON-preserving scalars"):
+                Literal[value]
+            return
+
+        annotation = Literal[value]
         with pytest.raises(TypeError, match="Literal values must be JSON scalars"):
             derive_schema(annotation)
 

--- a/tests/test_script_execution.py
+++ b/tests/test_script_execution.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 import dcc_mcp_core
+from dcc_mcp_core.dcc_api_executor import DccApiExecutor
 from dcc_mcp_core.script_execution import FileBackedScriptExecutionParams
 from dcc_mcp_core.script_execution import ScriptExecutionCapture
 from dcc_mcp_core.script_execution import ScriptExecutionContext
@@ -21,6 +22,75 @@ from dcc_mcp_core.script_execution import normalize_script_execution_params
 from dcc_mcp_core.script_execution import register_dcc_namespace
 from dcc_mcp_core.script_execution import reset_default_script_execution_context_for_tests
 from dcc_mcp_core.script_execution import validate_script_file_path
+
+
+@pytest.mark.parametrize("module", ["typing", "typing_extensions"])
+@pytest.mark.parametrize("dcc_type", ["3dsmax", "maya"])
+@pytest.mark.parametrize("qualified", [False, True])
+@pytest.mark.parametrize(
+    ("annotation", "argument", "schema_type"),
+    [
+        ("Annotated[int, 'units']", 7, "integer"),
+        ("Literal['fbx', 'usd']", "fbx", "string"),
+        ("List[int]", [1, 2], "array"),
+    ],
+)
+def test_materialized_annotations_execute_without_backport(
+    tmp_path: Path, module: str, dcc_type: str, qualified: bool, annotation: str, argument, schema_type: str
+) -> None:
+    symbol = annotation.split("[", 1)[0]
+    imports = f"import {module}" if qualified else f"from {module} import {symbol}"
+    annotation = f"{module}.{annotation}" if qualified else annotation
+    source = f"{imports}\ndef main(value: {annotation}):\n    return value\n"
+    backport_before = sys.modules.get("typing_extensions")
+    prepared = normalize_file_backed_script_execution_params(
+        {"code": source, "params": {"value": argument}},
+        dcc_type=dcc_type,
+        instance_id="annotation-contract",
+        session_id="offline",
+        materialization_root=tmp_path,
+    )
+    assert prepared.parameters_schema["properties"]["value"]["type"] == schema_type
+    assert Path(prepared.file_path).read_text(encoding="utf-8") == source
+    executor = DccApiExecutor(dcc_type, dispatcher=None, script_materialization_root=tmp_path)
+
+    result = executor.execute_params({"file_path": prepared.file_path, "params": {"value": argument}})
+
+    assert result["success"], result
+    assert result["output"] == argument
+    assert result["context"]["materialized_script"]["reused"] is True
+    assert sys.modules.get("typing_extensions") is backport_before
+
+
+@pytest.mark.parametrize("module", ["typing", "typing_extensions"])
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        ("return Annotated(int)", "not callable"),
+        ("return Annotated[int, 'units']", "indices"),
+        ("return Annotated.__class__", "reflective"),
+        ("return getattr(Annotated, '__class__')", "getattr"),
+        ("import os\n    return value", "sandbox import"),
+        ("from typing_extensions import get_type_hints\n    return value", "cannot import name"),
+    ],
+)
+def test_materialized_annotated_script_keeps_sandbox_restrictions(
+    tmp_path: Path, module: str, body: str, error: str
+) -> None:
+    source = f"from {module} import Annotated\ndef main(value: Annotated[int, 'units']):\n    {body}\n"
+    prepared = normalize_file_backed_script_execution_params(
+        {"code": source, "params": {"value": 7}},
+        dcc_type="3dsmax",
+        instance_id="annotation-contract",
+        session_id="offline",
+        materialization_root=tmp_path,
+    )
+    executor = DccApiExecutor("3dsmax", dispatcher=None, script_materialization_root=tmp_path)
+
+    result = executor.execute_params({"file_path": prepared.file_path, "params": {"value": 7}})
+
+    assert result["success"] is False
+    assert error in result["error"]
 
 
 def test_script_execution_helpers_are_exported() -> None:

--- a/tests/test_sdist_consumer_paths.py
+++ b/tests/test_sdist_consumer_paths.py
@@ -1,0 +1,114 @@
+"""Source archive names must match the paths package consumers actually open."""
+
+from __future__ import annotations
+
+import copy
+import inspect
+from pathlib import Path
+import tarfile
+
+import pytest
+
+from test_archive_publication_policy import _SDIST_ROOT
+from test_archive_publication_policy import _publication_cli
+from test_archive_publication_policy import _write_distribution_set
+from test_archive_publication_policy import _zip_entry
+
+
+def _rename_member(source: Path, destination: Path, old: str, new: str) -> None:
+    with tarfile.open(source) as original, tarfile.open(destination, "w:gz") as mutated:
+        for member in original:
+            renamed = copy.copy(member)
+            if member.name == old:
+                renamed.name = new
+            mutated.addfile(renamed, original.extractfile(member) if member.isfile() else None)
+
+
+def test_publication_rejects_nfkc_split_sdist_project_root(tmp_path: Path) -> None:
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(
+        directory,
+        "sdist",
+        [_zip_entry("pyproject.toml", b'[build-system]\nrequires = ["maturin"]\nbuild-backend = "maturin"\n')],
+    )
+    result = _publication_cli(directory)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    original = tmp_path / "original.tar.gz"
+    artifact.rename(original)
+    _rename_member(
+        original,
+        artifact,
+        f"{_SDIST_ROOT}/pyproject.toml",
+        f"{_SDIST_ROOT.replace('_', chr(0xFF3F), 1)}/pyproject.toml",
+    )
+    result = _publication_cli(directory)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "paths outside" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        f"{_SDIST_ROOT.replace('_', chr(0xFF3F), 1)}/PKG-INFO",
+        f"{_SDIST_ROOT}/\uff30KG-INFO",
+        f"{_SDIST_ROOT}/PKG-\uff29NFO",
+        f"{_SDIST_ROOT}/pkg-info",
+    ],
+)
+def test_publication_requires_literal_root_metadata(tmp_path: Path, replacement: str) -> None:
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, "sdist")
+    original = tmp_path / "original.tar.gz"
+    artifact.rename(original)
+    _rename_member(original, artifact, f"{_SDIST_ROOT}/PKG-INFO", replacement)
+    result = _publication_cli(directory)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "exactly one" in result.stderr
+
+
+def test_sdist_portable_alias_checks_still_reject_duplicate_metadata(tmp_path: Path) -> None:
+    directory = tmp_path / "dist"
+    _write_distribution_set(directory, "sdist", [_zip_entry("\uff30KG-INFO")])
+    result = _publication_cli(directory)
+    assert result.returncode == 1, (result.stdout, result.stderr)
+    assert "duplicate portable member paths" in result.stderr
+
+
+def test_sdist_pip_discovery_uses_literal_project_paths(tmp_path: Path) -> None:
+    unpacking = pytest.importorskip("pip._internal.utils.unpacking")
+    pyproject = pytest.importorskip("pip._internal.pyproject")
+    exceptions = pytest.importorskip("pip._internal.exceptions")
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(
+        directory,
+        "sdist",
+        [_zip_entry("pyproject.toml", b'[build-system]\nrequires = ["maturin"]\nbuild-backend = "maturin"\n')],
+    )
+    split = tmp_path / "split.tar.gz"
+    _rename_member(
+        artifact, split, f"{_SDIST_ROOT}/pyproject.toml", f"{_SDIST_ROOT.replace('_', chr(0xFF3F), 1)}/pyproject.toml"
+    )
+    for source, valid in [(artifact, True), (split, False)]:
+        target = tmp_path / ("original-unpack" if valid else "split-unpack")
+        target.mkdir()
+        unpacking.unpack_file(str(source), str(target))
+        arguments = [str(target / "pyproject.toml"), str(target / "setup.py"), "fixture"]
+        # pip 25 and 26 expose different signatures for the same discovery step.
+        if "use_pep517" in inspect.signature(pyproject.load_pyproject_toml).parameters:
+            arguments.insert(0, None)
+        if valid:
+            assert pyproject.load_pyproject_toml(*arguments).backend == "maturin"
+            assert (target / "PKG-INFO").is_file()
+        else:
+            assert not (target / "pyproject.toml").exists()
+            with pytest.raises(exceptions.InstallationError, match=r"neither 'setup\.py' nor 'pyproject\.toml'"):
+                pyproject.load_pyproject_toml(*arguments)
+
+
+def test_sdist_keeps_unicode_content_under_literal_root(tmp_path: Path) -> None:
+    directory = tmp_path / "dist"
+    artifact = _write_distribution_set(directory, "sdist", [_zip_entry("docs/\uff41nnotations.txt", b"content")])
+    result = _publication_cli(directory)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    with tarfile.open(artifact) as archive:
+        assert archive.extractfile(f"{_SDIST_ROOT}/docs/\uff41nnotations.txt").read() == b"content"

--- a/uv.lock
+++ b/uv.lock
@@ -758,7 +758,6 @@ version = "0.20.21"
 source = { editable = "." }
 dependencies = [
     { name = "dcc-mcp-server" },
-    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
 ]
 
 [package.optional-dependencies]
@@ -794,6 +793,7 @@ dev = [
     { name = "rez", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "rez", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8'" },
     { name = "ruff", marker = "python_full_version >= '3.8'" },
+    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "zipp", version = "3.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "zipp", version = "3.23.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "zipp", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -824,6 +824,7 @@ test = [
     { name = "pytest-xdist", version = "3.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "rez", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "rez", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8'" },
+    { name = "typing-extensions", version = "4.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8'" },
     { name = "zipp", version = "3.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "zipp", version = "3.23.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "zipp", version = "4.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -849,7 +850,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "python_full_version < '3.8' and extra == 'test'", specifier = "==3.5.0" },
     { name = "rez", marker = "extra == 'test'" },
     { name = "ruff", marker = "python_full_version >= '3.8' and extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "typing-extensions", marker = "python_full_version < '3.8'", specifier = "==4.7.1" },
+    { name = "typing-extensions", marker = "python_full_version < '3.8' and extra == 'test'", specifier = "==4.7.1" },
     { name = "websockets", marker = "extra == 'bridge'", specifier = ">=11,<18" },
     { name = "zipp", marker = "python_full_version >= '3.8' and extra == 'test'", specifier = ">=3.19.1" },
 ]


### PR DESCRIPTION
Closes #2388

## Summary
- remove `typing-extensions` from Core's default dependency and lock metadata
- keep `_typing` as the sole compatibility boundary, preserving stdlib identity on Python 3.8-3.14 and providing a bounded fail-closed Python 3.7 subset
- enforce zero-backport native/lite wheel and sdist contracts, including isolated Python 3.7 runtime smoke coverage

## Validation
- Python 3.7 isolated compatibility and lite-wheel smoke with `-I -S`
- Python 3.8-3.14 stdlib identity matrix
- targeted packaging, schema, batch, caller, hostile descriptor, and archive regressions
- Rust workspace preflight: 3,763 tests plus doctests
- VitePress build and bundled skill lint

## Boundary
No adapter, MZP, publication, or release changes are included. Real Windows MZP/Python 3.7 payload validation remains downstream in dcc-mcp-3dsmax#171 after Core merge and release.