### PR TITLE
chore(ci): bound Sentry real-ingest checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,9 @@ jobs:
     name: Sentry E2E
     needs: [rust-check]
     runs-on: ubuntu-latest
+    # Real-ingest is an external service probe. Bound the whole job so a
+    # stalled transport cannot hold every PR's required CI indefinitely.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -637,7 +640,10 @@ jobs:
             echo "DCC_MCP_SENTRY_DSN secret not configured; skipping Sentry E2E"
             exit 0
           fi
-          vx cargo test -p dcc-mcp-server --features sentry sentry_real_ingest_e2e \
+          # Keep the probe deadline shorter than the job timeout and terminate
+          # the process group so a blocked DNS/TLS/transport cannot leak.
+          timeout --signal=TERM --kill-after=60s 15m \
+            vx cargo test -p dcc-mcp-server --features sentry sentry_real_ingest_e2e \
             -- --exact --test-threads=1 --nocapture
 
   # -- mcpcall e2e: real MCP client vs live MCP servers/gateway --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,9 +642,19 @@ jobs:
           fi
           # Keep the probe deadline shorter than the job timeout and terminate
           # the process group so a blocked DNS/TLS/transport cannot leak.
-          timeout --signal=TERM --kill-after=60s 15m \
-            vx cargo test -p dcc-mcp-server --features sentry sentry_real_ingest_e2e \
-            -- --exact --test-threads=1 --nocapture
+          output_file="$(mktemp)"
+          trap 'rm -f "$output_file"' EXIT
+          if ! timeout --signal=TERM --kill-after=60s 15m \
+            vx cargo test -p dcc-mcp-server --features sentry \
+            sentry_init::tests::sentry_real_ingest_e2e \
+            -- --exact --test-threads=1 --nocapture 2>&1 | tee "$output_file"; then
+            echo "::error::Sentry real-ingest test command failed"
+            exit 1
+          fi
+          if ! grep -Eq 'running [1-9][0-9]* tests?' "$output_file"; then
+            echo "::error::Sentry real-ingest selector ran zero tests"
+            exit 1
+          fi
 
   # -- mcpcall e2e: real MCP client vs live MCP servers/gateway --
   # Exercises the full HTTP stack from outside the process:

--- a/tests/test_sentry_workflow.py
+++ b/tests/test_sentry_workflow.py
@@ -1,0 +1,23 @@
+"""CI contract for the bounded real-ingest Sentry probe."""
+
+from __future__ import annotations
+
+import re
+
+from conftest import REPO_ROOT
+
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_sentry_real_ingest_job_has_bounded_process_and_job_deadlines() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(r"(?ms)^  sentry-e2e:\n(.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", workflow)
+    assert match is not None
+    job = match.group(1)
+
+    assert "timeout-minutes: 20" in job
+    command_match = re.search(r"(?ms)^      - name: Run Sentry real-ingest E2E\n(.*?)(?=^      - |\Z)", job)
+    assert command_match is not None
+    command = command_match.group(1)
+    assert "timeout --signal=TERM --kill-after=60s 15m" in command
+    assert "sentry_real_ingest_e2e" in command

--- a/tests/test_sentry_workflow.py
+++ b/tests/test_sentry_workflow.py
@@ -9,15 +9,33 @@ from conftest import REPO_ROOT
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 
-def test_sentry_real_ingest_job_has_bounded_process_and_job_deadlines() -> None:
+def _sentry_e2e_job() -> str:
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     match = re.search(r"(?ms)^  sentry-e2e:\n(.*?)(?=^  [a-zA-Z0-9_-]+:|\Z)", workflow)
     assert match is not None
-    job = match.group(1)
+    return match.group(1)
 
-    assert "timeout-minutes: 20" in job
+
+def _sentry_e2e_command() -> str:
+    job = _sentry_e2e_job()
     command_match = re.search(r"(?ms)^      - name: Run Sentry real-ingest E2E\n(.*?)(?=^      - |\Z)", job)
     assert command_match is not None
-    command = command_match.group(1)
+    return command_match.group(1)
+
+
+def test_sentry_real_ingest_job_has_bounded_process_and_job_deadlines() -> None:
+    job = _sentry_e2e_job()
+    assert "timeout-minutes: 20" in job
+    command = _sentry_e2e_command()
     assert "timeout --signal=TERM --kill-after=60s 15m" in command
     assert "sentry_real_ingest_e2e" in command
+
+
+def test_sentry_real_ingest_job_requires_the_target_test_to_run() -> None:
+    command = _sentry_e2e_command()
+
+    # The test is nested under `sentry_init::tests`; a bare selector can
+    # produce a green cargo-test exit status while running zero tests.
+    assert "sentry_init::tests::sentry_real_ingest_e2e" in command
+    assert re.search(r"grep\s+-Eq\s+['\"]running \[1-9\]\[0-9\]\* tests?", command)
+    assert "exit 1" in command


### PR DESCRIPTION
## Summary
- bound the sentry-e2e job to 20 minutes
- bound the real-ingest cargo probe to 15 minutes and terminate it after a 60-second grace period
- add a workflow contract test covering both deadlines and the probe command

## Validation
- python -m pytest tests/test_sentry_workflow.py tests/test_workflow_spec.py -q (8 passed)
- uff check tests/test_sentry_workflow.py
- YAML parse check passed
- cargo fmt --all -- --check passed via push hook

## Context
This is an independent CI maintenance PR. It is a prerequisite for unblocking long-running Sentry checks seen in Core PRs #2391, #2334, and #2392. It does not modify recipe or runtime product code.