### PR TITLE
feat(execution): add split-phase in-process continuations

### DIFF
--- a/crates/dcc-mcp-http-py/src/bridge.rs
+++ b/crates/dcc-mcp-http-py/src/bridge.rs
@@ -403,5 +403,6 @@ pub fn py_create_skill_server(
         prompts,
         attached_dispatcher: parking_lot::Mutex::new(None),
         readiness_probe: parking_lot::Mutex::new(None),
+        split_phase_store: parking_lot::Mutex::new(None),
     })
 }

--- a/crates/dcc-mcp-http-py/src/server.rs
+++ b/crates/dcc-mcp-http-py/src/server.rs
@@ -123,6 +123,9 @@ impl PyServerHandle {
 
     /// Signal shutdown without blocking.
     fn signal_shutdown(&self) {
+        if let Some(store) = self.split_phase_store.as_ref() {
+            store.drain();
+        }
         if let Some(handle) = &self.inner {
             handle.signal_shutdown();
         }

--- a/crates/dcc-mcp-http-py/src/server.rs
+++ b/crates/dcc-mcp-http-py/src/server.rs
@@ -31,16 +31,23 @@ pub struct PyServerHandle {
     pub(crate) live_meta: Arc<RwLock<LiveMetaInner>>,
     /// Opt-in safety net for forgotten explicit shutdown calls.
     pub(crate) shutdown_on_drop: bool,
+    pub(crate) split_phase_store: Option<Arc<dcc_mcp_skills::catalog::execute::SplitPhaseStore>>,
 }
 
 impl PyServerHandle {
     fn shutdown_inner(&mut self) {
+        if let Some(store) = self.split_phase_store.take() {
+            store.drain();
+        }
         if let Some(handle) = self.inner.take() {
             self.runtime.block_on(handle.shutdown());
         }
     }
 
     fn shutdown_on_drop_inner(&mut self) {
+        if let Some(store) = self.split_phase_store.take() {
+            store.drain();
+        }
         let Some(handle) = self.inner.take() else {
             return;
         };

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -397,6 +397,7 @@ impl PyMcpHttpServer {
             ));
         }
         let executor_ref = executor.clone_ref(py);
+        let split_phase_store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         self.catalog
             .set_in_process_executor(move |script_path, params, context| {
                 Python::attach(|gil| {
@@ -459,28 +460,30 @@ impl PyMcpHttpServer {
                             return Err("split-phase continuation must be callable".to_string());
                         }
                         let continuation = continuation.unbind();
-                        let callback: std::sync::Arc<dcc_mcp_skills::catalog::execute::SplitPhaseContinuation> =
-                            std::sync::Arc::new(move || {
-                                Python::attach(|py| {
-                                    let value = continuation
-                                        .call0(py)
-                                        .map_err(|e| format!("continuation error: {e}"))?;
-                                    py_any_to_json_value(value.bind(py)).map_err(|e| e.to_string())
-                                })
-                            });
+                        let callback: std::sync::Arc<
+                            dcc_mcp_skills::catalog::execute::SplitPhaseContinuation,
+                        > = std::sync::Arc::new(move || {
+                            Python::attach(|py| {
+                                let value = continuation
+                                    .call0(py)
+                                    .map_err(|e| format!("continuation error: {e}"))?;
+                                py_any_to_json_value(value.bind(py)).map_err(|e| e.to_string())
+                            })
+                        });
                         let timeout_secs = raw_bound
                             .getattr("timeout_secs")
                             .ok()
                             .and_then(|v| v.extract::<f64>().ok())
                             .filter(|value| value.is_finite() && *value > 0.0)
+                            .map(|value| value.min(3_600_000.0))
                             .unwrap_or(3600.0);
-                        let id = dcc_mcp_skills::catalog::execute::register_split_phase_continuation_with_timeout(
-                            callback,
-                            std::time::Duration::from_secs_f64(timeout_secs),
-                        );
+                        let id = split_phase_store
+                            .register(callback, std::time::Duration::from_secs_f64(timeout_secs));
                         return Ok(serde_json::json!({
                             "_dcc_mcp_split_phase": {
                                 "kind": "continuation.v1",
+                                "owner": split_phase_store.owner(),
+                                "generation": split_phase_store.generation(),
                                 "continuation_id": id
                             }
                         }));

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -441,7 +441,51 @@ impl PyMcpHttpServer {
                         &kwargs,
                     )
                     .map_err(|e| format!("executor error: {e}"))?;
-                    py_any_to_json_value(raw.bind(gil)).map_err(|e| e.to_string())
+                    let raw_bound = raw.bind(gil);
+                    // A ``ContinuationOutcome`` is transport-internal: retain
+                    // its callable in Core and return only an opaque marker.
+                    // The marker is consumed by MCP/REST routing after the
+                    // bounded host-thread phase, never serialized to clients.
+                    if raw_bound
+                        .getattr("_dcc_mcp_split_phase")
+                        .ok()
+                        .and_then(|v| v.extract::<bool>().ok())
+                        .unwrap_or(false)
+                    {
+                        let continuation = raw_bound
+                            .getattr("continuation")
+                            .map_err(|e| format!("continuation attribute: {e}"))?;
+                        if !continuation.is_callable() {
+                            return Err("split-phase continuation must be callable".to_string());
+                        }
+                        let continuation = continuation.unbind();
+                        let callback: std::sync::Arc<dcc_mcp_skills::catalog::execute::SplitPhaseContinuation> =
+                            std::sync::Arc::new(move || {
+                                Python::attach(|py| {
+                                    let value = continuation
+                                        .call0(py)
+                                        .map_err(|e| format!("continuation error: {e}"))?;
+                                    py_any_to_json_value(value.bind(py)).map_err(|e| e.to_string())
+                                })
+                            });
+                        let timeout_secs = raw_bound
+                            .getattr("timeout_secs")
+                            .ok()
+                            .and_then(|v| v.extract::<f64>().ok())
+                            .filter(|value| value.is_finite() && *value > 0.0)
+                            .unwrap_or(3600.0);
+                        let id = dcc_mcp_skills::catalog::execute::register_split_phase_continuation_with_timeout(
+                            callback,
+                            std::time::Duration::from_secs_f64(timeout_secs),
+                        );
+                        return Ok(serde_json::json!({
+                            "_dcc_mcp_split_phase": {
+                                "kind": "continuation.v1",
+                                "continuation_id": id
+                            }
+                        }));
+                    }
+                    py_any_to_json_value(raw_bound).map_err(|e| e.to_string())
                 })
             });
         tracing::info!(

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -474,20 +474,21 @@ impl PyMcpHttpServer {
                             dcc_mcp_skills::catalog::execute::SplitPhaseContinuation,
                         > = std::sync::Arc::new(move |control| {
                             Python::attach(|py| {
-                                let value = if let Some(job_context) = callback_context.as_ref() {
+                                let job_context = callback_context.clone().unwrap_or_else(|| {
+                                    dcc_mcp_actions::DispatchJobContext::new("split-phase", || {
+                                        false
+                                    })
+                                });
+                                let value = {
                                     let probe =
                                         dcc_mcp_skills::catalog::execute::cancellation_probe(
                                             py,
-                                            job_context.clone(),
+                                            job_context,
                                             control,
                                         )
                                         .map_err(|e| format!("cancellation probe: {e}"))?;
                                     continuation
                                         .call1(py, (probe,))
-                                        .map_err(|e| format!("continuation error: {e}"))?
-                                } else {
-                                    continuation
-                                        .call0(py)
                                         .map_err(|e| format!("continuation error: {e}"))?
                                 };
                                 py_any_to_json_value(value.bind(py)).map_err(|e| e.to_string())

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -53,6 +53,8 @@ pub struct PyMcpHttpServer {
     /// flip the bits on this one instance.
     pub(crate) readiness_probe:
         parking_lot::Mutex<Option<Arc<dyn dcc_mcp_skill_rest::ReadinessProbe>>>,
+    pub(crate) split_phase_store:
+        parking_lot::Mutex<Option<Arc<dcc_mcp_skills::catalog::execute::SplitPhaseStore>>>,
     /// Shared [`dcc_mcp_http::prompts::PromptRegistry`] (issue #792).
     ///
     /// Built at construction time using the same `PromptRegistry::new`
@@ -109,6 +111,7 @@ impl PyMcpHttpServer {
             prompts,
             attached_dispatcher: parking_lot::Mutex::new(None),
             readiness_probe: parking_lot::Mutex::new(None),
+            split_phase_store: parking_lot::Mutex::new(None),
         })
     }
 
@@ -208,6 +211,7 @@ impl PyMcpHttpServer {
         let bind_addr = handle.bind_addr.clone();
         let is_gateway = handle.is_gateway;
         let instance_id = handle.instance_id.map(|id| id.to_string());
+        let split_phase_store = self.split_phase_store.lock().as_ref().cloned();
 
         Ok(PyServerHandle {
             inner: Some(handle),
@@ -218,6 +222,7 @@ impl PyMcpHttpServer {
             instance_id,
             live_meta: self.live_meta.clone(),
             shutdown_on_drop: self.config.shutdown_on_drop(),
+            split_phase_store,
         })
     }
 
@@ -398,12 +403,14 @@ impl PyMcpHttpServer {
         }
         let executor_ref = executor.clone_ref(py);
         let split_phase_store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        *self.split_phase_store.lock() = Some(split_phase_store.clone());
         self.catalog
             .set_in_process_executor(move |script_path, params, context| {
                 Python::attach(|gil| {
                     use dcc_mcp_models::ExecutionMode;
                     use dcc_mcp_pybridge::py_json::{json_value_to_bound_py, py_any_to_json_value};
                     use pyo3::types::PyDict;
+                    let continuation_context = dcc_mcp_actions::current_dispatch_job_context();
 
                     let py_params = json_value_to_bound_py(gil, &params)
                         .map_err(|e| format!("failed to convert params: {e}"))?;
@@ -460,13 +467,26 @@ impl PyMcpHttpServer {
                             return Err("split-phase continuation must be callable".to_string());
                         }
                         let continuation = continuation.unbind();
+                        let callback_context = continuation_context.clone();
                         let callback: std::sync::Arc<
                             dcc_mcp_skills::catalog::execute::SplitPhaseContinuation,
                         > = std::sync::Arc::new(move || {
                             Python::attach(|py| {
-                                let value = continuation
-                                    .call0(py)
-                                    .map_err(|e| format!("continuation error: {e}"))?;
+                                let value = if let Some(job_context) = callback_context.as_ref() {
+                                    let probe =
+                                        dcc_mcp_skills::catalog::execute::cancellation_probe(
+                                            py,
+                                            job_context.clone(),
+                                        )
+                                        .map_err(|e| format!("cancellation probe: {e}"))?;
+                                    continuation
+                                        .call1(py, (probe,))
+                                        .map_err(|e| format!("continuation error: {e}"))?
+                                } else {
+                                    continuation
+                                        .call0(py)
+                                        .map_err(|e| format!("continuation error: {e}"))?
+                                };
                                 py_any_to_json_value(value.bind(py)).map_err(|e| e.to_string())
                             })
                         });
@@ -475,8 +495,8 @@ impl PyMcpHttpServer {
                             .ok()
                             .and_then(|v| v.extract::<f64>().ok())
                             .filter(|value| value.is_finite() && *value > 0.0)
-                            .map(|value| value.min(3_600_000.0))
-                            .unwrap_or(3600.0);
+                            .map(|value| value.min(300.0))
+                            .unwrap_or(300.0);
                         let id = split_phase_store
                             .register(callback, std::time::Duration::from_secs_f64(timeout_secs));
                         return Ok(serde_json::json!({

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -472,13 +472,14 @@ impl PyMcpHttpServer {
                         let callback_context = continuation_context.clone();
                         let callback: std::sync::Arc<
                             dcc_mcp_skills::catalog::execute::SplitPhaseContinuation,
-                        > = std::sync::Arc::new(move || {
+                        > = std::sync::Arc::new(move |control| {
                             Python::attach(|py| {
                                 let value = if let Some(job_context) = callback_context.as_ref() {
                                     let probe =
                                         dcc_mcp_skills::catalog::execute::cancellation_probe(
                                             py,
                                             job_context.clone(),
+                                            control,
                                         )
                                         .map_err(|e| format!("cancellation probe: {e}"))?;
                                     continuation

--- a/crates/dcc-mcp-http-py/src/skill_server.rs
+++ b/crates/dcc-mcp-http-py/src/skill_server.rs
@@ -202,6 +202,10 @@ impl PyMcpHttpServer {
         if let Some(probe) = self.readiness_probe.lock().as_ref().cloned() {
             server = server.with_readiness(probe);
         }
+        let split_phase_store = self.split_phase_store.lock().as_ref().cloned();
+        if let Some(store) = split_phase_store.as_ref() {
+            store.resume();
+        }
         let handle = self
             .runtime
             .block_on(server.start())
@@ -211,8 +215,6 @@ impl PyMcpHttpServer {
         let bind_addr = handle.bind_addr.clone();
         let is_gateway = handle.is_gateway;
         let instance_id = handle.instance_id.map(|id| id.to_string());
-        let split_phase_store = self.split_phase_store.lock().as_ref().cloned();
-
         Ok(PyServerHandle {
             inner: Some(handle),
             runtime: self.runtime.clone(),

--- a/crates/dcc-mcp-http-server/src/job_aware_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/job_aware_invoker.rs
@@ -112,7 +112,22 @@ impl ToolInvoker for JobAwareInvoker {
                         let _ = jobs.complete(&spawned_job_id, outcome.output);
                     }
                     Err(error) => {
-                        let _ = jobs.fail(&spawned_job_id, error.message);
+                        // Preserve the shared structured envelope for
+                        // split-phase failures so async readback matches MCP
+                        // and synchronous REST. Legacy errors remain plain
+                        // strings for wire compatibility.
+                        let persisted = if error
+                            .context
+                            .as_deref()
+                            .and_then(|ctx| ctx.get("code"))
+                            .and_then(Value::as_str)
+                            .is_some_and(|code| code.starts_with("SPLIT_PHASE_"))
+                        {
+                            serde_json::to_string(&error).unwrap_or(error.message.clone())
+                        } else {
+                            error.message
+                        };
+                        let _ = jobs.fail(&spawned_job_id, persisted);
                     }
                 }
             });

--- a/crates/dcc-mcp-http-server/src/job_aware_invoker.rs
+++ b/crates/dcc-mcp-http-server/src/job_aware_invoker.rs
@@ -116,17 +116,19 @@ impl ToolInvoker for JobAwareInvoker {
                         // split-phase failures so async readback matches MCP
                         // and synchronous REST. Legacy errors remain plain
                         // strings for wire compatibility.
-                        let persisted = if error
+                        let persisted = error
                             .context
                             .as_deref()
                             .and_then(|ctx| ctx.get("code"))
                             .and_then(Value::as_str)
-                            .is_some_and(|code| code.starts_with("SPLIT_PHASE_"))
-                        {
-                            serde_json::to_string(&error).unwrap_or(error.message.clone())
-                        } else {
-                            error.message
-                        };
+                            .filter(|code| code.starts_with("SPLIT_PHASE_"))
+                            .map(|code| {
+                                crate::split_phase::project_error_for_job(&format!(
+                                    "{code}: {}",
+                                    error.message
+                                ))
+                            })
+                            .unwrap_or(error.message);
                         let _ = jobs.fail(&spawned_job_id, persisted);
                     }
                 }

--- a/crates/dcc-mcp-http-server/src/lib.rs
+++ b/crates/dcc-mcp-http-server/src/lib.rs
@@ -27,6 +27,7 @@ pub mod job_aware_invoker;
 pub mod notifications;
 pub mod server_state;
 pub mod session;
+pub mod split_phase;
 pub mod workspace;
 
 pub mod mcp_tool_catalog;

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -160,7 +160,9 @@ async fn run_async_execution_lane(
         );
 
         let outcome = match response.await {
-            Ok(Ok(result)) => Ok(result.output),
+            Ok(Ok(result)) => {
+                crate::split_phase::resolve_output(result.output, Some(cancel_token.clone())).await
+            }
             Ok(Err(error)) => Err(error.to_string()),
             Err(_) => Err("CANCELLED".to_string()),
         };
@@ -197,6 +199,12 @@ async fn run_async_execution_lane(
             .await
             .map_err(|err| err.to_string())
             .and_then(|inner| inner);
+        let outcome = match outcome {
+            Ok(output) => {
+                crate::split_phase::resolve_output(output, Some(cancel_token.clone())).await
+            }
+            Err(err) => Err(err),
+        };
         if cancel_token.is_cancelled() {
             Err("CANCELLED".to_string())
         } else {

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_async.rs
@@ -250,7 +250,10 @@ fn spawn_async_registry_dispatch(state: &ServerState, request: AsyncExecutionReq
                 }
             }
             Err(msg) => {
-                jobs.fail(&spawn_job_id, msg);
+                jobs.fail(
+                    &spawn_job_id,
+                    crate::split_phase::project_error_for_job(&msg),
+                );
             }
         }
     });

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
@@ -19,6 +19,26 @@ pub(in crate::rmcp_tool_call_dispatch) fn compute_job_timestamps(
     (job.started_at, job.completed_at)
 }
 
+fn project_job_error(error: &str) -> Value {
+    let Ok(value) = serde_json::from_str::<Value>(error) else {
+        return Value::String(error.to_owned());
+    };
+    let recognized = value
+        .as_object()
+        .and_then(|object| {
+            object
+                .get("layer")
+                .and_then(Value::as_str)
+                .zip(object.get("code").and_then(Value::as_str))
+        })
+        .is_some_and(|(layer, code)| layer == "instance" && code.starts_with("SPLIT_PHASE_"));
+    if recognized {
+        value
+    } else {
+        Value::String(error.to_owned())
+    }
+}
+
 pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
     state: &ServerState,
     arguments: &Value,
@@ -104,7 +124,7 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
     envelope.insert(
         "error".into(),
         match &job.error {
-            Some(e) => serde_json::from_str(e).unwrap_or_else(|_| Value::String(e.clone())),
+            Some(e) => project_job_error(e),
             None => Value::Null,
         },
     );
@@ -255,6 +275,33 @@ mod tests {
         let error = payload.structured_content.unwrap()["error"].clone();
         assert_eq!(error["layer"], "instance");
         assert_eq!(error["code"], "SPLIT_PHASE_TIMEOUT");
+    }
+
+    #[test]
+    fn jobs_get_status_preserves_json_looking_legacy_error_strings() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register_action(ToolMeta {
+            name: "legacy_tool".into(),
+            ..Default::default()
+        });
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let jobs = Arc::new(JobManager::new());
+        let handle = jobs.create("legacy_tool");
+        let id = handle.read().id.clone();
+        jobs.start(&id).unwrap();
+        jobs.fail(&id, r#"{"reason":"bad"}"#).unwrap();
+        let state = ServerState::builder(registry, dispatcher, catalog)
+            .with_jobs(jobs)
+            .build();
+        let payload = handle_jobs_get_status(&state, &json!({"job_id": id}));
+        assert_eq!(
+            payload.structured_content.unwrap()["error"],
+            r#"{"reason":"bad"}"#
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
@@ -104,7 +104,7 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_jobs_get_status(
     envelope.insert(
         "error".into(),
         match &job.error {
-            Some(e) => Value::String(e.clone()),
+            Some(e) => serde_json::from_str(e).unwrap_or_else(|_| Value::String(e.clone())),
             None => Value::Null,
         },
     );

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/jobs.rs
@@ -226,6 +226,38 @@ mod tests {
     }
 
     #[test]
+    fn jobs_get_status_projects_split_phase_error_as_structured_envelope() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register_action(ToolMeta {
+            name: "split_tool".into(),
+            ..Default::default()
+        });
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let jobs = Arc::new(JobManager::new());
+        let handle = jobs.create("split_tool");
+        let id = handle.read().id.clone();
+        jobs.start(&id).unwrap();
+        jobs.fail(
+            &id,
+            crate::split_phase::project_error_for_job(
+                "SPLIT_PHASE_TIMEOUT: continuation timed out",
+            ),
+        )
+        .unwrap();
+        let state = ServerState::builder(registry, dispatcher, catalog)
+            .with_jobs(jobs)
+            .build();
+        let payload = handle_jobs_get_status(&state, &json!({"job_id": id}));
+        let error = payload.structured_content.unwrap()["error"].clone();
+        assert_eq!(error["layer"], "instance");
+        assert_eq!(error["code"], "SPLIT_PHASE_TIMEOUT");
+    }
+
+    #[test]
     fn terminal_core_job_exposes_declared_adapter_poll_contract() {
         let registry = Arc::new(ToolRegistry::new());
         registry.register_action(ToolMeta {

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/helpers.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/helpers.rs
@@ -272,6 +272,21 @@ fn record_native_image_error(rich: &mut serde_json::Map<String, Value>, message:
 
 pub(crate) fn dispatch_err_result(tool_name: &str, msg: impl Into<String>) -> CallToolResult {
     let err_msg = msg.into();
+    if let Some((code, detail)) = err_msg
+        .split_once(": ")
+        .filter(|(prefix, _)| prefix.starts_with(crate::split_phase::SPLIT_PHASE_ERROR_PREFIX))
+    {
+        let envelope = ToolCallErrorEnvelope::new("instance", code, detail);
+        let structured = serde_json::from_str::<Value>(&envelope.to_json()).ok();
+        return CallToolResult {
+            content: vec![ToolContent::Text {
+                text: envelope.to_json(),
+            }],
+            structured_content: structured,
+            is_error: true,
+            meta: None,
+        };
+    }
     if err_msg.contains("no handler registered") {
         let envelope = ToolCallErrorEnvelope::new(
             "instance",

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/mod.rs
@@ -1319,6 +1319,17 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn split_phase_errors_use_structured_instance_envelope() {
+        let result =
+            dispatch_err_result("split_tool", "SPLIT_PHASE_TIMEOUT: continuation timed out");
+        assert!(result.is_error);
+        let structured = result.structured_content.expect("structured error");
+        assert_eq!(structured["layer"], "instance");
+        assert_eq!(structured["code"], "SPLIT_PHASE_TIMEOUT");
+        assert_eq!(structured["message"], "continuation timed out");
+    }
+
     #[tokio::test]
     async fn sync_tool_with_timeout_hint_returns_result_payload() {
         let registry = ToolRegistry::new();

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
@@ -154,16 +154,16 @@ async fn run_on_worker(request: WorkerDispatch) -> Result<DispatchResult, Dispat
     let outcome = dispatch_fut
         .await
         .map_err(|err| DispatchError::HandlerError(err.to_string()))??;
+    let result = outcome;
+    let output = crate::split_phase::resolve_output(result.output, cancel_token.clone())
+        .await
+        .map_err(DispatchError::HandlerError)?;
     if cancel_token
         .as_ref()
         .is_some_and(|token| token.is_cancelled())
     {
         Err(DispatchError::HandlerError("CANCELLED".to_string()))
     } else {
-        let result = outcome;
-        let output = crate::split_phase::resolve_output(result.output, cancel_token)
-            .await
-            .map_err(DispatchError::HandlerError)?;
         Ok(DispatchResult { output, ..result })
     }
 }

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/thread_route.rs
@@ -67,16 +67,38 @@ async fn run_on_main_thread(
         let response = executor.submit_deferred_typed(&tool_name, cancel_token.clone(), task);
         let outcome = response
             .await
-            .map_err(|_| DispatchError::HandlerError("CANCELLED".to_string()))?;
-        if cancel_token.is_cancelled() {
-            return Err(DispatchError::HandlerError("CANCELLED".to_string()));
-        }
-        outcome
+            .map_err(|_| DispatchError::HandlerError("CANCELLED".to_string()))??;
+        let dcc_mcp_actions::DispatchResult {
+            action,
+            output: raw_output,
+            validation_skipped,
+        } = outcome;
+        let output = crate::split_phase::resolve_output(raw_output, Some(cancel_token.clone()))
+            .await
+            .map_err(DispatchError::HandlerError)?;
+        Ok(DispatchResult {
+            action,
+            output,
+            validation_skipped,
+        })
     } else {
-        executor
+        let outcome = executor
             .execute_typed(task)
             .await
-            .map_err(|e| DispatchError::HandlerError(e.to_string()))?
+            .map_err(|e| DispatchError::HandlerError(e.to_string()))??;
+        let dcc_mcp_actions::DispatchResult {
+            action,
+            output: raw_output,
+            validation_skipped,
+        } = outcome;
+        let output = crate::split_phase::resolve_output(raw_output, None)
+            .await
+            .map_err(DispatchError::HandlerError)?;
+        Ok(DispatchResult {
+            action,
+            output,
+            validation_skipped,
+        })
     }
 }
 
@@ -131,11 +153,18 @@ async fn run_on_worker(request: WorkerDispatch) -> Result<DispatchResult, Dispat
     });
     let outcome = dispatch_fut
         .await
-        .map_err(|err| DispatchError::HandlerError(err.to_string()))?;
-    if cancel_token.is_some_and(|token| token.is_cancelled()) {
+        .map_err(|err| DispatchError::HandlerError(err.to_string()))??;
+    if cancel_token
+        .as_ref()
+        .is_some_and(|token| token.is_cancelled())
+    {
         Err(DispatchError::HandlerError("CANCELLED".to_string()))
     } else {
-        outcome
+        let result = outcome;
+        let output = crate::split_phase::resolve_output(result.output, cancel_token)
+            .await
+            .map_err(DispatchError::HandlerError)?;
+        Ok(DispatchResult { output, ..result })
     }
 }
 

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -5,6 +5,12 @@ use serde_json::Value;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
+pub const SPLIT_PHASE_ERROR_PREFIX: &str = "SPLIT_PHASE_";
+
+fn split_phase_error(code: &str, message: &str) -> String {
+    format!("{SPLIT_PHASE_ERROR_PREFIX}{code}: {message}")
+}
+
 /// Resolve a continuation marker after the main-affinity dispatch closure has
 /// returned. The callback is consumed before execution, enforcing ownership
 /// and one-shot replay protection.
@@ -31,10 +37,23 @@ pub async fn resolve_output(
             &owner, &id, generation,
         )
     else {
-        return Err("split-phase continuation is missing or already consumed".to_string());
+        return Err(split_phase_error(
+            "MISSING",
+            "continuation is missing or already consumed",
+        ));
     };
     let timeout = registration.timeout;
     let control = registration.control();
+    // Re-check the lifecycle after ownership transfer and immediately before
+    // submitting the blocking callback. Shutdown may race with marker take;
+    // never start a callback that cannot commit durably.
+    if !registration.commit_allowed() {
+        registration.cancel();
+        return Err(split_phase_error(
+            "INVALIDATED",
+            "continuation invalidated before execution",
+        ));
+    }
     let worker = tokio::time::timeout(
         timeout,
         tokio::task::spawn_blocking({
@@ -49,7 +68,7 @@ pub async fn resolve_output(
             result = &mut worker => result,
             _ = token.cancelled() => {
                 registration.cancel();
-                return Err("CANCELLED".to_string());
+                return Err(split_phase_error("CANCELLED", "continuation cancelled"));
             }
         }
     } else {
@@ -58,7 +77,7 @@ pub async fn resolve_output(
     let result = match result {
         Err(_) => {
             registration.cancel();
-            return Err("split-phase continuation timed out".to_string());
+            return Err(split_phase_error("TIMEOUT", "continuation timed out"));
         }
         Ok(result) => {
             result.map_err(|err| format!("split-phase continuation worker failed: {err}"))??
@@ -66,16 +85,22 @@ pub async fn resolve_output(
     };
 
     if dcc_mcp_skills::catalog::execute::split_phase_marker(&result).is_some() {
-        return Err("nested split-phase continuation rejected".to_string());
+        return Err(split_phase_error(
+            "NESTED",
+            "nested split-phase continuation rejected",
+        ));
     }
     if cancellation
         .as_ref()
         .is_some_and(CancellationToken::is_cancelled)
     {
-        return Err("CANCELLED".to_string());
+        return Err(split_phase_error("CANCELLED", "continuation cancelled"));
     }
     if !registration.commit_allowed() {
-        return Err("split-phase continuation invalidated by shutdown".to_string());
+        return Err(split_phase_error(
+            "SHUTDOWN",
+            "continuation invalidated by shutdown",
+        ));
     }
     Ok(result)
 }
@@ -180,6 +205,38 @@ mod tests {
         let err = task.await.unwrap().unwrap_err();
         assert!(err.contains("invalidated"));
         assert!(!published.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_new_registration_and_resume_recovers() {
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        store.drain();
+        let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let called_in_callback = called.clone();
+        let id = store.register(
+            Arc::new(move |_| {
+                called_in_callback.store(true, std::sync::atomic::Ordering::Release);
+                Ok(json!({"published": true}))
+            }),
+            std::time::Duration::from_secs(1),
+        );
+        let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
+        assert!(resolve_output(marker, None).await.is_err());
+        assert!(!called.load(std::sync::atomic::Ordering::Acquire));
+
+        store.resume();
+        let id = store.register(
+            Arc::new(|control| {
+                control.check()?;
+                Ok(json!({"published": true}))
+            }),
+            std::time::Duration::from_secs(1),
+        );
+        let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
+        assert_eq!(
+            resolve_output(marker, None).await.unwrap(),
+            json!({"published": true})
+        );
     }
 
     #[test]

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -105,4 +105,35 @@ mod tests {
         let err = resolve_output(marker, None).await.unwrap_err();
         assert!(err.contains("timed out"));
     }
+
+    #[test]
+    fn shutdown_generation_drops_old_entries_and_isolates_owners() {
+        let first = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let second = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let first_id = first.register(
+            Arc::new(|| Ok(serde_json::json!({"owner": "first"}))),
+            std::time::Duration::from_secs(1),
+        );
+        let second_id = second.register(
+            Arc::new(|| Ok(serde_json::json!({"owner": "second"}))),
+            std::time::Duration::from_secs(1),
+        );
+        let old_generation = first.generation();
+        first.drain();
+        assert!(
+            dcc_mcp_skills::catalog::execute::take_split_phase_continuation_if_generation(
+                first.owner(),
+                &first_id,
+                old_generation,
+            )
+            .is_none()
+        );
+        assert!(
+            dcc_mcp_skills::catalog::execute::take_split_phase_continuation(
+                second.owner(),
+                &second_id,
+            )
+            .is_some()
+        );
+    }
 }

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -34,16 +34,36 @@ pub async fn resolve_output(
         return Err("split-phase continuation is missing or already consumed".to_string());
     };
     let timeout = registration.timeout;
-    let result = tokio::time::timeout(
+    let control = registration.control();
+    let worker = tokio::time::timeout(
         timeout,
         tokio::task::spawn_blocking({
             let callback = registration.callback.clone();
-            move || (callback)()
+            let control = control.clone();
+            move || (callback)(control)
         }),
-    )
-    .await
-    .map_err(|_| "split-phase continuation timed out".to_string())?
-    .map_err(|err| format!("split-phase continuation worker failed: {err}"))??;
+    );
+    tokio::pin!(worker);
+    let result = if let Some(token) = cancellation.as_ref() {
+        tokio::select! {
+            result = &mut worker => result,
+            _ = token.cancelled() => {
+                registration.cancel();
+                return Err("CANCELLED".to_string());
+            }
+        }
+    } else {
+        worker.await
+    };
+    let result = match result {
+        Err(_) => {
+            registration.cancel();
+            return Err("split-phase continuation timed out".to_string());
+        }
+        Ok(result) => {
+            result.map_err(|err| format!("split-phase continuation worker failed: {err}"))??
+        }
+    };
 
     if dcc_mcp_skills::catalog::execute::split_phase_marker(&result).is_some() {
         return Err("nested split-phase continuation rejected".to_string());
@@ -69,7 +89,7 @@ mod tests {
     async fn resolves_once_and_rejects_replay() {
         let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let id = store.register(
-            Arc::new(|| Ok(serde_json::json!({"ok": true}))),
+            Arc::new(|_| Ok(serde_json::json!({"ok": true}))),
             std::time::Duration::from_secs(1),
         );
         let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
@@ -84,7 +104,7 @@ mod tests {
     async fn cancellation_is_checked_before_continuation_and_consumes_ownership() {
         let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let id = store.register(
-            Arc::new(|| Ok(serde_json::json!({"published": true}))),
+            Arc::new(|_| Ok(serde_json::json!({"published": true}))),
             std::time::Duration::from_secs(1),
         );
         let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
@@ -101,7 +121,7 @@ mod tests {
     async fn timeout_fails_closed() {
         let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let id = store.register(
-            Arc::new(|| {
+            Arc::new(|_| {
                 std::thread::sleep(std::time::Duration::from_millis(30));
                 Ok(serde_json::json!({"ok": true}))
             }),
@@ -113,14 +133,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timeout_control_blocks_late_durable_side_effect() {
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let published = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let published_callback = published.clone();
+        let id = store.register(
+            Arc::new(move |control| {
+                std::thread::sleep(std::time::Duration::from_millis(30));
+                if control.check().is_ok() {
+                    published_callback.store(true, std::sync::atomic::Ordering::Release);
+                }
+                Ok(serde_json::json!({"published": true}))
+            }),
+            std::time::Duration::from_millis(1),
+        );
+        let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
+        assert!(resolve_output(marker, None).await.is_err());
+        std::thread::sleep(std::time::Duration::from_millis(40));
+        assert!(!published.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[tokio::test]
     async fn shutdown_invalidates_running_continuation_before_commit() {
         let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let started = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let started_callback = started.clone();
+        let published = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let published_callback = published.clone();
         let id = store.register(
-            Arc::new(move || {
+            Arc::new(move |control| {
                 started_callback.store(true, std::sync::atomic::Ordering::Release);
                 std::thread::sleep(std::time::Duration::from_millis(30));
+                if control.check().is_ok() {
+                    published_callback.store(true, std::sync::atomic::Ordering::Release);
+                }
                 Ok(serde_json::json!({"published": true}))
             }),
             std::time::Duration::from_secs(1),
@@ -133,6 +179,7 @@ mod tests {
         store.drain();
         let err = task.await.unwrap().unwrap_err();
         assert!(err.contains("invalidated"));
+        assert!(!published.load(std::sync::atomic::Ordering::Acquire));
     }
 
     #[test]
@@ -140,11 +187,11 @@ mod tests {
         let first = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let second = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let first_id = first.register(
-            Arc::new(|| Ok(serde_json::json!({"owner": "first"}))),
+            Arc::new(|_| Ok(serde_json::json!({"owner": "first"}))),
             std::time::Duration::from_secs(1),
         );
         let second_id = second.register(
-            Arc::new(|| Ok(serde_json::json!({"owner": "second"}))),
+            Arc::new(|_| Ok(serde_json::json!({"owner": "second"}))),
             std::time::Duration::from_secs(1),
         );
         let old_generation = first.generation();
@@ -170,7 +217,7 @@ mod tests {
     fn orphaned_marker_is_reaped_after_ttl_without_take() {
         let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
         let id = store.register(
-            Arc::new(|| Ok(serde_json::json!({"orphan": true}))),
+            Arc::new(|_| Ok(serde_json::json!({"orphan": true}))),
             std::time::Duration::from_millis(10),
         );
         std::thread::sleep(std::time::Duration::from_millis(1_100));

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -11,6 +11,29 @@ fn split_phase_error(code: &str, message: &str) -> String {
     format!("{SPLIT_PHASE_ERROR_PREFIX}{code}: {message}")
 }
 
+/// Project a split-phase failure into the transport-neutral job envelope.
+/// Legacy non-split errors remain plain strings for wire compatibility.
+#[must_use]
+pub fn project_error_for_job(message: &str) -> String {
+    let message = if message == "CANCELLED" {
+        split_phase_error("CANCELLED", "continuation cancelled")
+    } else {
+        message.to_owned()
+    };
+    let Some((code, detail)) = message.split_once(": ") else {
+        return message;
+    };
+    if !code.starts_with(SPLIT_PHASE_ERROR_PREFIX) {
+        return message;
+    }
+    serde_json::json!({
+        "layer": "instance",
+        "code": code,
+        "message": detail,
+    })
+    .to_string()
+}
+
 /// Resolve a continuation marker after the main-affinity dispatch closure has
 /// returned. The callback is consumed before execution, enforcing ownership
 /// and one-shot replay protection.
@@ -36,7 +59,7 @@ pub async fn resolve_output(
         .is_some_and(CancellationToken::is_cancelled)
     {
         let _ = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&owner, &id);
-        return Err("CANCELLED".to_string());
+        return Err(split_phase_error("CANCELLED", "continuation cancelled"));
     }
     let Some(registration) =
         dcc_mcp_skills::catalog::execute::take_split_phase_continuation_if_generation(
@@ -154,9 +177,18 @@ mod tests {
         token.cancel();
         assert_eq!(
             resolve_output(marker.clone(), Some(token)).await,
-            Err("CANCELLED".into())
+            Err("SPLIT_PHASE_CANCELLED: continuation cancelled".into())
         );
         assert!(resolve_output(marker, None).await.is_err());
+    }
+
+    #[test]
+    fn project_error_for_job_preserves_machine_readable_fields() {
+        let projected = project_error_for_job("SPLIT_PHASE_TIMEOUT: continuation timed out");
+        let value: serde_json::Value = serde_json::from_str(&projected).expect("JSON envelope");
+        assert_eq!(value["layer"], "instance");
+        assert_eq!(value["code"], "SPLIT_PHASE_TIMEOUT");
+        assert_eq!(value["message"], "continuation timed out");
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -83,14 +83,12 @@ pub async fn resolve_output(
             "continuation invalidated before execution",
         ));
     }
-    let worker = tokio::time::timeout(
-        timeout,
-        tokio::task::spawn_blocking({
-            let callback = registration.callback.clone();
-            let control = control.clone();
-            move || (callback)(control)
-        }),
-    );
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let callback = registration.callback.clone();
+    std::thread::spawn(move || {
+        let _ = sender.send((callback)(control));
+    });
+    let worker = tokio::time::timeout(timeout, receiver);
     tokio::pin!(worker);
     let result = if let Some(token) = cancellation.as_ref() {
         tokio::select! {
@@ -108,14 +106,14 @@ pub async fn resolve_output(
             registration.cancel();
             return Err(split_phase_error("TIMEOUT", "continuation timed out"));
         }
-        Ok(result) => result
-            .map_err(|err| {
-                split_phase_error(
-                    "WORKER_FAILED",
-                    &format!("continuation worker failed: {err}"),
-                )
-            })?
-            .map_err(|err| split_phase_error("CALLBACK_FAILED", &err))?,
+        Ok(Ok(result)) => result.map_err(|err| split_phase_error("CALLBACK_FAILED", &err))?,
+        Ok(Err(err)) => {
+            registration.cancel();
+            return Err(split_phase_error(
+                "WORKER_FAILED",
+                &format!("continuation worker failed: {err}"),
+            ));
+        }
     };
 
     if dcc_mcp_skills::catalog::execute::has_split_phase_marker(&result) {
@@ -224,6 +222,46 @@ mod tests {
         let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
         assert!(resolve_output(marker, None).await.is_err());
         std::thread::sleep(std::time::Duration::from_millis(40));
+        assert!(!published.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn aborting_sync_resolver_cancels_detached_callback() {
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let released = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let published = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let id = store.register(
+            {
+                let started = Arc::clone(&started);
+                let released = Arc::clone(&released);
+                let published = Arc::clone(&published);
+                Arc::new(move |control| {
+                    started.store(true, std::sync::atomic::Ordering::Release);
+                    while !released.load(std::sync::atomic::Ordering::Acquire) {
+                        std::thread::yield_now();
+                    }
+                    if control.check().is_ok() {
+                        published.store(true, std::sync::atomic::Ordering::Release);
+                    }
+                    Ok(json!({"published": true}))
+                })
+            },
+            std::time::Duration::from_secs(5),
+        );
+        let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
+        let task = tokio::spawn(resolve_output(marker, None));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !started.load(std::sync::atomic::Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("callback started");
+        task.abort();
+        let _ = task.await;
+        released.store(true, std::sync::atomic::Ordering::Release);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         assert!(!published.load(std::sync::atomic::Ordering::Acquire));
     }
 

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -18,10 +18,16 @@ pub async fn resolve_output(
     output: Value,
     cancellation: Option<CancellationToken>,
 ) -> Result<Value, String> {
+    let marker = dcc_mcp_skills::catalog::execute::split_phase_marker(&output);
     let Some((owner, id, generation)) =
-        dcc_mcp_skills::catalog::execute::split_phase_marker(&output)
-            .map(|(owner, id, generation)| (owner.to_owned(), id.to_owned(), generation))
+        marker.map(|(owner, id, generation)| (owner.to_owned(), id.to_owned(), generation))
     else {
+        if dcc_mcp_skills::catalog::execute::has_split_phase_marker(&output) {
+            return Err(split_phase_error(
+                "MALFORMED_MARKER",
+                "reserved split-phase marker is malformed",
+            ));
+        }
         return Ok(output);
     };
 
@@ -79,12 +85,17 @@ pub async fn resolve_output(
             registration.cancel();
             return Err(split_phase_error("TIMEOUT", "continuation timed out"));
         }
-        Ok(result) => {
-            result.map_err(|err| format!("split-phase continuation worker failed: {err}"))??
-        }
+        Ok(result) => result
+            .map_err(|err| {
+                split_phase_error(
+                    "WORKER_FAILED",
+                    &format!("continuation worker failed: {err}"),
+                )
+            })?
+            .map_err(|err| split_phase_error("CALLBACK_FAILED", &err))?,
     };
 
-    if dcc_mcp_skills::catalog::execute::split_phase_marker(&result).is_some() {
+    if dcc_mcp_skills::catalog::execute::has_split_phase_marker(&result) {
         return Err(split_phase_error(
             "NESTED",
             "nested split-phase continuation rejected",
@@ -123,6 +134,12 @@ mod tests {
             json!({"ok": true})
         );
         assert!(resolve_output(marker, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn malformed_reserved_marker_fails_closed() {
+        let malformed = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1"}});
+        assert!(resolve_output(malformed, None).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -36,7 +36,10 @@ pub async fn resolve_output(
     let timeout = registration.timeout;
     let result = tokio::time::timeout(
         timeout,
-        tokio::task::spawn_blocking(move || (registration.callback)()),
+        tokio::task::spawn_blocking({
+            let callback = registration.callback.clone();
+            move || (callback)()
+        }),
     )
     .await
     .map_err(|_| "split-phase continuation timed out".to_string())?
@@ -50,6 +53,9 @@ pub async fn resolve_output(
         .is_some_and(CancellationToken::is_cancelled)
     {
         return Err("CANCELLED".to_string());
+    }
+    if !registration.commit_allowed() {
+        return Err("split-phase continuation invalidated by shutdown".to_string());
     }
     Ok(result)
 }
@@ -106,6 +112,29 @@ mod tests {
         assert!(err.contains("timed out"));
     }
 
+    #[tokio::test]
+    async fn shutdown_invalidates_running_continuation_before_commit() {
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let started = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let started_callback = started.clone();
+        let id = store.register(
+            Arc::new(move || {
+                started_callback.store(true, std::sync::atomic::Ordering::Release);
+                std::thread::sleep(std::time::Duration::from_millis(30));
+                Ok(serde_json::json!({"published": true}))
+            }),
+            std::time::Duration::from_secs(1),
+        );
+        let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
+        let task = tokio::spawn(resolve_output(marker, None));
+        while !started.load(std::sync::atomic::Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+        store.drain();
+        let err = task.await.unwrap().unwrap_err();
+        assert!(err.contains("invalidated"));
+    }
+
     #[test]
     fn shutdown_generation_drops_old_entries_and_isolates_owners() {
         let first = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
@@ -134,6 +163,20 @@ mod tests {
                 &second_id,
             )
             .is_some()
+        );
+    }
+
+    #[test]
+    fn orphaned_marker_is_reaped_after_ttl_without_take() {
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let id = store.register(
+            Arc::new(|| Ok(serde_json::json!({"orphan": true}))),
+            std::time::Duration::from_millis(10),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(1_100));
+        assert!(
+            dcc_mcp_skills::catalog::execute::take_split_phase_continuation(store.owner(), &id,)
+                .is_none()
         );
     }
 }

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -1,0 +1,102 @@
+//! Resolution of transport-internal in-process split-phase continuations.
+
+use serde_json::Value;
+#[cfg(test)]
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+/// Resolve a continuation marker after the main-affinity dispatch closure has
+/// returned. The callback is consumed before execution, enforcing ownership
+/// and one-shot replay protection.
+pub async fn resolve_output(
+    output: Value,
+    cancellation: Option<CancellationToken>,
+) -> Result<Value, String> {
+    let Some(id) =
+        dcc_mcp_skills::catalog::execute::split_phase_continuation_id(&output).map(str::to_owned)
+    else {
+        return Ok(output);
+    };
+
+    if cancellation
+        .as_ref()
+        .is_some_and(CancellationToken::is_cancelled)
+    {
+        let _ = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&id);
+        return Err("CANCELLED".to_string());
+    }
+    let Some(registration) = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&id)
+    else {
+        return Err("split-phase continuation is missing or already consumed".to_string());
+    };
+    let timeout = registration.timeout;
+    let result = tokio::time::timeout(
+        timeout,
+        tokio::task::spawn_blocking(move || (registration.callback)()),
+    )
+    .await
+    .map_err(|_| "split-phase continuation timed out".to_string())?
+    .map_err(|err| format!("split-phase continuation worker failed: {err}"))??;
+
+    if dcc_mcp_skills::catalog::execute::split_phase_continuation_id(&result).is_some() {
+        return Err("nested split-phase continuation rejected".to_string());
+    }
+    if cancellation
+        .as_ref()
+        .is_some_and(CancellationToken::is_cancelled)
+    {
+        return Err("CANCELLED".to_string());
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn resolves_once_and_rejects_replay() {
+        let id =
+            dcc_mcp_skills::catalog::execute::register_split_phase_continuation(Arc::new(|| {
+                Ok(serde_json::json!({"ok": true}))
+            }));
+        let marker =
+            json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "continuation_id": id}});
+        assert_eq!(
+            resolve_output(marker.clone(), None).await.unwrap(),
+            json!({"ok": true})
+        );
+        assert!(resolve_output(marker, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancellation_is_checked_before_continuation_and_consumes_ownership() {
+        let id =
+            dcc_mcp_skills::catalog::execute::register_split_phase_continuation(Arc::new(|| {
+                Ok(serde_json::json!({"published": true}))
+            }));
+        let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "continuation_id": id}});
+        let token = CancellationToken::new();
+        token.cancel();
+        assert_eq!(
+            resolve_output(marker.clone(), Some(token)).await,
+            Err("CANCELLED".into())
+        );
+        assert!(resolve_output(marker, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn timeout_fails_closed() {
+        let id = dcc_mcp_skills::catalog::execute::register_split_phase_continuation_with_timeout(
+            Arc::new(|| {
+                std::thread::sleep(std::time::Duration::from_millis(30));
+                Ok(serde_json::json!({"ok": true}))
+            }),
+            std::time::Duration::from_millis(1),
+        );
+        let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "continuation_id": id}});
+        let err = resolve_output(marker, None).await.unwrap_err();
+        assert!(err.contains("timed out"));
+    }
+}

--- a/crates/dcc-mcp-http-server/src/split_phase.rs
+++ b/crates/dcc-mcp-http-server/src/split_phase.rs
@@ -12,8 +12,9 @@ pub async fn resolve_output(
     output: Value,
     cancellation: Option<CancellationToken>,
 ) -> Result<Value, String> {
-    let Some(id) =
-        dcc_mcp_skills::catalog::execute::split_phase_continuation_id(&output).map(str::to_owned)
+    let Some((owner, id, generation)) =
+        dcc_mcp_skills::catalog::execute::split_phase_marker(&output)
+            .map(|(owner, id, generation)| (owner.to_owned(), id.to_owned(), generation))
     else {
         return Ok(output);
     };
@@ -22,10 +23,13 @@ pub async fn resolve_output(
         .as_ref()
         .is_some_and(CancellationToken::is_cancelled)
     {
-        let _ = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&id);
+        let _ = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&owner, &id);
         return Err("CANCELLED".to_string());
     }
-    let Some(registration) = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&id)
+    let Some(registration) =
+        dcc_mcp_skills::catalog::execute::take_split_phase_continuation_if_generation(
+            &owner, &id, generation,
+        )
     else {
         return Err("split-phase continuation is missing or already consumed".to_string());
     };
@@ -38,7 +42,7 @@ pub async fn resolve_output(
     .map_err(|_| "split-phase continuation timed out".to_string())?
     .map_err(|err| format!("split-phase continuation worker failed: {err}"))??;
 
-    if dcc_mcp_skills::catalog::execute::split_phase_continuation_id(&result).is_some() {
+    if dcc_mcp_skills::catalog::execute::split_phase_marker(&result).is_some() {
         return Err("nested split-phase continuation rejected".to_string());
     }
     if cancellation
@@ -57,12 +61,12 @@ mod tests {
 
     #[tokio::test]
     async fn resolves_once_and_rejects_replay() {
-        let id =
-            dcc_mcp_skills::catalog::execute::register_split_phase_continuation(Arc::new(|| {
-                Ok(serde_json::json!({"ok": true}))
-            }));
-        let marker =
-            json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "continuation_id": id}});
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let id = store.register(
+            Arc::new(|| Ok(serde_json::json!({"ok": true}))),
+            std::time::Duration::from_secs(1),
+        );
+        let marker = json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
         assert_eq!(
             resolve_output(marker.clone(), None).await.unwrap(),
             json!({"ok": true})
@@ -72,11 +76,12 @@ mod tests {
 
     #[tokio::test]
     async fn cancellation_is_checked_before_continuation_and_consumes_ownership() {
-        let id =
-            dcc_mcp_skills::catalog::execute::register_split_phase_continuation(Arc::new(|| {
-                Ok(serde_json::json!({"published": true}))
-            }));
-        let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "continuation_id": id}});
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let id = store.register(
+            Arc::new(|| Ok(serde_json::json!({"published": true}))),
+            std::time::Duration::from_secs(1),
+        );
+        let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
         let token = CancellationToken::new();
         token.cancel();
         assert_eq!(
@@ -88,14 +93,15 @@ mod tests {
 
     #[tokio::test]
     async fn timeout_fails_closed() {
-        let id = dcc_mcp_skills::catalog::execute::register_split_phase_continuation_with_timeout(
+        let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+        let id = store.register(
             Arc::new(|| {
                 std::thread::sleep(std::time::Duration::from_millis(30));
                 Ok(serde_json::json!({"ok": true}))
             }),
             std::time::Duration::from_millis(1),
         );
-        let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "continuation_id": id}});
+        let marker = serde_json::json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": store.owner(), "generation": store.generation(), "continuation_id": id}});
         let err = resolve_output(marker, None).await.unwrap_err();
         assert!(err.contains("timed out"));
     }

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -1024,13 +1024,12 @@ async fn resolve_split_phase_output(
     }
     let timeout = registration.timeout;
     let control = registration.control();
-    let worker = tokio::time::timeout(
-        timeout,
-        tokio::task::spawn_blocking({
-            let callback = registration.callback.clone();
-            move || callback(control)
-        }),
-    );
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let callback = registration.callback.clone();
+    std::thread::spawn(move || {
+        let _ = sender.send(callback(control));
+    });
+    let worker = tokio::time::timeout(timeout, receiver);
     tokio::pin!(worker);
     let result = if let Some(cancellation) = cancellation {
         tokio::select! {
@@ -1051,14 +1050,16 @@ async fn resolve_split_phase_output(
                 "continuation timed out",
             ));
         }
-        Ok(joined) => joined
-            .map_err(|err| {
-                split_phase_service_error(
-                    "WORKER_FAILED",
-                    format!("continuation worker failed: {err}"),
-                )
-            })?
-            .map_err(|err| split_phase_service_error("CALLBACK_FAILED", err))?,
+        Ok(Ok(result)) => {
+            result.map_err(|err| split_phase_service_error("CALLBACK_FAILED", err))?
+        }
+        Ok(Err(err)) => {
+            registration.cancel();
+            return Err(split_phase_service_error(
+                "WORKER_FAILED",
+                format!("continuation worker failed: {err}"),
+            ));
+        }
     };
     if dcc_mcp_skills::catalog::execute::has_split_phase_marker(&result) {
         return Err(split_phase_service_error(

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -978,6 +978,109 @@ pub struct DispatcherInvoker {
     standalone_main_thread_execution: bool,
 }
 
+fn split_phase_service_error(code: &str, message: impl Into<String>) -> ServiceError {
+    let message = message.into();
+    ServiceError::new(ServiceErrorKind::BackendError, message.clone()).with_context(
+        serde_json::json!({"layer": "instance", "code": format!("SPLIT_PHASE_{code}"), "message": message}),
+    )
+}
+
+async fn resolve_split_phase_output(
+    output: Value,
+    cancellation: Option<&InvocationCancellation>,
+) -> Result<Value, ServiceError> {
+    let marker = dcc_mcp_skills::catalog::execute::split_phase_marker(&output);
+    let Some((owner, id, generation)) = marker else {
+        if dcc_mcp_skills::catalog::execute::has_split_phase_marker(&output) {
+            return Err(split_phase_service_error(
+                "MALFORMED_MARKER",
+                "reserved split-phase marker is malformed",
+            ));
+        }
+        return Ok(output);
+    };
+    let owner = owner.to_owned();
+    let id = id.to_owned();
+    if cancellation.is_some_and(|c| c.cancel_token().is_cancelled()) {
+        let _ = dcc_mcp_skills::catalog::execute::take_split_phase_continuation(&owner, &id);
+        return Err(split_phase_service_error(
+            "CANCELLED",
+            "continuation cancelled",
+        ));
+    }
+    let registration =
+        dcc_mcp_skills::catalog::execute::take_split_phase_continuation_if_generation(
+            &owner, &id, generation,
+        )
+        .ok_or_else(|| {
+            split_phase_service_error("MISSING", "continuation is missing or already consumed")
+        })?;
+    if !registration.commit_allowed() {
+        registration.cancel();
+        return Err(split_phase_service_error(
+            "INVALIDATED",
+            "continuation invalidated before execution",
+        ));
+    }
+    let timeout = registration.timeout;
+    let control = registration.control();
+    let worker = tokio::time::timeout(
+        timeout,
+        tokio::task::spawn_blocking({
+            let callback = registration.callback.clone();
+            move || callback(control)
+        }),
+    );
+    tokio::pin!(worker);
+    let result = if let Some(cancellation) = cancellation {
+        tokio::select! {
+            result = &mut worker => result,
+            _ = cancellation.cancel_token().cancelled() => {
+                registration.cancel();
+                return Err(split_phase_service_error("CANCELLED", "continuation cancelled"));
+            }
+        }
+    } else {
+        worker.await
+    };
+    let result = match result {
+        Err(_) => {
+            registration.cancel();
+            return Err(split_phase_service_error(
+                "TIMEOUT",
+                "continuation timed out",
+            ));
+        }
+        Ok(joined) => joined
+            .map_err(|err| {
+                split_phase_service_error(
+                    "WORKER_FAILED",
+                    format!("continuation worker failed: {err}"),
+                )
+            })?
+            .map_err(|err| split_phase_service_error("CALLBACK_FAILED", err))?,
+    };
+    if dcc_mcp_skills::catalog::execute::has_split_phase_marker(&result) {
+        return Err(split_phase_service_error(
+            "NESTED",
+            "nested split-phase continuation rejected",
+        ));
+    }
+    if cancellation.is_some_and(|c| c.cancel_token().is_cancelled()) {
+        return Err(split_phase_service_error(
+            "CANCELLED",
+            "continuation cancelled",
+        ));
+    }
+    if !registration.commit_allowed() {
+        return Err(split_phase_service_error(
+            "SHUTDOWN",
+            "continuation invalidated by shutdown",
+        ));
+    }
+    Ok(result)
+}
+
 impl DispatcherInvoker {
     pub fn new(dispatcher: Arc<ToolDispatcher>) -> Self {
         Self {
@@ -993,7 +1096,7 @@ impl DispatcherInvoker {
         }
     }
 
-    fn invoke_inner(
+    async fn invoke_inner(
         &self,
         action_name: &str,
         params: Value,
@@ -1011,7 +1114,7 @@ impl DispatcherInvoker {
                 .registry()
                 .get_action(action_name, None)
                 .is_some_and(|meta| matches!(meta.thread_affinity, ThreadAffinity::Main));
-        with_execution_context(exec_ctx, || {
+        let outcome = with_execution_context(exec_ctx, || {
             let dispatch = || {
                 let dispatched = if standalone_main {
                     with_thread_affinity(ThreadAffinity::Main, || {
@@ -1030,7 +1133,7 @@ impl DispatcherInvoker {
                 }
             };
 
-            match cancellation {
+            match cancellation.as_ref() {
                 Some(cancellation) if cancellation.cancel_token().is_cancelled() => Err(
                     ServiceError::new(ServiceErrorKind::BackendError, "CANCELLED"),
                 ),
@@ -1039,7 +1142,10 @@ impl DispatcherInvoker {
                 }
                 None => dispatch(),
             }
-        })
+        })?;
+        let mut outcome = outcome;
+        outcome.output = resolve_split_phase_output(outcome.output, cancellation.as_ref()).await?;
+        Ok(outcome)
     }
 }
 
@@ -1144,7 +1250,7 @@ impl ToolInvoker for DispatcherInvoker {
         params: Value,
         meta: Option<Value>,
     ) -> Result<CallOutcome, ServiceError> {
-        self.invoke_inner(action_name, params, meta, None)
+        self.invoke_inner(action_name, params, meta, None).await
     }
 
     async fn invoke_with_cancellation(
@@ -1155,6 +1261,7 @@ impl ToolInvoker for DispatcherInvoker {
         cancellation: InvocationCancellation,
     ) -> Result<CallOutcome, ServiceError> {
         self.invoke_inner(action_name, params, meta, Some(cancellation))
+            .await
     }
 }
 

--- a/crates/dcc-mcp-skill-rest/src/service.rs
+++ b/crates/dcc-mcp-skill-rest/src/service.rs
@@ -1114,6 +1114,16 @@ pub fn dispatch_error_to_service_error(err: DispatchError) -> ServiceError {
         DispatchError::HandlerError(m) if m == "CANCELLED" => {
             ServiceError::new(ServiceErrorKind::BackendError, m)
         }
+        DispatchError::HandlerError(m) if m.starts_with("SPLIT_PHASE_") => {
+            let (code, detail) = m.split_once(": ").unwrap_or(("SPLIT_PHASE_ERROR", &m));
+            ServiceError::new(ServiceErrorKind::BackendError, detail.to_string()).with_context(
+                serde_json::json!({
+                    "layer": "instance",
+                    "code": code,
+                    "message": detail,
+                }),
+            )
+        }
         DispatchError::HandlerError(m) => ServiceError::new(ServiceErrorKind::BackendError, m),
         DispatchError::MetadataNotFound(m) => ServiceError::new(ServiceErrorKind::Internal, m),
     }

--- a/crates/dcc-mcp-skill-rest/src/service_tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/service_tests.rs
@@ -681,6 +681,18 @@ fn queue_overload_maps_to_host_busy() {
     }
 }
 
+#[test]
+fn split_phase_errors_preserve_structured_instance_context() {
+    let err = dispatch_error_to_service_error(DispatchError::HandlerError(
+        "SPLIT_PHASE_TIMEOUT: continuation timed out".into(),
+    ));
+    assert_eq!(err.kind, ServiceErrorKind::BackendError);
+    assert_eq!(err.message, "continuation timed out");
+    let context = err.context.expect("structured split-phase context");
+    assert_eq!(context["layer"], "instance");
+    assert_eq!(context["code"], "SPLIT_PHASE_TIMEOUT");
+}
+
 #[tokio::test]
 async fn call_dispatches_and_normalises_slug() {
     let (svc, inv) = build_service(vec![sphere_action(true)]);

--- a/crates/dcc-mcp-skill-rest/src/tests.rs
+++ b/crates/dcc-mcp-skill-rest/src/tests.rs
@@ -142,6 +142,54 @@ async fn search_describe_call_round_trip() {
     assert_eq!(out["output"]["radius"], 2.5);
 }
 
+#[tokio::test]
+async fn rest_default_dispatcher_resolves_split_phase_marker() {
+    let registry = Arc::new(ToolRegistry::new());
+    registry.register_action(ToolMeta {
+        name: "split_phase".into(),
+        dcc: "maya".into(),
+        description: "split phase test".into(),
+        skill_name: Some("split".into()),
+        enabled: true,
+        ..Default::default()
+    });
+    let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+    let store = dcc_mcp_skills::catalog::execute::SplitPhaseStore::new();
+    let callback: Arc<dcc_mcp_skills::catalog::execute::SplitPhaseContinuation> =
+        Arc::new(|control| {
+            control.check()?;
+            Ok(json!({"resolved": true}))
+        });
+    let id = store.register(callback, std::time::Duration::from_secs(1));
+    let owner = store.owner().to_owned();
+    let generation = store.generation();
+    dispatcher.register_handler("split_phase", move |_| {
+        Ok(json!({"_dcc_mcp_split_phase": {"kind": "continuation.v1", "owner": owner, "generation": generation, "continuation_id": id}}))
+    });
+    let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+        registry,
+        dispatcher.clone(),
+    ));
+    catalog.add_skill(SkillMetadata {
+        name: "split".into(),
+        dcc: "maya".into(),
+        ..Default::default()
+    });
+    let _ = catalog.load_skill("split");
+    let server = build_server(SkillRestService::from_catalog_and_dispatcher(
+        catalog, dispatcher,
+    ))
+    .0;
+    let response = server
+        .post("/v1/call")
+        .json(&json!({"tool_slug": "maya.split.split_phase", "params": {}}))
+        .await;
+    response.assert_status_ok();
+    let body: Value = response.json();
+    assert_eq!(body["output"]["resolved"], true);
+    assert!(body.to_string().find("_dcc_mcp_split_phase").is_none());
+}
+
 struct ImmediatePendingInvoker {
     inner: DispatcherInvoker,
 }

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -108,7 +108,7 @@ impl SplitPhaseStore {
     pub fn take(&self, id: &str) -> Option<SplitPhaseRegistration> {
         let mut entries = self.entries.lock();
         entries.retain(|_, value| {
-            value.created_at.elapsed() < value.timeout.max(Duration::from_secs(3600))
+            value.created_at.elapsed() < value.timeout.min(Duration::from_secs(300))
         });
         entries.remove(id)
     }
@@ -169,7 +169,7 @@ pub fn split_phase_marker(value: &serde_json::Value) -> Option<(&str, &str, u64)
 #[cfg(feature = "python-bindings")]
 #[pyclass(frozen)]
 pub struct DispatchCancellationProbe {
-    context: DispatchJobContext,
+    pub context: DispatchJobContext,
 }
 
 #[cfg(feature = "python-bindings")]
@@ -184,6 +184,12 @@ impl DispatchCancellationProbe {
     fn job_id(&self) -> &str {
         self.context.job_id()
     }
+}
+
+/// Construct a Python cancellation probe for a retained continuation.
+#[cfg(feature = "python-bindings")]
+pub fn cancellation_probe(py: Python<'_>, context: DispatchJobContext) -> PyResult<Py<PyAny>> {
+    Ok(Py::new(py, DispatchCancellationProbe { context })?.into_any())
 }
 
 /// Add server-owned job identity and a read-only cancellation probe to Python

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -26,8 +26,8 @@
 use dcc_mcp_models::{ExecutionMode, JobStrategy, ThreadAffinity, ToolDeclaration};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::sync::{Arc, OnceLock, Weak};
+use std::time::{Duration, Instant};
 
 #[cfg(feature = "python-bindings")]
 use dcc_mcp_actions::{DispatchJobContext, current_dispatch_job_context};
@@ -55,48 +55,114 @@ pub type SplitPhaseContinuation = dyn Fn() -> Result<serde_json::Value, String> 
 pub struct SplitPhaseRegistration {
     pub callback: Arc<SplitPhaseContinuation>,
     pub timeout: Duration,
+    pub created_at: Instant,
 }
 
-static SPLIT_PHASE_CONTINUATIONS: OnceLock<Mutex<HashMap<String, SplitPhaseRegistration>>> =
+pub struct SplitPhaseStore {
+    owner: String,
+    generation: std::sync::atomic::AtomicU64,
+    entries: Mutex<HashMap<String, SplitPhaseRegistration>>,
+}
+
+static SPLIT_PHASE_STORES: OnceLock<Mutex<HashMap<String, Weak<SplitPhaseStore>>>> =
     OnceLock::new();
 
-fn continuation_store() -> &'static Mutex<HashMap<String, SplitPhaseRegistration>> {
-    SPLIT_PHASE_CONTINUATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+fn stores() -> &'static Mutex<HashMap<String, Weak<SplitPhaseStore>>> {
+    SPLIT_PHASE_STORES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Register a continuation and return its one-shot opaque id.
-pub fn register_split_phase_continuation(continuation: Arc<SplitPhaseContinuation>) -> String {
-    register_split_phase_continuation_with_timeout(continuation, Duration::from_secs(3600))
+impl SplitPhaseStore {
+    pub fn new() -> Arc<Self> {
+        let store = Arc::new(Self {
+            owner: uuid::Uuid::new_v4().to_string(),
+            generation: std::sync::atomic::AtomicU64::new(0),
+            entries: Mutex::new(HashMap::new()),
+        });
+        stores()
+            .lock()
+            .insert(store.owner.clone(), Arc::downgrade(&store));
+        store
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn register(&self, continuation: Arc<SplitPhaseContinuation>, timeout: Duration) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.entries.lock().insert(
+            id.clone(),
+            SplitPhaseRegistration {
+                callback: continuation,
+                timeout,
+                created_at: Instant::now(),
+            },
+        );
+        id
+    }
+
+    pub fn take(&self, id: &str) -> Option<SplitPhaseRegistration> {
+        let mut entries = self.entries.lock();
+        entries.retain(|_, value| {
+            value.created_at.elapsed() < value.timeout.max(Duration::from_secs(3600))
+        });
+        entries.remove(id)
+    }
+
+    pub fn take_if_generation(&self, id: &str, generation: u64) -> Option<SplitPhaseRegistration> {
+        (self.generation() == generation)
+            .then(|| self.take(id))
+            .flatten()
+    }
+
+    pub fn drain(&self) {
+        self.entries.lock().clear();
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
-pub fn register_split_phase_continuation_with_timeout(
-    continuation: Arc<SplitPhaseContinuation>,
-    timeout: Duration,
-) -> String {
-    let id = uuid::Uuid::new_v4().to_string();
-    continuation_store().lock().insert(
-        id.clone(),
-        SplitPhaseRegistration {
-            callback: continuation,
-            timeout,
-        },
-    );
-    id
+impl Drop for SplitPhaseStore {
+    fn drop(&mut self) {
+        self.entries.lock().clear();
+        stores().lock().remove(&self.owner);
+    }
 }
 
 /// Take (consume) a continuation by id. Consumption enforces one-shot
 /// ownership and prevents replay after a terminal result.
-pub fn take_split_phase_continuation(id: &str) -> Option<SplitPhaseRegistration> {
-    continuation_store().lock().remove(id)
+pub fn take_split_phase_continuation(owner: &str, id: &str) -> Option<SplitPhaseRegistration> {
+    stores().lock().get(owner).and_then(Weak::upgrade)?.take(id)
+}
+
+pub fn take_split_phase_continuation_if_generation(
+    owner: &str,
+    id: &str,
+    generation: u64,
+) -> Option<SplitPhaseRegistration> {
+    stores()
+        .lock()
+        .get(owner)
+        .and_then(Weak::upgrade)?
+        .take_if_generation(id, generation)
 }
 
 /// Extract the reserved transport marker from a handler output.
-pub fn split_phase_continuation_id(value: &serde_json::Value) -> Option<&str> {
-    value
-        .get("_dcc_mcp_split_phase")
-        .filter(|v| v.get("kind").and_then(serde_json::Value::as_str) == Some("continuation.v1"))
-        .and_then(|v| v.get("continuation_id"))
-        .and_then(serde_json::Value::as_str)
+pub fn split_phase_marker(value: &serde_json::Value) -> Option<(&str, &str, u64)> {
+    value.get("_dcc_mcp_split_phase").and_then(|v| {
+        if v.get("kind").and_then(serde_json::Value::as_str) != Some("continuation.v1") {
+            return None;
+        }
+        Some((
+            v.get("owner")?.as_str()?,
+            v.get("continuation_id")?.as_str()?,
+            v.get("generation")?.as_u64()?,
+        ))
+    })
 }
 
 /// Python-facing read-only view of a Rust cancellation probe.

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -24,6 +24,10 @@
 //! subprocess path is taken.
 
 use dcc_mcp_models::{ExecutionMode, JobStrategy, ThreadAffinity, ToolDeclaration};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 #[cfg(feature = "python-bindings")]
 use dcc_mcp_actions::{DispatchJobContext, current_dispatch_job_context};
@@ -42,6 +46,57 @@ pub struct ScriptExecutionContext {
     pub execution: ExecutionMode,
     pub timeout_hint_secs: Option<u32>,
     pub job_strategy: JobStrategy,
+}
+
+/// Opaque continuation callback retained between the bounded host phase and
+/// the request/job worker. The callback never crosses the MCP/REST wire.
+pub type SplitPhaseContinuation = dyn Fn() -> Result<serde_json::Value, String> + Send + Sync;
+
+pub struct SplitPhaseRegistration {
+    pub callback: Arc<SplitPhaseContinuation>,
+    pub timeout: Duration,
+}
+
+static SPLIT_PHASE_CONTINUATIONS: OnceLock<Mutex<HashMap<String, SplitPhaseRegistration>>> =
+    OnceLock::new();
+
+fn continuation_store() -> &'static Mutex<HashMap<String, SplitPhaseRegistration>> {
+    SPLIT_PHASE_CONTINUATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Register a continuation and return its one-shot opaque id.
+pub fn register_split_phase_continuation(continuation: Arc<SplitPhaseContinuation>) -> String {
+    register_split_phase_continuation_with_timeout(continuation, Duration::from_secs(3600))
+}
+
+pub fn register_split_phase_continuation_with_timeout(
+    continuation: Arc<SplitPhaseContinuation>,
+    timeout: Duration,
+) -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    continuation_store().lock().insert(
+        id.clone(),
+        SplitPhaseRegistration {
+            callback: continuation,
+            timeout,
+        },
+    );
+    id
+}
+
+/// Take (consume) a continuation by id. Consumption enforces one-shot
+/// ownership and prevents replay after a terminal result.
+pub fn take_split_phase_continuation(id: &str) -> Option<SplitPhaseRegistration> {
+    continuation_store().lock().remove(id)
+}
+
+/// Extract the reserved transport marker from a handler output.
+pub fn split_phase_continuation_id(value: &serde_json::Value) -> Option<&str> {
+    value
+        .get("_dcc_mcp_split_phase")
+        .filter(|v| v.get("kind").and_then(serde_json::Value::as_str) == Some("continuation.v1"))
+        .and_then(|v| v.get("continuation_id"))
+        .and_then(serde_json::Value::as_str)
 }
 
 /// Python-facing read-only view of a Rust cancellation probe.

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -64,11 +64,13 @@ pub struct SplitPhaseControl {
 
 impl SplitPhaseControl {
     pub fn cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Acquire)
-            || Instant::now() >= self.deadline
-            || self.lifecycle.upgrade().map_or(true, |store| {
-                store.shutdown.load(Ordering::Acquire) || store.generation() != self.generation
-            })
+        if self.cancelled.load(Ordering::Acquire) || Instant::now() >= self.deadline {
+            return true;
+        }
+        let Some(store) = self.lifecycle.upgrade() else {
+            return true;
+        };
+        store.shutdown.load(Ordering::Acquire) || store.generation() != self.generation
     }
 
     pub fn check(&self) -> Result<(), String> {

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -120,6 +120,8 @@ pub struct SplitPhaseStore {
     owner: String,
     generation: std::sync::atomic::AtomicU64,
     shutdown: std::sync::atomic::AtomicBool,
+    /// Serializes admission with shutdown/generation transitions.
+    admission: Mutex<()>,
     entries: Mutex<HashMap<String, SplitPhaseRegistration>>,
     active: Mutex<HashMap<String, SplitPhaseControl>>,
 }
@@ -137,6 +139,7 @@ impl SplitPhaseStore {
             owner: uuid::Uuid::new_v4().to_string(),
             generation: std::sync::atomic::AtomicU64::new(0),
             shutdown: std::sync::atomic::AtomicBool::new(false),
+            admission: Mutex::new(()),
             entries: Mutex::new(HashMap::new()),
             active: Mutex::new(HashMap::new()),
         });
@@ -168,6 +171,12 @@ impl SplitPhaseStore {
         timeout: Duration,
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
+        let _admission = self.admission.lock();
+        if self.shutdown.load(std::sync::atomic::Ordering::Acquire) {
+            // Preserve the marker shape for callers while ensuring the
+            // rejected registration has no retained callback to execute.
+            return id;
+        }
         let generation = self.generation();
         let control = SplitPhaseControl {
             cancelled: Arc::new(AtomicBool::new(false)),
@@ -190,6 +199,11 @@ impl SplitPhaseStore {
     }
 
     pub fn take(&self, id: &str) -> Option<SplitPhaseRegistration> {
+        let _admission = self.admission.lock();
+        self.take_inner(id)
+    }
+
+    fn take_inner(&self, id: &str) -> Option<SplitPhaseRegistration> {
         self.reap_expired();
         let registration = self.entries.lock().remove(id);
         if let Some(registration) = registration.as_ref() {
@@ -208,12 +222,14 @@ impl SplitPhaseStore {
     }
 
     pub fn take_if_generation(&self, id: &str, generation: u64) -> Option<SplitPhaseRegistration> {
+        let _admission = self.admission.lock();
         (self.generation() == generation)
-            .then(|| self.take(id))
+            .then(|| self.take_inner(id))
             .flatten()
     }
 
     pub fn drain(&self) {
+        let _admission = self.admission.lock();
         self.shutdown
             .store(true, std::sync::atomic::Ordering::Release);
         self.entries.lock().clear();
@@ -226,6 +242,7 @@ impl SplitPhaseStore {
     }
 
     pub fn resume(&self) {
+        let _admission = self.admission.lock();
         self.shutdown
             .store(false, std::sync::atomic::Ordering::Release);
         self.generation

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -290,6 +290,13 @@ pub fn split_phase_marker(value: &serde_json::Value) -> Option<(&str, &str, u64)
     })
 }
 
+/// Return whether a value carries the reserved split-phase field, even when
+/// its payload is malformed. Callers at transport boundaries must fail closed
+/// instead of treating malformed reserved data as ordinary handler output.
+pub fn has_split_phase_marker(value: &serde_json::Value) -> bool {
+    value.get("_dcc_mcp_split_phase").is_some()
+}
+
 /// Python-facing read-only view of a Rust cancellation probe.
 #[cfg(feature = "python-bindings")]
 #[pyclass(frozen)]

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -110,6 +110,7 @@ impl SplitPhaseRegistration {
 
 impl Drop for SplitPhaseRegistration {
     fn drop(&mut self) {
+        self.control.cancel();
         if let Some(store) = self.store.upgrade() {
             store.active.lock().remove(&self.id);
         }

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -276,7 +276,7 @@ pub fn split_phase_marker(value: &serde_json::Value) -> Option<(&str, &str, u64)
 #[pyclass(frozen)]
 pub struct DispatchCancellationProbe {
     pub context: DispatchJobContext,
-    pub control: SplitPhaseControl,
+    pub control: Option<SplitPhaseControl>,
 }
 
 #[cfg(feature = "python-bindings")]
@@ -284,7 +284,11 @@ pub struct DispatchCancellationProbe {
 impl DispatchCancellationProbe {
     #[getter]
     fn cancelled(&self) -> bool {
-        self.context.is_cancelled() || self.control.cancelled()
+        self.context.is_cancelled()
+            || self
+                .control
+                .as_ref()
+                .map_or(false, SplitPhaseControl::cancelled)
     }
 
     fn check(&self) -> PyResult<()> {
@@ -310,7 +314,14 @@ pub fn cancellation_probe(
     context: DispatchJobContext,
     control: SplitPhaseControl,
 ) -> PyResult<Py<PyAny>> {
-    Ok(Py::new(py, DispatchCancellationProbe { context, control })?.into_any())
+    Ok(Py::new(
+        py,
+        DispatchCancellationProbe {
+            context,
+            control: Some(control),
+        },
+    )?
+    .into_any())
 }
 
 /// Add server-owned job identity and a read-only cancellation probe to Python
@@ -326,6 +337,7 @@ pub fn set_job_context_kwargs(py: Python<'_>, kwargs: &Bound<'_, PyDict>) -> PyR
                 py,
                 DispatchCancellationProbe {
                     context: job_context,
+                    control: None,
                 },
             )?,
         )?;

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -26,6 +26,7 @@
 use dcc_mcp_models::{ExecutionMode, JobStrategy, ThreadAffinity, ToolDeclaration};
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -53,15 +54,37 @@ pub struct ScriptExecutionContext {
 pub type SplitPhaseContinuation = dyn Fn() -> Result<serde_json::Value, String> + Send + Sync;
 
 pub struct SplitPhaseRegistration {
+    id: String,
     pub callback: Arc<SplitPhaseContinuation>,
     pub timeout: Duration,
     pub created_at: Instant,
+    store: Weak<SplitPhaseStore>,
+    generation: u64,
+}
+
+impl SplitPhaseRegistration {
+    pub fn commit_allowed(&self) -> bool {
+        self.store.upgrade().is_some_and(|store| {
+            !store.shutdown.load(std::sync::atomic::Ordering::Acquire)
+                && store.generation() == self.generation
+        })
+    }
+}
+
+impl Drop for SplitPhaseRegistration {
+    fn drop(&mut self) {
+        if let Some(store) = self.store.upgrade() {
+            store.active.lock().remove(&self.id);
+        }
+    }
 }
 
 pub struct SplitPhaseStore {
     owner: String,
     generation: std::sync::atomic::AtomicU64,
+    shutdown: std::sync::atomic::AtomicBool,
     entries: Mutex<HashMap<String, SplitPhaseRegistration>>,
+    active: Mutex<HashSet<String>>,
 }
 
 static SPLIT_PHASE_STORES: OnceLock<Mutex<HashMap<String, Weak<SplitPhaseStore>>>> =
@@ -76,11 +99,21 @@ impl SplitPhaseStore {
         let store = Arc::new(Self {
             owner: uuid::Uuid::new_v4().to_string(),
             generation: std::sync::atomic::AtomicU64::new(0),
+            shutdown: std::sync::atomic::AtomicBool::new(false),
             entries: Mutex::new(HashMap::new()),
+            active: Mutex::new(HashSet::new()),
         });
         stores()
             .lock()
             .insert(store.owner.clone(), Arc::downgrade(&store));
+        let weak = Arc::downgrade(&store);
+        std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(Duration::from_secs(1));
+                let Some(store) = weak.upgrade() else { break };
+                store.reap_expired();
+            }
+        });
         store
     }
 
@@ -92,25 +125,41 @@ impl SplitPhaseStore {
         self.generation.load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    pub fn register(&self, continuation: Arc<SplitPhaseContinuation>, timeout: Duration) -> String {
+    pub fn register(
+        self: &Arc<Self>,
+        continuation: Arc<SplitPhaseContinuation>,
+        timeout: Duration,
+    ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
+        let generation = self.generation();
         self.entries.lock().insert(
             id.clone(),
             SplitPhaseRegistration {
+                id: id.clone(),
                 callback: continuation,
                 timeout,
                 created_at: Instant::now(),
+                store: Arc::downgrade(self),
+                generation,
             },
         );
         id
     }
 
     pub fn take(&self, id: &str) -> Option<SplitPhaseRegistration> {
+        self.reap_expired();
+        let registration = self.entries.lock().remove(id);
+        if registration.is_some() {
+            self.active.lock().insert(id.to_owned());
+        }
+        registration
+    }
+
+    pub fn reap_expired(&self) {
         let mut entries = self.entries.lock();
         entries.retain(|_, value| {
             value.created_at.elapsed() < value.timeout.min(Duration::from_secs(300))
         });
-        entries.remove(id)
     }
 
     pub fn take_if_generation(&self, id: &str, generation: u64) -> Option<SplitPhaseRegistration> {
@@ -120,7 +169,17 @@ impl SplitPhaseStore {
     }
 
     pub fn drain(&self) {
+        self.shutdown
+            .store(true, std::sync::atomic::Ordering::Release);
         self.entries.lock().clear();
+        self.active.lock().clear();
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn resume(&self) {
+        self.shutdown
+            .store(false, std::sync::atomic::Ordering::Release);
         self.generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
@@ -129,6 +188,7 @@ impl SplitPhaseStore {
 impl Drop for SplitPhaseStore {
     fn drop(&mut self) {
         self.entries.lock().clear();
+        self.active.lock().clear();
         stores().lock().remove(&self.owner);
     }
 }

--- a/crates/dcc-mcp-skills/src/catalog/execute.rs
+++ b/crates/dcc-mcp-skills/src/catalog/execute.rs
@@ -26,7 +26,7 @@
 use dcc_mcp_models::{ExecutionMode, JobStrategy, ThreadAffinity, ToolDeclaration};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -51,7 +51,38 @@ pub struct ScriptExecutionContext {
 
 /// Opaque continuation callback retained between the bounded host phase and
 /// the request/job worker. The callback never crosses the MCP/REST wire.
-pub type SplitPhaseContinuation = dyn Fn() -> Result<serde_json::Value, String> + Send + Sync;
+pub type SplitPhaseContinuation =
+    dyn Fn(SplitPhaseControl) -> Result<serde_json::Value, String> + Send + Sync;
+
+#[derive(Clone)]
+pub struct SplitPhaseControl {
+    cancelled: Arc<AtomicBool>,
+    deadline: Instant,
+    lifecycle: Weak<SplitPhaseStore>,
+    generation: u64,
+}
+
+impl SplitPhaseControl {
+    pub fn cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+            || Instant::now() >= self.deadline
+            || self.lifecycle.upgrade().map_or(true, |store| {
+                store.shutdown.load(Ordering::Acquire) || store.generation() != self.generation
+            })
+    }
+
+    pub fn check(&self) -> Result<(), String> {
+        if self.cancelled() {
+            Err("split-phase continuation cancelled before durable commit".to_string())
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
 
 pub struct SplitPhaseRegistration {
     id: String,
@@ -59,15 +90,19 @@ pub struct SplitPhaseRegistration {
     pub timeout: Duration,
     pub created_at: Instant,
     store: Weak<SplitPhaseStore>,
-    generation: u64,
+    control: SplitPhaseControl,
 }
 
 impl SplitPhaseRegistration {
     pub fn commit_allowed(&self) -> bool {
-        self.store.upgrade().is_some_and(|store| {
-            !store.shutdown.load(std::sync::atomic::Ordering::Acquire)
-                && store.generation() == self.generation
-        })
+        self.control.check().is_ok()
+    }
+
+    pub fn cancel(&self) {
+        self.control.cancel();
+    }
+    pub fn control(&self) -> SplitPhaseControl {
+        self.control.clone()
     }
 }
 
@@ -84,7 +119,7 @@ pub struct SplitPhaseStore {
     generation: std::sync::atomic::AtomicU64,
     shutdown: std::sync::atomic::AtomicBool,
     entries: Mutex<HashMap<String, SplitPhaseRegistration>>,
-    active: Mutex<HashSet<String>>,
+    active: Mutex<HashMap<String, SplitPhaseControl>>,
 }
 
 static SPLIT_PHASE_STORES: OnceLock<Mutex<HashMap<String, Weak<SplitPhaseStore>>>> =
@@ -101,7 +136,7 @@ impl SplitPhaseStore {
             generation: std::sync::atomic::AtomicU64::new(0),
             shutdown: std::sync::atomic::AtomicBool::new(false),
             entries: Mutex::new(HashMap::new()),
-            active: Mutex::new(HashSet::new()),
+            active: Mutex::new(HashMap::new()),
         });
         stores()
             .lock()
@@ -132,6 +167,12 @@ impl SplitPhaseStore {
     ) -> String {
         let id = uuid::Uuid::new_v4().to_string();
         let generation = self.generation();
+        let control = SplitPhaseControl {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            deadline: Instant::now() + timeout.min(Duration::from_secs(300)),
+            lifecycle: Arc::downgrade(self),
+            generation,
+        };
         self.entries.lock().insert(
             id.clone(),
             SplitPhaseRegistration {
@@ -140,7 +181,7 @@ impl SplitPhaseStore {
                 timeout,
                 created_at: Instant::now(),
                 store: Arc::downgrade(self),
-                generation,
+                control,
             },
         );
         id
@@ -149,8 +190,10 @@ impl SplitPhaseStore {
     pub fn take(&self, id: &str) -> Option<SplitPhaseRegistration> {
         self.reap_expired();
         let registration = self.entries.lock().remove(id);
-        if registration.is_some() {
-            self.active.lock().insert(id.to_owned());
+        if let Some(registration) = registration.as_ref() {
+            self.active
+                .lock()
+                .insert(id.to_owned(), registration.control());
         }
         registration
     }
@@ -172,6 +215,9 @@ impl SplitPhaseStore {
         self.shutdown
             .store(true, std::sync::atomic::Ordering::Release);
         self.entries.lock().clear();
+        for control in self.active.lock().values() {
+            control.cancel();
+        }
         self.active.lock().clear();
         self.generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -230,6 +276,7 @@ pub fn split_phase_marker(value: &serde_json::Value) -> Option<(&str, &str, u64)
 #[pyclass(frozen)]
 pub struct DispatchCancellationProbe {
     pub context: DispatchJobContext,
+    pub control: SplitPhaseControl,
 }
 
 #[cfg(feature = "python-bindings")]
@@ -237,7 +284,17 @@ pub struct DispatchCancellationProbe {
 impl DispatchCancellationProbe {
     #[getter]
     fn cancelled(&self) -> bool {
-        self.context.is_cancelled()
+        self.context.is_cancelled() || self.control.cancelled()
+    }
+
+    fn check(&self) -> PyResult<()> {
+        if self.cancelled() {
+            Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "split-phase continuation cancelled before durable commit",
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     #[getter]
@@ -248,8 +305,12 @@ impl DispatchCancellationProbe {
 
 /// Construct a Python cancellation probe for a retained continuation.
 #[cfg(feature = "python-bindings")]
-pub fn cancellation_probe(py: Python<'_>, context: DispatchJobContext) -> PyResult<Py<PyAny>> {
-    Ok(Py::new(py, DispatchCancellationProbe { context })?.into_any())
+pub fn cancellation_probe(
+    py: Python<'_>,
+    context: DispatchJobContext,
+    control: SplitPhaseControl,
+) -> PyResult<Py<PyAny>> {
+    Ok(Py::new(py, DispatchCancellationProbe { context, control })?.into_any())
 }
 
 /// Add server-owned job identity and a read-only cancellation probe to Python

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -471,9 +471,12 @@ def main(params):
 
 Core releases the host lane before invoking the continuation on the request or
 async-job worker. The continuation is transport-internal and never appears in
-MCP/REST JSON. It is one-shot; nested outcomes fail closed. Continuations must
-accept the cancellation probe and gate durable writes on it; callbacks without
-that probe are rejected before they run. Cancellation and shutdown are checked
-before and after the continuation, so a result cannot be committed after a
-request is cancelled. `timeout_secs` is finite and bounded to 300 seconds;
-server shutdown drains all pending continuations and advances their generation.
+MCP/REST JSON. It is one-shot; nested outcomes fail closed. The callback
+receives a `SplitPhaseControl`; it must call `control.check()` immediately
+before every durable write or host mutation. Timeout, cancellation and
+shutdown revoke that control and invalidate the active registration. A callback
+that cannot observe the control is rejected before it runs; Core only promises
+to publish results after the gate, and does not claim to undo side effects from
+callbacks that ignore the protocol. `timeout_secs` is finite and bounded to
+300 seconds; server shutdown drains all pending continuations and advances
+their generation.

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -466,11 +466,14 @@ from dcc_mcp_core import SplitPhaseOutcome
 
 def main(params):
     snapshot = capture_on_main_thread(params)
-    return SplitPhaseOutcome(lambda: encode_and_publish(snapshot))
+    return SplitPhaseOutcome(lambda cancel: encode_and_publish(snapshot, cancel))
 ```
 
 Core releases the host lane before invoking the continuation on the request or
 async-job worker. The continuation is transport-internal and never appears in
-MCP/REST JSON. It is one-shot; nested outcomes fail closed. Cancellation and
-shutdown are checked before and after the continuation, so a result cannot be
-committed after a request is cancelled.
+MCP/REST JSON. It is one-shot; nested outcomes fail closed. Continuations must
+accept the cancellation probe and gate durable writes on it; callbacks without
+that probe are rejected before they run. Cancellation and shutdown are checked
+before and after the continuation, so a result cannot be committed after a
+request is cancelled. `timeout_secs` is finite and bounded to 300 seconds;
+server shutdown drains all pending continuations and advances their generation.

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -466,7 +466,7 @@ from dcc_mcp_core import SplitPhaseOutcome
 
 def main(params):
     snapshot = capture_on_main_thread(params)
-    return SplitPhaseOutcome(lambda cancel: encode_and_publish(snapshot, cancel))
+    return SplitPhaseOutcome(lambda control: encode_and_publish(snapshot, control))
 ```
 
 Core releases the host lane before invoking the continuation on the request or

--- a/docs/api/dispatcher.md
+++ b/docs/api/dispatcher.md
@@ -456,3 +456,21 @@ smokes. The core reference is
 it exercises Maya-like and 3ds Max-like dispatch flows, malformed payloads,
 missing servers, missing source files, executor errors, cancellation, timeout,
 and shutdown cleanup without launching a real DCC.
+## In-process split-phase continuations
+
+Main-affinity in-process tools may return `dcc_mcp_core.SplitPhaseOutcome`
+(alias `ContinuationOutcome`) after completing their bounded host work:
+
+```python
+from dcc_mcp_core import SplitPhaseOutcome
+
+def main(params):
+    snapshot = capture_on_main_thread(params)
+    return SplitPhaseOutcome(lambda: encode_and_publish(snapshot))
+```
+
+Core releases the host lane before invoking the continuation on the request or
+async-job worker. The continuation is transport-internal and never appears in
+MCP/REST JSON. It is one-shot; nested outcomes fail closed. Cancellation and
+shutdown are checked before and after the continuation, so a result cannot be
+committed after a request is cancelled.

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -274,6 +274,8 @@ _ALL_LAZY: dict[str, str] = {
     "BaseDccCallableDispatcherFull": "dcc_mcp_core.server",
     "BaseDccPump": "dcc_mcp_core.server",
     "DeferredToolResult": "dcc_mcp_core.server",
+    "ContinuationOutcome": "dcc_mcp_core.server",
+    "SplitPhaseOutcome": "dcc_mcp_core.server",
     "DebugPathMapping": "dcc_mcp_core.adapter_contracts",
     "DebugSessionDescriptor": "dcc_mcp_core.adapter_contracts",
     "DebugSessionStatus": "dcc_mcp_core.adapter_contracts",

--- a/python/dcc_mcp_core/_server/__init__.py
+++ b/python/dcc_mcp_core/_server/__init__.py
@@ -42,9 +42,11 @@ from dcc_mcp_core._server.host_ui_dispatcher import current_host_ui_job
 from dcc_mcp_core._server.host_ui_dispatcher import host_ui_outcome
 from dcc_mcp_core._server.host_ui_dispatcher import normalize_affinity
 from dcc_mcp_core._server.inprocess_executor import BaseDccCallableDispatcher
+from dcc_mcp_core._server.inprocess_executor import ContinuationOutcome
 from dcc_mcp_core._server.inprocess_executor import DeferredToolResult
 from dcc_mcp_core._server.inprocess_executor import HostExecutionBridge
 from dcc_mcp_core._server.inprocess_executor import InProcessExecutionContext
+from dcc_mcp_core._server.inprocess_executor import SplitPhaseOutcome
 from dcc_mcp_core._server.inprocess_executor import build_inprocess_executor
 from dcc_mcp_core._server.inprocess_executor import clear_script_package
 from dcc_mcp_core._server.inprocess_executor import exception_to_error_envelope
@@ -88,6 +90,7 @@ __all__ = [
     "BaseDccCallableDispatcherFull",
     "BaseDccPump",
     "BridgeExecution",
+    "ContinuationOutcome",
     "DccServerOptions",
     "DeferredToolResult",
     "DiagnosticsOptions",
@@ -126,6 +129,7 @@ __all__ = [
     "ServerRuntimeController",
     "SkillDiscoveryController",
     "SkillQueryClient",
+    "SplitPhaseOutcome",
     "StandaloneMainThreadExecution",
     "TelemetryManager",
     "ThreadedHostTimerAdapter",

--- a/python/dcc_mcp_core/_server/_continuation_lifecycle.py
+++ b/python/dcc_mcp_core/_server/_continuation_lifecycle.py
@@ -24,6 +24,11 @@ def resolve_bridge_result(
     """Resolve a bridge result while enforcing continuation lifecycle gates."""
     if isinstance(result, ContinuationOutcome):
         is_host_thread = getattr(dispatcher, "is_host_thread", None)
+        if dispatcher is not None and not callable(is_host_thread):
+            return exception_to_error_envelope(
+                RuntimeError("dispatcher does not expose host thread identity"),
+                message="Split-phase continuation requires dispatcher thread identity",
+            )
         if callable(is_host_thread) and is_host_thread():
             return exception_to_error_envelope(
                 RuntimeError("split-phase continuation cannot resolve on the host thread"),

--- a/python/dcc_mcp_core/_server/_continuation_lifecycle.py
+++ b/python/dcc_mcp_core/_server/_continuation_lifecycle.py
@@ -1,0 +1,52 @@
+"""Lifecycle and thread-affinity gates for split-phase in-process results."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Callable
+
+from dcc_mcp_core._server._inprocess_contracts import ContinuationOutcome
+from dcc_mcp_core._server._inprocess_contracts import InProcessExecutionContext
+from dcc_mcp_core._server._inprocess_contracts import exception_to_error_envelope
+from dcc_mcp_core._server._inprocess_results import resolve_execution_result
+
+
+def resolve_bridge_result(
+    result: Any,
+    context: InProcessExecutionContext,
+    *,
+    dispatcher: Any,
+    dispatch_raw: Callable[..., Any],
+    cancel_token: Any | None,
+    current_generation: Callable[[], int | None],
+    is_current_generation: Callable[[int], bool],
+) -> Any:
+    """Resolve a bridge result while enforcing continuation lifecycle gates."""
+    if isinstance(result, ContinuationOutcome):
+        is_host_thread = getattr(dispatcher, "is_host_thread", None)
+        if callable(is_host_thread) and is_host_thread():
+            return exception_to_error_envelope(
+                RuntimeError("split-phase continuation cannot resolve on the host thread"),
+                message="Split-phase continuation must resolve off the host thread",
+            )
+
+    generation = current_generation()
+    if generation is None and isinstance(result, ContinuationOutcome):
+        return exception_to_error_envelope(
+            RuntimeError("host execution bridge is shutting down"),
+            message="Host execution bridge is shutting down; call rejected.",
+        )
+
+    lifecycle_check = (
+        (lambda: is_current_generation(generation))
+        if isinstance(result, ContinuationOutcome) and generation is not None
+        else None
+    )
+    return resolve_execution_result(
+        result,
+        context,
+        dispatcher=dispatcher,
+        dispatch_raw=dispatch_raw,
+        cancel_token=cancel_token,
+        lifecycle_check=lifecycle_check,
+    )

--- a/python/dcc_mcp_core/_server/_inprocess_contracts.py
+++ b/python/dcc_mcp_core/_server/_inprocess_contracts.py
@@ -19,6 +19,7 @@ from dcc_mcp_core.result_envelope import ToolResultEnvelope
 logger = logging.getLogger(__name__)
 
 _MAX_TIMEOUT_MS = 3_600_000
+_MAX_CONTINUATION_TIMEOUT_SECS = 300.0
 
 
 @dataclass(frozen=True)
@@ -70,8 +71,8 @@ class ContinuationOutcome:
     only that terminal value to MCP and REST callers.
     """
 
-    continuation: Callable[[], Any]
-    timeout_secs: float = 3600.0
+    continuation: Callable[..., Any]
+    timeout_secs: float = 300.0
     _dcc_mcp_split_phase: bool = True
     _claimed: bool = field(default=False, init=False, repr=False)
     _claim_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
@@ -79,8 +80,12 @@ class ContinuationOutcome:
     def __post_init__(self) -> None:
         if not callable(self.continuation):
             raise TypeError("continuation must be callable")
-        if not math.isfinite(self.timeout_secs) or self.timeout_secs <= 0:
-            raise ValueError("timeout_secs must be finite and > 0")
+        if (
+            not math.isfinite(self.timeout_secs)
+            or self.timeout_secs <= 0
+            or self.timeout_secs > _MAX_CONTINUATION_TIMEOUT_SECS
+        ):
+            raise ValueError("timeout_secs must be finite, > 0, and <= 300 seconds")
 
     def claim(self) -> bool:
         """Atomically claim ownership; returns ``False`` on replay."""

--- a/python/dcc_mcp_core/_server/_inprocess_contracts.py
+++ b/python/dcc_mcp_core/_server/_inprocess_contracts.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 import logging
 from pathlib import Path
+import threading
 import traceback
 from typing import Any
 from typing import Callable
@@ -55,6 +57,41 @@ class DeferredToolResult:
             raise ValueError("timeout_secs must be > 0")
         if self.poll_interval_secs <= 0:
             raise ValueError("poll_interval_secs must be > 0")
+
+
+@dataclass
+class ContinuationOutcome:
+    """Transport-internal split-phase result.
+
+    The callable is intentionally kept out of the wire result.  A host
+    dispatcher may return this value after its bounded main-thread phase;
+    Core then invokes ``continuation`` on the request/job worker and exposes
+    only that terminal value to MCP and REST callers.
+    """
+
+    continuation: Callable[[], Any]
+    timeout_secs: float = 3600.0
+    _dcc_mcp_split_phase: bool = True
+    _claimed: bool = field(default=False, init=False, repr=False)
+    _claim_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not callable(self.continuation):
+            raise TypeError("continuation must be callable")
+        if self.timeout_secs <= 0:
+            raise ValueError("timeout_secs must be > 0")
+
+    def claim(self) -> bool:
+        """Atomically claim ownership; returns ``False`` on replay."""
+        with self._claim_lock:
+            if self._claimed:
+                return False
+            self._claimed = True
+            return True
+
+
+# Descriptive alias used by adapter-facing code and issue #2380.
+SplitPhaseOutcome = ContinuationOutcome
 
 
 def context_from_kwargs(
@@ -220,6 +257,8 @@ def is_host_queue_dispatcher(dispatcher: Any | None) -> bool:
 for _public_contract in (
     BaseDccCallableDispatcher,
     DeferredToolResult,
+    ContinuationOutcome,
+    SplitPhaseOutcome,
     InProcessExecutionContext,
     exception_to_error_envelope,
     sandbox_denied_envelope,

--- a/python/dcc_mcp_core/_server/_inprocess_contracts.py
+++ b/python/dcc_mcp_core/_server/_inprocess_contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 import logging
+import math
 from pathlib import Path
 import threading
 import traceback
@@ -78,8 +79,8 @@ class ContinuationOutcome:
     def __post_init__(self) -> None:
         if not callable(self.continuation):
             raise TypeError("continuation must be callable")
-        if self.timeout_secs <= 0:
-            raise ValueError("timeout_secs must be > 0")
+        if not math.isfinite(self.timeout_secs) or self.timeout_secs <= 0:
+            raise ValueError("timeout_secs must be finite and > 0")
 
     def claim(self) -> bool:
         """Atomically claim ownership; returns ``False`` on replay."""

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -15,6 +15,8 @@ from dcc_mcp_core._server._inprocess_contracts import InProcessExecutionContext
 from dcc_mcp_core._server._inprocess_contracts import attach_deferred_streams
 from dcc_mcp_core._server._inprocess_contracts import exception_to_error_envelope
 from dcc_mcp_core._server._inprocess_contracts import timeout_hint_secs_to_ms
+from dcc_mcp_core.cancellation import DccMcpCancelledError
+from dcc_mcp_core.cancellation import check_cancelled
 from dcc_mcp_core.chunked_runner import ChunkedRunner
 
 
@@ -24,6 +26,7 @@ def resolve_execution_result(
     *,
     dispatcher: Any,
     dispatch_raw: Callable[..., Any],
+    cancel_token: Any | None = None,
 ) -> Any:
     """Resolve a returned chunk runner or deferred result."""
     if isinstance(result, ChunkedRunner):
@@ -35,7 +38,7 @@ def resolve_execution_result(
         )
     if not isinstance(result, DeferredToolResult):
         if isinstance(result, ContinuationOutcome):
-            return _resolve_continuation(result, context)
+            return _resolve_continuation(result, context, cancel_token=cancel_token)
         return result
 
     deadline = time.monotonic() + result.timeout_secs
@@ -75,6 +78,8 @@ def resolve_execution_result(
 def _resolve_continuation(
     outcome: ContinuationOutcome,
     context: InProcessExecutionContext,
+    *,
+    cancel_token: Any | None = None,
 ) -> Any:
     """Run a split-phase continuation off the host dispatch closure.
 
@@ -92,11 +97,14 @@ def _resolve_continuation(
     try:
         # Cancellation is checked both before submit and at the commit seam.
         # ``check_cancelled`` is a no-op when no request token is installed.
-        from dcc_mcp_core.cancellation import check_cancelled
-
-        check_cancelled()
+        if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
+            raise DccMcpCancelledError("Request cancelled by client")
         finished = outcome.continuation()
+        if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
+            raise DccMcpCancelledError("Request cancelled by client")
         check_cancelled()
+    except DccMcpCancelledError as exc:
+        return exception_to_error_envelope(exc, message="Split-phase continuation cancelled before commit")
     except Exception as exc:
         return exception_to_error_envelope(exc, message="Split-phase continuation failed")
 

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -28,6 +28,7 @@ def resolve_execution_result(
     dispatcher: Any,
     dispatch_raw: Callable[..., Any],
     cancel_token: Any | None = None,
+    lifecycle_check: Callable[[], bool] | None = None,
 ) -> Any:
     """Resolve a returned chunk runner or deferred result."""
     if isinstance(result, ChunkedRunner):
@@ -39,7 +40,12 @@ def resolve_execution_result(
         )
     if not isinstance(result, DeferredToolResult):
         if isinstance(result, ContinuationOutcome):
-            return _resolve_continuation(result, context, cancel_token=cancel_token)
+            return _resolve_continuation(
+                result,
+                context,
+                cancel_token=cancel_token,
+                lifecycle_check=lifecycle_check,
+            )
         return result
 
     deadline = time.monotonic() + result.timeout_secs
@@ -81,6 +87,7 @@ def _resolve_continuation(
     context: InProcessExecutionContext,
     *,
     cancel_token: Any | None = None,
+    lifecycle_check: Callable[[], bool] | None = None,
 ) -> Any:
     """Run a split-phase continuation off the host dispatch closure.
 
@@ -100,6 +107,8 @@ def _resolve_continuation(
         # ``check_cancelled`` is a no-op when no request token is installed.
         if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
             raise DccMcpCancelledError("Request cancelled by client")
+        if lifecycle_check is not None and not lifecycle_check():
+            raise DccMcpCancelledError("Host execution bridge is shutting down")
         # A cancellable request must expose its probe to the continuation;
         # otherwise a blocking callback could perform durable work after the
         # request has timed out/cancelled.  Refuse such callbacks before they
@@ -122,6 +131,8 @@ def _resolve_continuation(
         finished = continuation(cancel_token) if accepts_probe else continuation()
         if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
             raise DccMcpCancelledError("Request cancelled by client")
+        if lifecycle_check is not None and not lifecycle_check():
+            raise DccMcpCancelledError("Host execution bridge is shutting down")
         check_cancelled()
     except DccMcpCancelledError as exc:
         return exception_to_error_envelope(exc, message="Split-phase continuation cancelled before commit")

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -80,6 +80,11 @@ def resolve_execution_result(
             message="Chunked tool returned a monolithic result",
         )
     if not isinstance(result, DeferredToolResult):
+        if isinstance(result, dict) and "_dcc_mcp_split_phase" in result:
+            return exception_to_error_envelope(
+                ValueError("reserved split-phase marker cannot be supplied as a plain mapping"),
+                message="Malformed split-phase marker rejected",
+            )
         if isinstance(result, ContinuationOutcome):
             return _resolve_continuation(
                 result,

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -18,7 +18,49 @@ from dcc_mcp_core._server._inprocess_contracts import exception_to_error_envelop
 from dcc_mcp_core._server._inprocess_contracts import timeout_hint_secs_to_ms
 from dcc_mcp_core.cancellation import DccMcpCancelledError
 from dcc_mcp_core.cancellation import check_cancelled
+from dcc_mcp_core.cancellation import reset_cancel_token
+from dcc_mcp_core.cancellation import set_cancel_token
 from dcc_mcp_core.chunked_runner import ChunkedRunner
+
+
+class _ContinuationProbe:
+    """Cooperative cancellation/deadline probe for split-phase callbacks.
+
+    The probe is always passed to a continuation, including synchronous
+    MCP/REST calls that do not have a server cancellation token.  This keeps
+    the callback contract identical across all routes and gives callbacks a
+    deadline gate before durable work.
+    """
+
+    __slots__ = ("_cancel_token", "_deadline", "_lifecycle_check")
+
+    def __init__(
+        self,
+        cancel_token: Any | None,
+        deadline: float,
+        lifecycle_check: Callable[[], bool] | None,
+    ) -> None:
+        self._cancel_token = cancel_token
+        self._deadline = deadline
+        self._lifecycle_check = lifecycle_check
+
+    @property
+    def cancelled(self) -> bool:
+        token = self._cancel_token
+        if token is not None and bool(getattr(token, "cancelled", False)):
+            return True
+        if time.monotonic() >= self._deadline:
+            return True
+        return self._lifecycle_check is not None and not self._lifecycle_check()
+
+    @property
+    def job_id(self) -> str | None:
+        job_id = getattr(self._cancel_token, "job_id", None)
+        return job_id if isinstance(job_id, str) else None
+
+    def check(self) -> None:
+        if self.cancelled:
+            raise DccMcpCancelledError("Split-phase continuation cancelled or timed out")
 
 
 def resolve_execution_result(
@@ -105,14 +147,16 @@ def _resolve_continuation(
     try:
         # Cancellation is checked both before submit and at the commit seam.
         # ``check_cancelled`` is a no-op when no request token is installed.
-        if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
-            raise DccMcpCancelledError("Request cancelled by client")
-        if lifecycle_check is not None and not lifecycle_check():
-            raise DccMcpCancelledError("Host execution bridge is shutting down")
-        # A cancellable request must expose its probe to the continuation;
-        # otherwise a blocking callback could perform durable work after the
-        # request has timed out/cancelled.  Refuse such callbacks before they
-        # run (fail closed rather than guessing at side effects).
+        probe = _ContinuationProbe(
+            cancel_token,
+            started + outcome.timeout_secs,
+            lifecycle_check,
+        )
+        probe.check()
+        # Every continuation must expose a probe; otherwise a blocking
+        # callback could perform durable work after its deadline or lifecycle
+        # has been cancelled. Refuse such callbacks before they run (fail
+        # closed rather than guessing at side effects).
         continuation = outcome.continuation
         accepts_probe = False
         try:
@@ -123,16 +167,17 @@ def _resolve_continuation(
             ) or any(parameter.kind == parameter.VAR_POSITIONAL for parameter in signature.parameters.values())
         except (TypeError, ValueError):
             accepts_probe = False
-        if cancel_token is not None and not accepts_probe:
+        if not accepts_probe:
             return exception_to_error_envelope(
                 TypeError("continuation does not accept a cancellation probe"),
                 message="Uncancellable continuation rejected before commit",
             )
-        finished = continuation(cancel_token) if accepts_probe else continuation()
-        if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
-            raise DccMcpCancelledError("Request cancelled by client")
-        if lifecycle_check is not None and not lifecycle_check():
-            raise DccMcpCancelledError("Host execution bridge is shutting down")
+        reset = set_cancel_token(probe)
+        try:
+            finished = continuation(probe)
+        finally:
+            reset_cancel_token(reset)
+        probe.check()
         check_cancelled()
     except DccMcpCancelledError as exc:
         return exception_to_error_envelope(exc, message="Split-phase continuation cancelled before commit")

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -17,7 +17,6 @@ from dcc_mcp_core._server._inprocess_contracts import attach_deferred_streams
 from dcc_mcp_core._server._inprocess_contracts import exception_to_error_envelope
 from dcc_mcp_core._server._inprocess_contracts import timeout_hint_secs_to_ms
 from dcc_mcp_core.cancellation import DccMcpCancelledError
-from dcc_mcp_core.cancellation import check_cancelled
 from dcc_mcp_core.cancellation import reset_cancel_token
 from dcc_mcp_core.cancellation import set_cancel_token
 from dcc_mcp_core.chunked_runner import ChunkedRunner
@@ -146,7 +145,6 @@ def _resolve_continuation(
     started = time.monotonic()
     try:
         # Cancellation is checked both before submit and at the commit seam.
-        # ``check_cancelled`` is a no-op when no request token is installed.
         probe = _ContinuationProbe(
             cancel_token,
             started + outcome.timeout_secs,
@@ -178,7 +176,6 @@ def _resolve_continuation(
         finally:
             reset_cancel_token(reset)
         probe.check()
-        check_cancelled()
     except DccMcpCancelledError as exc:
         return exception_to_error_envelope(exc, message="Split-phase continuation cancelled before commit")
     except Exception as exc:

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import threading
 import time
@@ -99,7 +100,26 @@ def _resolve_continuation(
         # ``check_cancelled`` is a no-op when no request token is installed.
         if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
             raise DccMcpCancelledError("Request cancelled by client")
-        finished = outcome.continuation()
+        # A cancellable request must expose its probe to the continuation;
+        # otherwise a blocking callback could perform durable work after the
+        # request has timed out/cancelled.  Refuse such callbacks before they
+        # run (fail closed rather than guessing at side effects).
+        continuation = outcome.continuation
+        accepts_probe = False
+        try:
+            signature = inspect.signature(continuation)
+            accepts_probe = any(
+                parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+                for parameter in signature.parameters.values()
+            ) or any(parameter.kind == parameter.VAR_POSITIONAL for parameter in signature.parameters.values())
+        except (TypeError, ValueError):
+            accepts_probe = False
+        if cancel_token is not None and not accepts_probe:
+            return exception_to_error_envelope(
+                TypeError("continuation does not accept a cancellation probe"),
+                message="Uncancellable continuation rejected before commit",
+            )
+        finished = continuation(cancel_token) if accepts_probe else continuation()
         if cancel_token is not None and bool(getattr(cancel_token, "cancelled", False)):
             raise DccMcpCancelledError("Request cancelled by client")
         check_cancelled()

--- a/python/dcc_mcp_core/_server/_inprocess_results.py
+++ b/python/dcc_mcp_core/_server/_inprocess_results.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import Callable
 import uuid
 
+from dcc_mcp_core._server._inprocess_contracts import ContinuationOutcome
 from dcc_mcp_core._server._inprocess_contracts import DeferredToolResult
 from dcc_mcp_core._server._inprocess_contracts import InProcessExecutionContext
 from dcc_mcp_core._server._inprocess_contracts import attach_deferred_streams
@@ -33,6 +34,8 @@ def resolve_execution_result(
             message="Chunked tool returned a monolithic result",
         )
     if not isinstance(result, DeferredToolResult):
+        if isinstance(result, ContinuationOutcome):
+            return _resolve_continuation(result, context)
         return result
 
     deadline = time.monotonic() + result.timeout_secs
@@ -67,6 +70,54 @@ def resolve_execution_result(
             return attach_deferred_streams(finished, result)
 
         time.sleep(result.poll_interval_secs)
+
+
+def _resolve_continuation(
+    outcome: ContinuationOutcome,
+    context: InProcessExecutionContext,
+) -> Any:
+    """Run a split-phase continuation off the host dispatch closure.
+
+    ``dispatch_raw`` has already returned before this function is entered,
+    which is the key main-affinity invariant.  The continuation is one-shot;
+    nested outcomes are rejected so an adapter cannot accidentally retain the
+    host lane through recursive hand-offs.
+    """
+    if not outcome.claim():
+        return exception_to_error_envelope(
+            RuntimeError("split-phase continuation already consumed"),
+            message="Split-phase continuation replay rejected",
+        )
+    started = time.monotonic()
+    try:
+        # Cancellation is checked both before submit and at the commit seam.
+        # ``check_cancelled`` is a no-op when no request token is installed.
+        from dcc_mcp_core.cancellation import check_cancelled
+
+        check_cancelled()
+        finished = outcome.continuation()
+        check_cancelled()
+    except Exception as exc:
+        return exception_to_error_envelope(exc, message="Split-phase continuation failed")
+
+    if time.monotonic() - started > outcome.timeout_secs:
+        return exception_to_error_envelope(
+            TimeoutError(f"Continuation timed out after {outcome.timeout_secs:g}s"),
+            message="Split-phase continuation exceeded timeout",
+        )
+    if isinstance(finished, (ContinuationOutcome, DeferredToolResult)):
+        return exception_to_error_envelope(
+            TypeError("Nested continuation outcomes are not supported"),
+            message="Nested split-phase continuation rejected",
+        )
+    try:
+        json.dumps(finished)
+    except TypeError as exc:
+        return exception_to_error_envelope(
+            exc,
+            message="Split-phase continuation returned a non-serialisable result",
+        )
+    return finished
 
 
 def _resolve_chunked_runner(

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -35,6 +35,7 @@ from typing import Sequence
 import uuid
 
 from dcc_mcp_core._server._inprocess_contracts import BaseDccCallableDispatcher
+from dcc_mcp_core._server._inprocess_contracts import ContinuationOutcome
 from dcc_mcp_core._server._inprocess_contracts import DeferredToolResult
 from dcc_mcp_core._server._inprocess_contracts import InProcessExecutionContext
 from dcc_mcp_core._server._inprocess_contracts import context_from_kwargs as _context_from_kwargs
@@ -69,9 +70,11 @@ _SCRIPT_PACKAGE_CLEAR_TIMEOUT_SECS = 1.0
 
 __all__ = [
     "BaseDccCallableDispatcher",
+    "ContinuationOutcome",
     "DeferredToolResult",
     "HostExecutionBridge",
     "InProcessExecutionContext",
+    "SplitPhaseOutcome",
     "build_inprocess_executor",
     "clear_script_package",
     "exception_to_error_envelope",
@@ -79,6 +82,8 @@ __all__ = [
     "sandbox_denied_envelope",
     "timeout_hint_secs_to_ms",
 ]
+
+SplitPhaseOutcome = ContinuationOutcome
 
 
 @dataclass

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -355,12 +355,20 @@ class HostExecutionBridge:
                     RuntimeError("split-phase continuation cannot resolve on the host thread"),
                     message="Split-phase continuation must resolve off the host thread",
                 )
+        generation = self._current_generation()
+        if generation is None and isinstance(result, ContinuationOutcome):
+            return self._shutdown_error()
         return resolve_execution_result(
             result,
             context,
             dispatcher=self.dispatcher,
             dispatch_raw=self._dispatch_raw,
             cancel_token=context.cancel_token,
+            lifecycle_check=(
+                (lambda: self._is_current_generation(generation))
+                if isinstance(result, ContinuationOutcome) and generation is not None
+                else None
+            ),
         )
 
     def execute_script(

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -34,6 +34,7 @@ from typing import Mapping
 from typing import Sequence
 import uuid
 
+from dcc_mcp_core._server._continuation_lifecycle import resolve_bridge_result
 from dcc_mcp_core._server._inprocess_contracts import BaseDccCallableDispatcher
 from dcc_mcp_core._server._inprocess_contracts import ContinuationOutcome
 from dcc_mcp_core._server._inprocess_contracts import DeferredToolResult
@@ -44,7 +45,6 @@ from dcc_mcp_core._server._inprocess_contracts import is_host_queue_dispatcher a
 from dcc_mcp_core._server._inprocess_contracts import resolve_sandbox_action_name as _resolve_sandbox_action_name
 from dcc_mcp_core._server._inprocess_contracts import sandbox_denied_envelope
 from dcc_mcp_core._server._inprocess_contracts import timeout_hint_secs_to_ms
-from dcc_mcp_core._server._inprocess_results import resolve_execution_result
 from dcc_mcp_core.cancellation import _reset_current_job_id
 from dcc_mcp_core.cancellation import _set_current_job_id
 from dcc_mcp_core.cancellation import check_cancelled
@@ -348,27 +348,14 @@ class HostExecutionBridge:
         context: InProcessExecutionContext,
     ) -> Any:
         """Resolve a DeferredToolResult or ChunkedRunner."""
-        if isinstance(result, ContinuationOutcome):
-            is_host_thread = getattr(self.dispatcher, "is_host_thread", None)
-            if callable(is_host_thread) and is_host_thread():
-                return exception_to_error_envelope(
-                    RuntimeError("split-phase continuation cannot resolve on the host thread"),
-                    message="Split-phase continuation must resolve off the host thread",
-                )
-        generation = self._current_generation()
-        if generation is None and isinstance(result, ContinuationOutcome):
-            return self._shutdown_error()
-        return resolve_execution_result(
+        return resolve_bridge_result(
             result,
             context,
             dispatcher=self.dispatcher,
             dispatch_raw=self._dispatch_raw,
             cancel_token=context.cancel_token,
-            lifecycle_check=(
-                (lambda: self._is_current_generation(generation))
-                if isinstance(result, ContinuationOutcome) and generation is not None
-                else None
-            ),
+            current_generation=self._current_generation,
+            is_current_generation=self._is_current_generation,
         )
 
     def execute_script(

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -348,6 +348,13 @@ class HostExecutionBridge:
         context: InProcessExecutionContext,
     ) -> Any:
         """Resolve a DeferredToolResult or ChunkedRunner."""
+        if isinstance(result, ContinuationOutcome):
+            is_host_thread = getattr(self.dispatcher, "is_host_thread", None)
+            if callable(is_host_thread) and is_host_thread():
+                return exception_to_error_envelope(
+                    RuntimeError("split-phase continuation cannot resolve on the host thread"),
+                    message="Split-phase continuation must resolve off the host thread",
+                )
         return resolve_execution_result(
             result,
             context,

--- a/python/dcc_mcp_core/_server/inprocess_executor.py
+++ b/python/dcc_mcp_core/_server/inprocess_executor.py
@@ -353,6 +353,7 @@ class HostExecutionBridge:
             context,
             dispatcher=self.dispatcher,
             dispatch_raw=self._dispatch_raw,
+            cancel_token=context.cancel_token,
         )
 
     def execute_script(

--- a/python/dcc_mcp_core/_server/lifecycle_controller.py
+++ b/python/dcc_mcp_core/_server/lifecycle_controller.py
@@ -138,6 +138,13 @@ class LifecycleController:
         close_admission = getattr(bridge, "close_script_admission", None)
         if callable(close_admission):
             close_admission()
+        # Advance the Rust split-phase lifecycle at the same admission
+        # boundary.  This invalidates already-taken continuations before
+        # quit hooks or transport teardown can race with durable commits.
+        handle = getattr(owner, "_handle", None)
+        signal_shutdown = getattr(handle, "signal_shutdown", None)
+        if callable(signal_shutdown):
+            signal_shutdown()
         self._run_quit_hooks()
         self._runtime_ctrl().stop_gateway_guardian()
         self._runtime_ctrl().stop_gateway_election()

--- a/python/dcc_mcp_core/cancellation.py
+++ b/python/dcc_mcp_core/cancellation.py
@@ -104,6 +104,10 @@ class CancellationProbe(Protocol):
         """Server-owned asynchronous job id, when one exists."""
         ...
 
+    def check(self) -> None:
+        """Raise when cancellation has been requested."""
+        ...
+
 
 class CancelToken:
     """Thread-safe cancellation flag settable by the request dispatcher.
@@ -146,6 +150,11 @@ class CancelToken:
         """Whether :meth:`cancel` has been invoked on this token."""
         with self._lock:
             return self._cancelled
+
+    def check(self) -> None:
+        """Raise if cancellation has been requested."""
+        if self.cancelled:
+            raise DccMcpCancelledError("Request cancelled by client")
 
     @property
     def job_id(self) -> str | None:

--- a/python/dcc_mcp_core/ui_control_server.py
+++ b/python/dcc_mcp_core/ui_control_server.py
@@ -72,6 +72,11 @@ def _shutdown(bridge, handle) -> None:
     """Close admission, stop HTTP, then always release owned Host state."""
     try:
         bridge.close_script_admission()
+        # Keep the Rust continuation store on the same shutdown boundary as
+        # the Python bridge admission gate.
+        signal_shutdown = getattr(handle, "signal_shutdown", None)
+        if callable(signal_shutdown):
+            signal_shutdown()
     finally:
         try:
             handle.shutdown()

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dcc_mcp_core import ContinuationOutcome
+from dcc_mcp_core import HostExecutionBridge
+from dcc_mcp_core import SplitPhaseOutcome
+
+
+def test_split_phase_releases_main_segment_before_continuation() -> None:
+    segments: list[float] = []
+
+    class MainDispatcher:
+        def dispatch_callable(self, func, **kwargs):
+            started = time.perf_counter()
+            value = func()
+            segments.append(time.perf_counter() - started)
+            return value
+
+    bridge = HostExecutionBridge(dispatcher=MainDispatcher())
+
+    def main_phase():
+        return SplitPhaseOutcome(lambda: (time.sleep(0.075), {"ok": True})[1])
+
+    started = time.perf_counter()
+    result = bridge.dispatch_callable(main_phase, thread_affinity="main")
+    elapsed = time.perf_counter() - started
+
+    assert result == {"ok": True}
+    assert elapsed >= 0.075
+    assert segments and segments[0] < 0.05
+
+
+def test_split_phase_rejects_nested_outcome() -> None:
+    bridge = HostExecutionBridge()
+    result = bridge.dispatch_callable(
+        lambda: ContinuationOutcome(lambda: ContinuationOutcome(lambda: {"bad": True})),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert "nested" in result["message"].lower()
+
+
+def test_split_phase_non_serializable_output_fails_closed() -> None:
+    bridge = HostExecutionBridge()
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(lambda: object()),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert "serial" in result["message"].lower()
+
+
+def test_split_phase_exception_is_structured() -> None:
+    bridge = HostExecutionBridge()
+
+    def fail():
+        raise RuntimeError("encode failed")
+
+    result = bridge.dispatch_callable(lambda: SplitPhaseOutcome(fail), thread_affinity="main")
+    assert result["success"] is False
+    assert result["error"] == "RuntimeError"
+
+
+def test_split_phase_requires_callable() -> None:
+    with pytest.raises(TypeError):
+        SplitPhaseOutcome(1)  # type: ignore[arg-type]

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -55,7 +55,7 @@ def test_split_phase_releases_main_segment_before_continuation() -> None:
 def test_split_phase_rejects_nested_outcome() -> None:
     bridge = HostExecutionBridge()
     result = bridge.dispatch_callable(
-        lambda: ContinuationOutcome(lambda: ContinuationOutcome(lambda: {"bad": True})),
+        lambda: ContinuationOutcome(lambda _probe: ContinuationOutcome(lambda _nested_probe: {"bad": True})),
         thread_affinity="main",
     )
     assert result["success"] is False
@@ -65,7 +65,7 @@ def test_split_phase_rejects_nested_outcome() -> None:
 def test_split_phase_non_serializable_output_fails_closed() -> None:
     bridge = HostExecutionBridge()
     result = bridge.dispatch_callable(
-        lambda: SplitPhaseOutcome(lambda: object()),
+        lambda: SplitPhaseOutcome(lambda _probe: object()),
         thread_affinity="main",
     )
     assert result["success"] is False
@@ -75,7 +75,7 @@ def test_split_phase_non_serializable_output_fails_closed() -> None:
 def test_split_phase_exception_is_structured() -> None:
     bridge = HostExecutionBridge()
 
-    def fail():
+    def fail(_probe):
         raise RuntimeError("encode failed")
 
     result = bridge.dispatch_callable(lambda: SplitPhaseOutcome(fail), thread_affinity="main")
@@ -130,6 +130,23 @@ def test_split_phase_rejects_uncancellable_callback_before_side_effect() -> None
     assert "uncancellable" in result["message"].lower()
 
 
+def test_split_phase_rejects_uncancellable_sync_callback_without_token() -> None:
+    published = []
+    bridge = HostExecutionBridge()
+
+    def continuation():
+        published.append(True)
+        return {"published": True}
+
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(continuation),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert published == []
+    assert "uncancellable" in result["message"].lower()
+
+
 def test_split_phase_resolution_fails_closed_on_host_thread() -> None:
     class HostDispatcher:
         def is_host_thread(self):
@@ -140,7 +157,7 @@ def test_split_phase_resolution_fails_closed_on_host_thread() -> None:
 
     bridge = HostExecutionBridge(dispatcher=HostDispatcher())
     result = bridge.dispatch_callable(
-        lambda: SplitPhaseOutcome(lambda: {"ok": True}),
+        lambda: SplitPhaseOutcome(lambda _probe: {"ok": True}),
         thread_affinity="main",
     )
     assert result["success"] is False
@@ -189,3 +206,22 @@ def test_running_cancellation_probe_blocks_durable_side_effect() -> None:
         result = call.result(timeout=2)
     assert result["success"] is False
     assert published == []
+
+
+def test_sync_continuation_receives_deadline_probe_without_cancel_token() -> None:
+    observed = []
+    bridge = HostExecutionBridge()
+
+    def continuation(probe):
+        observed.append(probe)
+        time.sleep(0.01)
+        probe.check()
+        return {"published": True}
+
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(continuation, timeout_secs=0.001),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert observed and observed[0] is not None
+    assert "cancel" in result["message"].lower()

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+from dcc_mcp_core import CancelToken
 from dcc_mcp_core import ContinuationOutcome
 from dcc_mcp_core import HostExecutionBridge
 from dcc_mcp_core import SplitPhaseOutcome
@@ -67,3 +68,20 @@ def test_split_phase_exception_is_structured() -> None:
 def test_split_phase_requires_callable() -> None:
     with pytest.raises(TypeError):
         SplitPhaseOutcome(1)  # type: ignore[arg-type]
+
+
+def test_cancelled_token_blocks_commit() -> None:
+    token = CancelToken()
+    bridge = HostExecutionBridge()
+
+    def continuation():
+        token.cancel()
+        return {"published": True}
+
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(continuation),
+        thread_affinity="main",
+        cancel_token=token,
+    )
+    assert result["success"] is False
+    assert "cancel" in result["message"].lower()

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -74,7 +74,7 @@ def test_cancelled_token_blocks_commit() -> None:
     token = CancelToken()
     bridge = HostExecutionBridge()
 
-    def continuation():
+    def continuation(_probe):
         token.cancel()
         return {"published": True}
 
@@ -85,3 +85,45 @@ def test_cancelled_token_blocks_commit() -> None:
     )
     assert result["success"] is False
     assert "cancel" in result["message"].lower()
+
+
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf"), 1e300, 301.0])
+def test_split_phase_timeout_is_finite_and_bounded(timeout: float) -> None:
+    with pytest.raises(ValueError):
+        SplitPhaseOutcome(lambda: {"ok": True}, timeout_secs=timeout)
+
+
+def test_split_phase_rejects_uncancellable_callback_before_side_effect() -> None:
+    published = []
+    token = CancelToken()
+    bridge = HostExecutionBridge()
+
+    def continuation():
+        published.append(True)
+        return {"published": True}
+
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(continuation),
+        thread_affinity="main",
+        cancel_token=token,
+    )
+    assert result["success"] is False
+    assert published == []
+    assert "uncancellable" in result["message"].lower()
+
+
+def test_split_phase_resolution_fails_closed_on_host_thread() -> None:
+    class HostDispatcher:
+        def is_host_thread(self):
+            return True
+
+        def dispatch_callable(self, func, **kwargs):
+            return func()
+
+    bridge = HostExecutionBridge(dispatcher=HostDispatcher())
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(lambda: {"ok": True}),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert "host thread" in result["message"].lower()

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -241,9 +241,9 @@ def test_sync_continuation_receives_deadline_probe_without_cancel_token() -> Non
 
     def continuation(probe):
         observed.append(probe)
-        deadline = time.perf_counter() + 0.02
-        while time.perf_counter() < deadline:
-            pass
+        wait_limit = time.monotonic() + 1.0
+        while not probe.cancelled and time.monotonic() < wait_limit:
+            time.sleep(0)
         probe.check()
         return {"published": True}
 

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import threading
 import time
 
 import pytest
@@ -33,7 +35,13 @@ def test_split_phase_releases_main_segment_before_continuation() -> None:
     bridge = HostExecutionBridge(dispatcher=MainDispatcher())
 
     def main_phase():
-        return SplitPhaseOutcome(lambda: (time.sleep(0.075), {"ok": True})[1])
+        def continuation(_probe):
+            deadline = time.perf_counter() + 0.075
+            while time.perf_counter() < deadline:
+                pass
+            return {"ok": True}
+
+        return SplitPhaseOutcome(continuation)
 
     started = time.perf_counter()
     result = bridge.dispatch_callable(main_phase, thread_affinity="main")
@@ -152,3 +160,32 @@ def test_split_phase_shutdown_during_continuation_blocks_commit() -> None:
     )
     assert result["success"] is False
     assert "cancel" in result["message"].lower()
+
+
+def test_running_cancellation_probe_blocks_durable_side_effect() -> None:
+    token = CancelToken()
+    started = threading.Event()
+    release = threading.Event()
+    published: list[bool] = []
+    bridge = HostExecutionBridge()
+
+    def continuation(probe):
+        started.set()
+        release.wait(1)
+        if not probe.cancelled:
+            published.append(True)
+        return {"published": True}
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        call = pool.submit(
+            bridge.dispatch_callable,
+            lambda: SplitPhaseOutcome(continuation),
+            thread_affinity="main",
+            cancel_token=token,
+        )
+        assert started.wait(1)
+        token.cancel()
+        release.set()
+        result = call.result(timeout=2)
+    assert result["success"] is False
+    assert published == []

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -26,6 +26,9 @@ def test_split_phase_releases_main_segment_before_continuation() -> None:
     segments: list[float] = []
 
     class MainDispatcher:
+        def is_host_thread(self):
+            return False
+
         def dispatch_callable(self, func, **kwargs):
             started = time.perf_counter()
             value = func()
@@ -164,6 +167,20 @@ def test_split_phase_resolution_fails_closed_on_host_thread() -> None:
     assert "host thread" in result["message"].lower()
 
 
+def test_split_phase_resolution_fails_closed_without_thread_identity() -> None:
+    class OpaqueDispatcher:
+        def dispatch_callable(self, func, **kwargs):
+            return func()
+
+    bridge = HostExecutionBridge(dispatcher=OpaqueDispatcher())
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(lambda _probe: {"ok": True}),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert "thread identity" in result["message"].lower()
+
+
 def test_split_phase_shutdown_during_continuation_blocks_commit() -> None:
     bridge = HostExecutionBridge()
 
@@ -214,7 +231,9 @@ def test_sync_continuation_receives_deadline_probe_without_cancel_token() -> Non
 
     def continuation(probe):
         observed.append(probe)
-        time.sleep(0.01)
+        deadline = time.perf_counter() + 0.02
+        while time.perf_counter() < deadline:
+            pass
         probe.check()
         return {"published": True}
 

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -127,3 +127,18 @@ def test_split_phase_resolution_fails_closed_on_host_thread() -> None:
     )
     assert result["success"] is False
     assert "host thread" in result["message"].lower()
+
+
+def test_split_phase_shutdown_during_continuation_blocks_commit() -> None:
+    bridge = HostExecutionBridge()
+
+    def continuation(_probe):
+        bridge.close_script_admission()
+        return {"published": True}
+
+    result = bridge.dispatch_callable(
+        lambda: SplitPhaseOutcome(continuation),
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert "cancel" in result["message"].lower()

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -10,6 +10,16 @@ from dcc_mcp_core import HostExecutionBridge
 from dcc_mcp_core import SplitPhaseOutcome
 
 
+def test_continuation_public_import_parity() -> None:
+    from dcc_mcp_core._server._continuation_lifecycle import resolve_bridge_result
+    from dcc_mcp_core._server._inprocess_results import resolve_execution_result
+    from dcc_mcp_core._server.inprocess_executor import ContinuationOutcome as ExecutorOutcome
+
+    assert ExecutorOutcome is ContinuationOutcome
+    assert callable(resolve_bridge_result)
+    assert callable(resolve_execution_result)
+
+
 def test_split_phase_releases_main_segment_before_continuation() -> None:
     segments: list[float] = []
 

--- a/tests/test_inprocess_continuation.py
+++ b/tests/test_inprocess_continuation.py
@@ -65,6 +65,16 @@ def test_split_phase_rejects_nested_outcome() -> None:
     assert "nested" in result["message"].lower()
 
 
+def test_split_phase_rejects_forged_mapping_marker() -> None:
+    bridge = HostExecutionBridge()
+    result = bridge.dispatch_callable(
+        lambda: {"_dcc_mcp_split_phase": {"kind": "continuation.v1"}},
+        thread_affinity="main",
+    )
+    assert result["success"] is False
+    assert "malformed split-phase marker" in result["message"].lower()
+
+
 def test_split_phase_non_serializable_output_fails_closed() -> None:
     bridge = HostExecutionBridge()
     result = bridge.dispatch_callable(

--- a/tests/test_issues_404_411.py
+++ b/tests/test_issues_404_411.py
@@ -15,6 +15,7 @@ package has been built with maturin develop.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import pathlib
 import time
@@ -138,24 +139,16 @@ class TestEvalContext:
         assert "safe preemption is unavailable" in str(observed["error"])
 
     def test_callable_cannot_swallow_deadline_timeout(self):
-        import signal
-
         EvalContext = _batch.EvalContext
         ctx = EvalContext(FakeDispatcher(), timeout_secs=1)
-        caught = []
 
         def swallow_timeout():
-            try:
+            with contextlib.suppress(TimeoutError):
                 time.sleep(1.1)
-            except TimeoutError:
-                caught.append("timeout")
             return "late-success"
 
         with pytest.raises(TimeoutError):
             ctx.run_callable(swallow_timeout)
-
-        if hasattr(signal, "SIGALRM"):
-            assert caught == ["timeout"]
 
 
 # ── issue #407: elicitation ──────────────────────────────────────────────────

--- a/tests/test_sentry_e2e.py
+++ b/tests/test_sentry_e2e.py
@@ -48,7 +48,7 @@ def test_sentry_real_ingest_via_rust_probe() -> None:
         "dcc-mcp-server",
         "--features",
         "sentry",
-        "sentry_real_ingest_e2e",
+        "sentry_init::tests::sentry_real_ingest_e2e",
         "--",
         "--exact",
         "--test-threads=1",
@@ -66,3 +66,7 @@ def test_sentry_real_ingest_via_rust_probe() -> None:
     if result.returncode != 0:
         combined = f"{result.stdout}\n{result.stderr}".strip()
         pytest.fail(f"sentry_real_ingest_e2e failed (exit {result.returncode}):\n{combined}")
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "test result: ok. 1 passed" in combined or "1 passed; 0 failed" in combined, (
+        "sentry selector matched no test; expected exactly one executed test\n" + combined
+    )

--- a/tests/test_ui_control_server.py
+++ b/tests/test_ui_control_server.py
@@ -92,6 +92,36 @@ def test_shutdown_stops_server_when_closing_admission_fails() -> None:
     assert events == ["close-admission", "server-shutdown", "clear-packages"]
 
 
+def test_shutdown_advances_split_phase_lifecycle_at_admission_boundary() -> None:
+    events: list[str] = []
+
+    class Bridge:
+        @staticmethod
+        def close_script_admission():
+            events.append("close-admission")
+
+        @staticmethod
+        def clear_script_packages():
+            events.append("clear-packages")
+
+    class Handle:
+        @staticmethod
+        def signal_shutdown():
+            events.append("signal-shutdown")
+
+        @staticmethod
+        def shutdown():
+            events.append("server-shutdown")
+
+    ui_control_server._shutdown(Bridge(), Handle())
+    assert events == [
+        "close-admission",
+        "signal-shutdown",
+        "server-shutdown",
+        "clear-packages",
+    ]
+
+
 def test_main_registers_executor_before_load_and_shuts_down_in_order(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add transport-internal split-phase continuation outcome for in-process main-affinity tools
- retain one-shot callbacks in Core and resolve them off the host lane with timeout/cancellation guards
- apply the same resolution to synchronous MCP/REST and async-job dispatch paths
- add Python, Rust, and dispatcher documentation/tests

## Validation
- cargo test -p dcc-mcp-http-server split_phase -- --nocapture
- cargo test -p dcc-mcp-http-server rmcp_tool_call_dispatch --lib
- cargo test -p dcc-mcp-skills catalog::tests --lib
- cargo check -p dcc-mcp-http-server -p dcc-mcp-http-py -p dcc-mcp-skills
- PYTHONPATH=python python -m pytest tests/test_inprocess_continuation.py -q

Closes #2380