### PR TITLE
fix(recipes): harden schema admission boundaries

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -1281,24 +1281,29 @@ mod tests {
         assert!(
             runner
                 .registry
-                .list_instances(GATEWAY_SENTINEL_DCC_TYPE)
+                .list_instances_async(GATEWAY_SENTINEL_DCC_TYPE.to_string())
+                .await
+                .unwrap()
                 .is_empty(),
             "challenger must not publish a sentinel before startup readback"
         );
 
         ready_tx.send(true).unwrap();
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
-        while runner
-            .registry
-            .list_instances(GATEWAY_SENTINEL_DCC_TYPE)
-            .is_empty()
-        {
-            assert!(tokio::time::Instant::now() < deadline);
-            // Leave the blocking registry worker enough time to acquire the
-            // in-process write lock. A tight synchronous read loop can starve
-            // the registration it is waiting to observe on loaded runners.
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        tokio::time::timeout(Duration::from_secs(30), async {
+            while runner
+                .registry
+                .list_instances_async(GATEWAY_SENTINEL_DCC_TYPE.to_string())
+                .await
+                .unwrap()
+                .is_empty()
+            {
+                // Avoid monopolizing the current-thread runtime or registry
+                // storage lock when nextest runs the workspace under load.
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("challenger sentinel should appear after startup readback");
         challenger.abort();
         drop(occupied);
     }

--- a/docs/api/recipes.md
+++ b/docs/api/recipes.md
@@ -65,13 +65,15 @@ validate_recipe_inputs(recipe, inputs) -> list[str]
 ```
 
 `validate_recipe_inputs` evaluates the published `inputs_schema` as a
-Draft 2020-12 contract (including nested/root JSON-Pointer `$ref`, bounds,
+Draft 2020-12 contract (including same-resource nested/root JSON-Pointer `$ref`, bounds,
 enums/constants, `additionalProperties`, `unevaluatedProperties`/
 `unevaluatedItems`, and composition such as `oneOf`). Applicator annotations
 are merged before unevaluated assertions are applied. It is implemented in
 Core without a runtime `jsonschema` dependency. Malformed or resource-heavy
 schemas (over 128 schema nesting levels, 10,000 schema nodes, or 1 MiB of JSON)
 fail closed; instance validation has the same bounded-depth/node behavior.
+Resource identifiers (`$id`) and dynamic references are not admitted until
+resource-relative scope is implemented; schemas using them fail closed.
 Returned errors are path-oriented without echoing input values.
 
 ## register_recipes_tools

--- a/llms.txt
+++ b/llms.txt
@@ -678,7 +678,7 @@ Rust `dcc_mcp_models::DccMcpError` enum.
 - `get_recipe_content(recipes_path, anchor) -> str | None` — fetch content of a specific anchor section
 - `load_recipe_pack(path) -> list[RecipeDefinition]` — load YAML `recipes:` packs with inputs schema, steps, output contract, and provenance (#616)
 - `list_recipe_entries(skill_metadata) -> list[dict]` / `find_recipe_entry(skill_metadata, name)` — merge Markdown anchors and structured recipe pack entries
-- `validate_recipe_inputs(recipe, inputs) -> list[str]` — Core-owned, zero-runtime-dependency Draft 2020-12 validation for recipe input schemas; malformed schemas fail closed and errors are path-oriented/redacted
+- `validate_recipe_inputs(recipe, inputs) -> list[str]` — Core-owned, zero-runtime-dependency Draft 2020-12 validation for recipe input schemas with same-resource local `$ref`; `$id`/dynamic references and malformed schemas fail closed, and errors are path-oriented/redacted
 - `register_recipes_tools(server, *, skills, dcc_name="dcc")` — register `recipes__list/search/get/validate/apply` tools
 - `register_metadata_driven_tools(server, *, skills=None, extra_paths=None, registrations=None, dcc_name="dcc")` — one helper for optional metadata-driven tools; defaults to recipes + skill reference docs and returns `MetadataRegistrationReport`
 

--- a/python/dcc_mcp_core/_runtime/recipe_schema.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema.py
@@ -44,6 +44,7 @@ class _RecipeSchemaValidator:
     _MAX_SCHEMA_NODES: ClassVar[int] = 10000
     _MAX_SCHEMA_SIZE: ClassVar[int] = 1_000_000
     _MAX_INSTANCE_SIZE: ClassVar[int] = 1_000_000
+    _SUPPORTED_DIALECT: ClassVar[str] = "https://json-schema.org/draft/2020-12/schema"
     _SUPPORTED_KEYWORDS: ClassVar[set[str]] = {
         "$schema",
         "$anchor",
@@ -124,11 +125,6 @@ class _RecipeSchemaValidator:
         self._validate(instance, self.schema, "$", errors, set(), 0)
         return errors
 
-    def _clone_annotations(self) -> dict[str, dict[str, set[Any]]]:
-        return {
-            kind: {path: set(values) for path, values in paths.items()} for kind, paths in self._annotations.items()
-        }
-
     @staticmethod
     def _empty_annotations() -> dict[str, dict[str, set[Any]]]:
         return {"properties": {}, "items": {}}
@@ -156,6 +152,10 @@ class _RecipeSchemaValidator:
             # keywords) must fail closed instead of being silently ignored.
             # In particular, $id remains unsupported until resource-relative
             # reference scope is implemented for every nested schema.
+            raise ValueError(path)
+        if "$schema" in schema and (
+            depth != 0 or not isinstance(schema["$schema"], str) or schema["$schema"] != cls._SUPPORTED_DIALECT
+        ):
             raise ValueError(path)
         # Dynamic references require runtime scope tracking that this
         # dependency-free validator does not implement. Reject them during
@@ -648,7 +648,7 @@ class _RecipeSchemaValidator:
                 matches = 0
                 for index, item in enumerate(value):
                     base_annotations = self._annotations
-                    self._annotations = self._clone_annotations()
+                    self._annotations = self._empty_annotations()
                     branch_annotations = self._annotations
                     item_valid = self._validate(item, schema["contains"], f"{path}[{index}]", [], resolving, depth + 1)
                     self._annotations = base_annotations

--- a/python/dcc_mcp_core/_runtime/recipe_schema.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema.py
@@ -106,6 +106,8 @@ class _RecipeSchemaValidator:
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError("schema is not JSON data") from exc
         self._check_schema(schema, "$")
+        self._schema_locations: set[tuple[str, ...]] = set()
+        self._collect_schema_locations(schema, ())
         self._collect_anchors(schema, set())
         self._check_refs(schema, set())
 
@@ -286,8 +288,10 @@ class _RecipeSchemaValidator:
         if not ref.startswith("#/"):
             raise ValueError(ref)
         value: Any = self.schema
+        location: list[str] = []
         for component in ref[2:].split("/"):
             component = component.replace("~1", "/").replace("~0", "~")
+            location.append(component)
             if isinstance(value, dict):
                 if component not in value:
                     raise ValueError(ref)
@@ -300,16 +304,18 @@ class _RecipeSchemaValidator:
                 value = value[index]
                 continue
             raise ValueError(ref)
+        if tuple(location) not in self._schema_locations:
+            raise ValueError(ref)
         return value
 
     @classmethod
-    def _schema_children(cls, value: dict[str, Any]) -> list[Any]:
-        """Return only schema-valued children, excluding instance data."""
-        children: list[Any] = []
+    def _schema_child_items(cls, value: dict[str, Any]) -> list[tuple[tuple[str, ...], Any]]:
+        """Return schema-valued children and their relative pointer tokens."""
+        children: list[tuple[tuple[str, ...], Any]] = []
         for key in ("properties", "patternProperties", "$defs", "definitions", "dependentSchemas"):
             mapping = value.get(key)
             if isinstance(mapping, dict):
-                children.extend(mapping.values())
+                children.extend(((key, name), child) for name, child in mapping.items())
         for key in (
             "additionalProperties",
             "unevaluatedProperties",
@@ -323,12 +329,24 @@ class _RecipeSchemaValidator:
             "else",
         ):
             if key in value:
-                children.append(value[key])
+                children.append(((key,), value[key]))
         for key in ("prefixItems", "allOf", "anyOf", "oneOf"):
             items = value.get(key)
             if isinstance(items, list):
-                children.extend(items)
+                children.extend(((key, str(index)), child) for index, child in enumerate(items))
         return children
+
+    @classmethod
+    def _schema_children(cls, value: dict[str, Any]) -> list[Any]:
+        """Return only schema-valued children, excluding instance data."""
+        return [child for _tokens, child in cls._schema_child_items(value)]
+
+    def _collect_schema_locations(self, value: Any, location: tuple[str, ...]) -> None:
+        """Record every location admitted recursively as a schema node."""
+        self._schema_locations.add(location)
+        if isinstance(value, dict):
+            for tokens, child in self._schema_child_items(value):
+                self._collect_schema_locations(child, location + tokens)
 
     def _collect_anchors(self, value: Any, seen: set[int]) -> None:
         if isinstance(value, dict):

--- a/python/dcc_mcp_core/_runtime/recipe_schema.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema.py
@@ -46,7 +46,6 @@ class _RecipeSchemaValidator:
     _MAX_INSTANCE_SIZE: ClassVar[int] = 1_000_000
     _SUPPORTED_KEYWORDS: ClassVar[set[str]] = {
         "$schema",
-        "$id",
         "$anchor",
         "$ref",
         "$defs",
@@ -153,6 +152,8 @@ class _RecipeSchemaValidator:
         if unsupported:
             # Unsupported assertion vocabularies (format/content and unknown
             # keywords) must fail closed instead of being silently ignored.
+            # In particular, $id remains unsupported until resource-relative
+            # reference scope is implemented for every nested schema.
             raise ValueError(path)
         # Dynamic references require runtime scope tracking that this
         # dependency-free validator does not implement. Reject them during

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -469,7 +469,7 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
                 nullable = _quantifier_allows_zero(pattern, atom_end)
                 leading_quantified = first_consumers.copy()
                 trailing_quantified = last_consumers.copy()
-            elif alternation_ambiguous:
+            elif alternation_ambiguous or (nullable and not first_consumers.is_empty()):
                 leading_ambiguous.update(first_consumers)
                 trailing_ambiguous.update(last_consumers)
             if frames[-1].add_atom(

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
 
 def pattern_is_safe(pattern: str) -> bool:
     """Accept only patterns whose backtracking structure is provably linear.
@@ -12,18 +10,18 @@ def pattern_is_safe(pattern: str) -> bool:
     Python 3.7. A flat textual blacklist is insufficient (for example,
     ``((ab)*)*$`` hides a nested quantifier behind two groups), so this
     scanner tracks the structure of every group and quantifier. Any
-    quantifier applied to a quantified or alternated atom, and every
-    backreference, is rejected before instance text reaches ``re.search``.
+    quantifier applied to a quantified atom, ambiguous alternation boundaries,
+    and every backreference are rejected before instance text reaches
+    ``re.search``.
     """
-    # Each frame records whether its group already contains a quantifier or
-    # an alternation. The preceding atom carries the same metadata when a
-    # closing parenthesis makes the group quantifiable.
-    frames: list[tuple[bool, bool, int]] = []
+    # Each frame records whether its group already contains a quantifier. The
+    # preceding atom carries the same metadata when a closing parenthesis makes
+    # the group quantifiable. Alternation ambiguity is handled by the boundary
+    # scan below, which has the actual consumer sets for every branch.
+    frames: list[bool] = []
     frame_has_quantifier = False
-    frame_has_alternation = False
     atom_present = False
     atom_has_quantifier = False
-    atom_has_alternation = False
     quantifier_pending = False
     in_character_class = False
     character_class_has_item = False
@@ -35,7 +33,7 @@ def pattern_is_safe(pattern: str) -> bool:
         nonlocal frame_has_quantifier
         nonlocal atom_has_quantifier
         nonlocal quantifier_pending
-        if not atom_present or atom_has_quantifier or atom_has_alternation:
+        if not atom_present or atom_has_quantifier:
             return False
         frame_has_quantifier = True
         atom_has_quantifier = True
@@ -56,7 +54,6 @@ def pattern_is_safe(pattern: str) -> bool:
                 character_class_may_negate = False
             atom_present = True
             atom_has_quantifier = False
-            atom_has_alternation = False
             quantifier_pending = False
             index += 1
             continue
@@ -76,7 +73,6 @@ def pattern_is_safe(pattern: str) -> bool:
                 character_class_may_negate = False
             atom_present = True
             atom_has_quantifier = False
-            atom_has_alternation = False
             quantifier_pending = False
             index += 1
             continue
@@ -86,7 +82,6 @@ def pattern_is_safe(pattern: str) -> bool:
             character_class_may_negate = True
             atom_present = True
             atom_has_quantifier = False
-            atom_has_alternation = False
             quantifier_pending = False
             index += 1
             continue
@@ -96,20 +91,16 @@ def pattern_is_safe(pattern: str) -> bool:
             # in this deliberately small safety grammar.
             if pattern.startswith("(?P=", index):
                 return False
-            frames.append((frame_has_quantifier, frame_has_alternation, index))
+            frames.append(frame_has_quantifier)
             frame_has_quantifier = False
-            frame_has_alternation = False
             atom_present = False
             atom_has_quantifier = False
-            atom_has_alternation = False
             quantifier_pending = False
             index += 1
             continue
         if character == "|":
-            frame_has_alternation = True
             atom_present = False
             atom_has_quantifier = False
-            atom_has_alternation = False
             quantifier_pending = False
             index += 1
             continue
@@ -117,19 +108,11 @@ def pattern_is_safe(pattern: str) -> bool:
             if not frames:
                 return False
             group_has_quantifier = frame_has_quantifier
-            group_has_alternation = frame_has_alternation
-            _, _, group_start = frames[-1]
-            frame_has_quantifier, frame_has_alternation, _ = frames.pop()
-            # Preserve nested structure in the enclosing group. Without
-            # this propagation, ``((a|b)c)+`` would hide its alternation
-            # behind an inner pair of parentheses.
+            frame_has_quantifier = frames.pop()
+            # Preserve nested quantifiers in the enclosing group.
             frame_has_quantifier = frame_has_quantifier or group_has_quantifier
-            frame_has_alternation = frame_has_alternation or group_has_alternation
             atom_present = True
             atom_has_quantifier = group_has_quantifier
-            atom_has_alternation = group_has_alternation and not _linear_alternation_group(
-                pattern[group_start + 1 : index]
-            )
             quantifier_pending = False
             index += 1
             continue
@@ -148,7 +131,6 @@ def pattern_is_safe(pattern: str) -> bool:
                 # not quantifiers; ``re.compile`` validates them.
                 atom_present = True
                 atom_has_quantifier = False
-                atom_has_alternation = False
                 quantifier_pending = False
             index += 1
             continue
@@ -164,27 +146,72 @@ def pattern_is_safe(pattern: str) -> bool:
         # single regular atoms.
         atom_present = True
         atom_has_quantifier = False
-        atom_has_alternation = False
         quantifier_pending = False
         index += 1
     # Draft ``pattern`` uses search semantics and therefore does not require
     # anchors. The structural scan above and adjacent-quantifier check below
     # keep the accepted subset linear on Python's backtracking engine.
-    # Unanchored quantified groups/classes can trigger expensive search
-    # retries at every offset. Keep Draft search semantics for literals and
-    # simple quantified atoms, while conservatively rejecting this higher-risk
-    # subset before invoking ``re.search``.
-    unanchored_complex = not pattern.startswith("^") and (
-        re.search(r"[)\]](?:[*+?]|\{(?:\d+(?:,\d*)?|,\d*)\})", pattern) is not None
-        or re.search(r"\([^)]*[+*?{][^)]*\)", pattern) is not None
-    )
+    # Search retries an unanchored quantified path at every candidate offset.
+    # Preserve Draft search semantics for unquantified patterns, but require
+    # every top-level path to carry an absolute-start anchor once any
+    # quantifier is present.
+    unanchored_quantified = frame_has_quantifier and not _all_top_level_paths_anchored(pattern)
     return (
         not escaped
         and not in_character_class
         and not frames
-        and not unanchored_complex
+        and not unanchored_quantified
         and not _has_adjacent_quantifiers(pattern)
     )
+
+
+def _all_top_level_paths_anchored(pattern: str) -> bool:
+    """Return whether every top-level alternative starts at the string root."""
+    branch_start = 0
+    depth = 0
+    escaped = False
+    in_class = False
+    class_has_item = False
+    for index, character in enumerate(pattern):
+        if escaped:
+            escaped = False
+            continue
+        if character == "\\":
+            escaped = True
+            continue
+        if in_class:
+            if character == "]" and class_has_item:
+                in_class = False
+            else:
+                class_has_item = True
+            continue
+        if character == "[":
+            in_class = True
+            class_has_item = False
+        elif character == "(":
+            depth += 1
+        elif character == ")" and depth:
+            depth -= 1
+        elif character == "|" and depth == 0:
+            if not _branch_starts_at_root(pattern[branch_start:index]):
+                return False
+            branch_start = index + 1
+    return _branch_starts_at_root(pattern[branch_start:])
+
+
+def _branch_starts_at_root(branch: str) -> bool:
+    r"""Recognize a leading global flag/comment group followed by ``^``/``\A``."""
+    cursor = 0
+    while branch.startswith("(?", cursor):
+        content_start, zero_width, _, supported = _group_content_start(
+            branch,
+            cursor + 1,
+            parent_ignore_case=False,
+        )
+        if not supported or not zero_width or content_start >= len(branch) or branch[content_start] != ")":
+            break
+        cursor = content_start + 1
+    return branch.startswith("^", cursor) or branch.startswith(r"\A", cursor)
 
 
 class _ConsumerSet:
@@ -211,9 +238,18 @@ class _ConsumerSet:
 
     @classmethod
     def literal(cls, codepoint: int, *, ignore_case: bool = False) -> _ConsumerSet:
-        """Return one literal code point, or an unknown fold when needed."""
-        if ignore_case:
+        """Return one literal and its bounded case-insensitive closure."""
+        if ignore_case and codepoint >= cls._ASCII_LIMIT:
             return cls.any_character()
+        if ignore_case and (ord("A") <= codepoint <= ord("Z") or ord("a") <= codepoint <= ord("z")):
+            lower = ord(chr(codepoint).lower())
+            upper = ord(chr(codepoint).upper())
+            extras = {
+                ord("i"): {0x0130, 0x0131},
+                ord("k"): {0x212A},
+                ord("s"): {0x017F},
+            }.get(lower, set())
+            return cls((1 << lower) | (1 << upper), extras)
         if codepoint < cls._ASCII_LIMIT:
             return cls(1 << codepoint)
         return cls(non_ascii_literals={codepoint})
@@ -234,11 +270,15 @@ class _ConsumerSet:
 
     def add_range(self, start: int, end: int, *, ignore_case: bool = False) -> None:
         """Add a class range without expanding an unbounded Unicode interval."""
-        if ignore_case:
-            self.update(self.any_character())
-            return
         if start > end:
             self.update(self.any_character())
+            return
+        if ignore_case:
+            if end >= self._ASCII_LIMIT:
+                self.update(self.any_character())
+                return
+            for codepoint in range(start, end + 1):
+                self.update(self.literal(codepoint, ignore_case=True))
             return
         ascii_start = max(start, 0)
         ascii_end = min(end, self._ASCII_LIMIT - 1)
@@ -282,17 +322,24 @@ class _ConsumerSet:
 class _BoundaryFrame:
     """Track consuming and quantified edges for one sequence or group."""
 
-    def __init__(self, *, zero_width: bool = False) -> None:
+    def __init__(self, *, zero_width: bool = False, ignore_case: bool = False) -> None:
         self.zero_width = zero_width
+        self.ignore_case = ignore_case
         self.first_consumers = _ConsumerSet()
         self.last_consumers = _ConsumerSet()
         self.leading_quantified = _ConsumerSet()
         self.trailing_quantified = _ConsumerSet()
+        self.leading_ambiguous = _ConsumerSet()
+        self.trailing_ambiguous = _ConsumerSet()
+        self.alternation_ambiguous = False
+        self.branch_count = 0
         self.nullable = False
         self.branch_first = _ConsumerSet()
         self.branch_last = _ConsumerSet()
         self.branch_leading_quantified = _ConsumerSet()
         self.branch_trailing_quantified = _ConsumerSet()
+        self.branch_leading_ambiguous = _ConsumerSet()
+        self.branch_trailing_ambiguous = _ConsumerSet()
         self.branch_nullable = True
 
     def add_atom(
@@ -303,78 +350,136 @@ class _BoundaryFrame:
         nullable: bool,
         leading_quantified: _ConsumerSet,
         trailing_quantified: _ConsumerSet,
+        leading_ambiguous: _ConsumerSet,
+        trailing_ambiguous: _ConsumerSet,
     ) -> bool:
-        """Add one atom and report an ambiguous quantified boundary."""
+        """Add one atom and report an unsafe quantified/ambiguous boundary."""
         if self.branch_trailing_quantified.overlaps(leading_quantified):
+            return True
+        if self.branch_trailing_ambiguous.overlaps(leading_ambiguous):
             return True
         prefix_nullable = self.branch_nullable
         if prefix_nullable:
             self.branch_first.update(first_consumers)
             self.branch_leading_quantified.update(leading_quantified)
+            self.branch_leading_ambiguous.update(leading_ambiguous)
         if nullable:
             self.branch_last.update(last_consumers)
             self.branch_trailing_quantified.update(trailing_quantified)
+            self.branch_trailing_ambiguous.update(trailing_ambiguous)
         else:
             self.branch_last = last_consumers.copy()
             self.branch_trailing_quantified = trailing_quantified.copy()
+            self.branch_trailing_ambiguous = trailing_ambiguous.copy()
         self.branch_nullable = prefix_nullable and nullable
         return False
 
     def end_branch(self) -> None:
         """Merge the current alternative into the group's edge summary."""
+        if self.branch_count and self.first_consumers.overlaps(self.branch_first):
+            self.alternation_ambiguous = True
         self.first_consumers.update(self.branch_first)
         self.last_consumers.update(self.branch_last)
         self.leading_quantified.update(self.branch_leading_quantified)
         self.trailing_quantified.update(self.branch_trailing_quantified)
+        self.leading_ambiguous.update(self.branch_leading_ambiguous)
+        self.trailing_ambiguous.update(self.branch_trailing_ambiguous)
         self.nullable = self.nullable or self.branch_nullable
+        self.branch_count += 1
         self.branch_first = _ConsumerSet()
         self.branch_last = _ConsumerSet()
         self.branch_leading_quantified = _ConsumerSet()
         self.branch_trailing_quantified = _ConsumerSet()
+        self.branch_leading_ambiguous = _ConsumerSet()
+        self.branch_trailing_ambiguous = _ConsumerSet()
         self.branch_nullable = True
 
-    def finish(self) -> tuple[_ConsumerSet, _ConsumerSet, bool, _ConsumerSet, _ConsumerSet]:
+    def finish(
+        self,
+    ) -> tuple[
+        _ConsumerSet,
+        _ConsumerSet,
+        bool,
+        _ConsumerSet,
+        _ConsumerSet,
+        _ConsumerSet,
+        _ConsumerSet,
+        bool,
+    ]:
         """Return the group's consuming and quantified edge summary."""
         self.end_branch()
         if self.zero_width:
-            return _ConsumerSet(), _ConsumerSet(), True, _ConsumerSet(), _ConsumerSet()
+            return (
+                _ConsumerSet(),
+                _ConsumerSet(),
+                True,
+                _ConsumerSet(),
+                _ConsumerSet(),
+                _ConsumerSet(),
+                _ConsumerSet(),
+                False,
+            )
         return (
             self.first_consumers,
             self.last_consumers,
             self.nullable,
             self.leading_quantified,
             self.trailing_quantified,
+            self.leading_ambiguous,
+            self.trailing_ambiguous,
+            self.alternation_ambiguous,
         )
 
 
 def _has_adjacent_quantifiers(pattern: str) -> bool:
-    """Detect adjacent quantified atoms in one linear structural pass."""
-    frames = [_BoundaryFrame()]
-    ignore_case = _pattern_may_ignore_case(pattern)
+    """Detect unsafe quantified and ambiguous boundaries in one pass."""
+    frames = [_BoundaryFrame(ignore_case=_leading_global_ignore_case(pattern))]
     index = 0
     while index < len(pattern):
         character = pattern[index]
         if character == "(":
-            content_start, zero_width = _group_content_start(pattern, index + 1)
-            frames.append(_BoundaryFrame(zero_width=zero_width))
+            content_start, zero_width, ignore_case, supported = _group_content_start(
+                pattern,
+                index + 1,
+                parent_ignore_case=frames[-1].ignore_case,
+            )
+            if not supported:
+                return True
+            frames.append(_BoundaryFrame(zero_width=zero_width, ignore_case=ignore_case))
             index = content_start
             continue
         if character == ")":
             if len(frames) == 1:
                 return False
-            first_consumers, last_consumers, nullable, leading_quantified, trailing_quantified = frames.pop().finish()
+            (
+                first_consumers,
+                last_consumers,
+                nullable,
+                leading_quantified,
+                trailing_quantified,
+                leading_ambiguous,
+                trailing_ambiguous,
+                alternation_ambiguous,
+            ) = frames.pop().finish()
             atom_end = index + 1
             quantifier_end = _quantifier_end(pattern, atom_end)
             if quantifier_end > atom_end:
+                if alternation_ambiguous:
+                    return True
                 nullable = nullable or _quantifier_allows_zero(pattern, atom_end)
                 leading_quantified = first_consumers.copy()
                 trailing_quantified = last_consumers.copy()
+            elif alternation_ambiguous:
+                leading_ambiguous.update(first_consumers)
+                trailing_ambiguous.update(last_consumers)
             if frames[-1].add_atom(
                 first_consumers,
                 last_consumers,
                 nullable=nullable,
                 leading_quantified=leading_quantified,
                 trailing_quantified=trailing_quantified,
+                leading_ambiguous=leading_ambiguous,
+                trailing_ambiguous=trailing_ambiguous,
             ):
                 return True
             index = quantifier_end
@@ -390,15 +495,25 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
                 nullable=True,
                 leading_quantified=_ConsumerSet(),
                 trailing_quantified=_ConsumerSet(),
+                leading_ambiguous=_ConsumerSet(),
+                trailing_ambiguous=_ConsumerSet(),
             ):
                 return True
             index += 1
             continue
 
         if character == "\\":
-            atom_end, consumers, zero_width = _escaped_consumer(pattern, index, ignore_case=ignore_case)
+            atom_end, consumers, zero_width = _escaped_consumer(
+                pattern,
+                index,
+                ignore_case=frames[-1].ignore_case,
+            )
         elif character == "[":
-            atom_end, consumers = _character_class_consumer(pattern, index, ignore_case=ignore_case)
+            atom_end, consumers = _character_class_consumer(
+                pattern,
+                index,
+                ignore_case=frames[-1].ignore_case,
+            )
             zero_width = False
         elif character == ".":
             atom_end = index + 1
@@ -406,7 +521,7 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
             zero_width = False
         else:
             atom_end = index + 1
-            consumers = _ConsumerSet.literal(ord(character), ignore_case=ignore_case)
+            consumers = _ConsumerSet.literal(ord(character), ignore_case=frames[-1].ignore_case)
             zero_width = False
 
         quantifier_end = _quantifier_end(pattern, atom_end)
@@ -419,56 +534,41 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
             nullable=nullable,
             leading_quantified=quantified_consumers,
             trailing_quantified=quantified_consumers,
+            leading_ambiguous=_ConsumerSet(),
+            trailing_ambiguous=_ConsumerSet(),
         ):
             return True
         index = quantifier_end
     return False
 
 
-def _pattern_may_ignore_case(pattern: str) -> bool:
-    """Return whether any inline flag enables case-insensitive matching."""
-    escaped = False
-    in_class = False
-    class_has_item = False
-    class_may_negate = False
-    index = 0
-    while index < len(pattern):
-        character = pattern[index]
-        if escaped:
-            escaped = False
-            if in_class:
-                class_has_item = True
-                class_may_negate = False
-            index += 1
-            continue
-        if character == "\\":
-            escaped = True
-            index += 1
-            continue
-        if in_class:
-            if character == "^" and class_may_negate:
-                class_may_negate = False
-            elif character == "]" and class_has_item:
-                in_class = False
-            else:
-                class_has_item = True
-                class_may_negate = False
-            index += 1
-            continue
-        if character == "[":
-            in_class = True
-            class_has_item = False
-            class_may_negate = True
-            index += 1
-            continue
-        if pattern.startswith("(?", index):
-            cursor = index + 2
-            while cursor < len(pattern) and pattern[cursor] in "aiLmsux-":
-                if pattern[cursor] == "i" and "-" not in pattern[index + 2 : cursor]:
-                    return True
-                cursor += 1
-        index += 1
-    return False
+def _leading_global_ignore_case(pattern: str) -> bool:
+    """Return the supported leading global case-fold state."""
+    if not pattern.startswith("(?"):
+        return False
+    content_start, zero_width, ignore_case, supported = _group_content_start(
+        pattern,
+        1,
+        parent_ignore_case=False,
+    )
+    if not supported or not zero_width or content_start >= len(pattern):
+        return False
+    return ignore_case if pattern[content_start] == ")" else False
+
+
+def _apply_inline_case_flag(flag_spec: str, parent_ignore_case: bool) -> tuple[bool, bool]:
+    """Apply an ``i``/``-i`` flag spec and reject unsupported flag syntax."""
+    if not flag_spec or flag_spec.count("-") > 1:
+        return parent_ignore_case, False
+    enabled, _, disabled = flag_spec.partition("-")
+    if any(flag != "i" for flag in enabled + disabled):
+        return parent_ignore_case, False
+    ignore_case = parent_ignore_case
+    if "i" in enabled:
+        ignore_case = True
+    if "i" in disabled:
+        ignore_case = False
+    return ignore_case, True
 
 
 _ASCII_DIGIT_MASK = ((1 << 10) - 1) << ord("0")
@@ -572,26 +672,40 @@ def _class_element(
     return index + 1, _ConsumerSet.literal(ord(pattern[index]), ignore_case=ignore_case)
 
 
-def _group_content_start(pattern: str, start: int) -> tuple[int, bool]:
-    """Skip zero-width group prefix syntax and return the content offset."""
+def _group_content_start(
+    pattern: str,
+    start: int,
+    *,
+    parent_ignore_case: bool,
+) -> tuple[int, bool, bool, bool]:
+    """Return group content, width, scoped case-fold state, and support."""
     for prefix in ("?:", "?=", "?!", "?<=", "?<!", "?>"):
         if pattern.startswith(prefix, start):
-            return start + len(prefix), prefix in {"?=", "?!", "?<=", "?<!"}
+            return (
+                start + len(prefix),
+                prefix in {"?=", "?!", "?<=", "?<!"},
+                parent_ignore_case,
+                True,
+            )
     if pattern.startswith("?P<", start):
         name_end = pattern.find(">", start + 3)
-        return (name_end + 1, False) if name_end >= 0 else (start, False)
+        content_start = name_end + 1 if name_end >= 0 else start
+        return content_start, False, parent_ignore_case, True
     if pattern.startswith("?#", start):
         comment_end = pattern.find(")", start + 2)
-        return (comment_end, True) if comment_end >= 0 else (start, True)
+        content_start = comment_end if comment_end >= 0 else start
+        return content_start, True, parent_ignore_case, True
     if start < len(pattern) and pattern[start] == "?":
         cursor = start + 1
         while cursor < len(pattern) and pattern[cursor] in "aiLmsux-":
             cursor += 1
-        if cursor < len(pattern) and pattern[cursor] == ":":
-            return cursor + 1, False
-        if cursor < len(pattern) and pattern[cursor] == ")":
-            return cursor, True
-    return start, False
+        if cursor > start + 1 and cursor < len(pattern) and pattern[cursor] in ":)":
+            ignore_case, supported = _apply_inline_case_flag(
+                pattern[start + 1 : cursor],
+                parent_ignore_case,
+            )
+            return cursor + 1 if pattern[cursor] == ":" else cursor, pattern[cursor] == ")", ignore_case, supported
+    return start, False, parent_ignore_case, True
 
 
 def _quantifier_end(pattern: str, atom_end: int) -> int:
@@ -639,47 +753,3 @@ def _quantifier_allows_zero(pattern: str, atom_end: int) -> bool:
         minimum_end += 1
     minimum = pattern[atom_end + 1 : minimum_end]
     return not minimum or int(minimum) == 0
-
-
-def _linear_alternation_group(body: str) -> bool:
-    """Return whether a group is a disjoint fixed-literal alternation."""
-    for prefix in ("?:", "?=", "?!", "?<=", "?<!", "?>"):
-        if body.startswith(prefix):
-            body = body[len(prefix) :]
-            break
-    branches: list[str] = []
-    start = 0
-    escaped = False
-    depth = 0
-    in_class = False
-    for index, character in enumerate(body):
-        if escaped:
-            escaped = False
-            continue
-        if character == "\\":
-            escaped = True
-            continue
-        if in_class:
-            if character == "]":
-                in_class = False
-            continue
-        if character == "[":
-            in_class = True
-        elif character == "(":
-            depth += 1
-        elif character == ")" and depth:
-            depth -= 1
-        elif character == "|" and depth == 0:
-            branches.append(body[start:index])
-            start = index + 1
-    if in_class or escaped or depth:
-        return False
-    branches.append(body[start:])
-    if len(branches) < 2:
-        return False
-    tokens: list[str] = []
-    for branch in branches:
-        if not branch or any(character in "\\[](){}*+?^$|." for character in branch):
-            return False
-        tokens.append(branch[0])
-    return len(set(tokens)) == len(tokens)

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -485,7 +485,7 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
             atom_end = index + 1
             quantifier_end = _quantifier_end(pattern, atom_end)
             if quantifier_end > atom_end:
-                if nullable or alternation_ambiguous:
+                if nullable or alternation_ambiguous or leading_ambiguous.overlaps(trailing_ambiguous):
                     return True
                 nullable = _quantifier_allows_zero(pattern, atom_end)
                 leading_quantified = first_consumers.copy()

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -464,9 +464,9 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
             atom_end = index + 1
             quantifier_end = _quantifier_end(pattern, atom_end)
             if quantifier_end > atom_end:
-                if alternation_ambiguous:
+                if nullable or alternation_ambiguous:
                     return True
-                nullable = nullable or _quantifier_allows_zero(pattern, atom_end)
+                nullable = _quantifier_allows_zero(pattern, atom_end)
                 leading_quantified = first_consumers.copy()
                 trailing_quantified = last_consumers.copy()
             elif alternation_ambiguous:
@@ -695,6 +695,8 @@ def _group_content_start(
         comment_end = pattern.find(")", start + 2)
         content_start = comment_end if comment_end >= 0 else start
         return content_start, True, parent_ignore_case, True
+    if pattern.startswith("?(", start):
+        return start, False, parent_ignore_case, False
     if start < len(pattern) and pattern[start] == "?":
         cursor = start + 1
         while cursor < len(pattern) and pattern[cursor] in "aiLmsux-":

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -268,6 +268,19 @@ class _ConsumerSet:
         self.non_ascii_literals.update(other.non_ascii_literals)
         self.non_ascii_unknown = self.non_ascii_unknown or other.non_ascii_unknown
 
+    def intersection(self, other: _ConsumerSet) -> _ConsumerSet:
+        """Return the conservative intersection with another consumer set."""
+        non_ascii_literals = self.non_ascii_literals.intersection(other.non_ascii_literals)
+        if self.non_ascii_unknown:
+            non_ascii_literals.update(other.non_ascii_literals)
+        if other.non_ascii_unknown:
+            non_ascii_literals.update(self.non_ascii_literals)
+        return _ConsumerSet(
+            self.ascii_mask & other.ascii_mask,
+            non_ascii_literals,
+            non_ascii_unknown=self.non_ascii_unknown and other.non_ascii_unknown,
+        )
+
     def add_range(self, start: int, end: int, *, ignore_case: bool = False) -> None:
         """Add a class range without expanding an unbounded Unicode interval."""
         if start > end:
@@ -358,6 +371,11 @@ class _BoundaryFrame:
             return True
         if self.branch_trailing_ambiguous.overlaps(leading_ambiguous):
             return True
+        # A fixed atom only separates quantified regions where its consuming
+        # path is disjoint; retain code points that can enter and leave it.
+        connected_quantified = self.branch_trailing_quantified.intersection(first_consumers).intersection(
+            last_consumers
+        )
         prefix_nullable = self.branch_nullable
         if prefix_nullable:
             self.branch_first.update(first_consumers)
@@ -370,6 +388,7 @@ class _BoundaryFrame:
         else:
             self.branch_last = last_consumers.copy()
             self.branch_trailing_quantified = trailing_quantified.copy()
+            self.branch_trailing_quantified.update(connected_quantified)
             self.branch_trailing_ambiguous = trailing_ambiguous.copy()
         self.branch_nullable = prefix_nullable and nullable
         return False

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -371,11 +371,12 @@ class _BoundaryFrame:
             return True
         if self.branch_trailing_ambiguous.overlaps(leading_ambiguous):
             return True
-        # A fixed atom only separates quantified regions where its consuming
-        # path is disjoint; retain code points that can enter and leave it.
+        # A fixed atom only separates tracked regions where its consuming path
+        # is disjoint; retain code points that can enter and leave it.
         connected_quantified = self.branch_trailing_quantified.intersection(first_consumers).intersection(
             last_consumers
         )
+        connected_ambiguous = self.branch_trailing_ambiguous.intersection(first_consumers).intersection(last_consumers)
         prefix_nullable = self.branch_nullable
         if prefix_nullable:
             self.branch_first.update(first_consumers)
@@ -390,6 +391,7 @@ class _BoundaryFrame:
             self.branch_trailing_quantified = trailing_quantified.copy()
             self.branch_trailing_quantified.update(connected_quantified)
             self.branch_trailing_ambiguous = trailing_ambiguous.copy()
+            self.branch_trailing_ambiguous.update(connected_ambiguous)
         self.branch_nullable = prefix_nullable and nullable
         return False
 

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -179,102 +179,184 @@ def pattern_is_safe(pattern: str) -> bool:
     )
 
 
+class _BoundaryFrame:
+    """Track quantified boundaries for one regex sequence or group."""
+
+    def __init__(self, *, zero_width: bool = False) -> None:
+        self.zero_width = zero_width
+        self.first_tokens: set[str] = set()
+        self.last_tokens: set[str] = set()
+        self.nullable = False
+        self.branch_first: set[str] = set()
+        self.branch_last: set[str] = set()
+        self.branch_nullable = True
+
+    def add_atom(self, first_tokens: set[str], last_tokens: set[str], *, nullable: bool) -> bool:
+        """Add one atom and report whether its leading boundary overlaps."""
+        if _quantifier_boundaries_overlap(self.branch_last, first_tokens):
+            return True
+        if self.branch_nullable:
+            self.branch_first.update(first_tokens)
+        if nullable:
+            self.branch_last.update(last_tokens)
+        else:
+            self.branch_last = set(last_tokens)
+        self.branch_nullable = self.branch_nullable and nullable
+        return False
+
+    def end_branch(self) -> None:
+        """Merge the current alternative into the group's edge summary."""
+        self.first_tokens.update(self.branch_first)
+        self.last_tokens.update(self.branch_last)
+        self.nullable = self.nullable or self.branch_nullable
+        self.branch_first = set()
+        self.branch_last = set()
+        self.branch_nullable = True
+
+    def finish(self) -> tuple[set[str], set[str], bool]:
+        """Return all quantified tokens exposed by the group's outer edges."""
+        self.end_branch()
+        if self.zero_width:
+            return set(), set(), True
+        return self.first_tokens, self.last_tokens, self.nullable
+
+
 def _has_adjacent_quantifiers(pattern: str) -> bool:
-    """Detect adjacent quantified atoms that can overlap or explode."""
-    previous_quantified: str | None = None
-    previous_group_quantified = False
+    """Detect adjacent quantified atoms in one linear structural pass."""
+    frames = [_BoundaryFrame()]
     index = 0
     while index < len(pattern):
         character = pattern[index]
         if character == "(":
-            # Treat a complete group as one atom. The main structural scanner
-            # validates its contents; this pass additionally catches quantified
-            # groups placed next to one another, which otherwise reset state at
-            # each parenthesis and allow exponential alternation backtracking.
-            depth = 1
-            cursor = index + 1
+            content_start, zero_width = _group_content_start(pattern, index + 1)
+            frames.append(_BoundaryFrame(zero_width=zero_width))
+            index = content_start
+            continue
+        if character == ")":
+            if len(frames) == 1:
+                return False
+            first_tokens, last_tokens, nullable = frames.pop().finish()
+            atom_end = index + 1
+            quantifier_end = _quantifier_end(pattern, atom_end)
+            if quantifier_end > atom_end:
+                first_tokens = {"<group>"}
+                last_tokens = first_tokens
+                nullable = nullable or _quantifier_allows_zero(pattern, atom_end)
+            if frames[-1].add_atom(first_tokens, last_tokens, nullable=nullable):
+                return True
+            index = quantifier_end
+            continue
+        if character == "|":
+            frames[-1].end_branch()
+            index += 1
+            continue
+        if character in "^$":
+            index += 1
+            continue
+
+        token = character
+        if character == "\\":
+            atom_end = min(index + 2, len(pattern))
+            token = pattern[index:atom_end]
+        elif character == "[":
+            atom_end = index + 1
             escaped = False
-            in_class = False
-            while cursor < len(pattern) and depth:
-                current = pattern[cursor]
+            while atom_end < len(pattern):
+                current = pattern[atom_end]
                 if escaped:
                     escaped = False
                 elif current == "\\":
                     escaped = True
-                elif in_class:
-                    if current == "]":
-                        in_class = False
-                elif current == "[":
-                    in_class = True
-                elif current == "(":
-                    depth += 1
-                elif current == ")":
-                    depth -= 1
-                cursor += 1
-            if depth or in_class:
-                return False
-            quantifier_end = cursor
-            if quantifier_end < len(pattern) and pattern[quantifier_end] in "*+?":
-                quantifier_end += 1
-            elif quantifier_end < len(pattern) and pattern[quantifier_end] == "{":
-                end = pattern.find("}", quantifier_end + 1)
-                if end >= 0:
-                    quantifier_end = end + 1
-            quantified = quantifier_end > cursor
-            if quantified and (previous_group_quantified or previous_quantified is not None):
-                return True
-            previous_group_quantified = quantified
-            previous_quantified = None
-            index = quantifier_end
-            continue
-        if character == "\\":
-            index += 2
-            previous_quantified = None
-            previous_group_quantified = False
-            continue
-        if character == "[":
-            end = index + 1
-            while end < len(pattern) and pattern[end] != "]":
-                end += 2 if pattern[end] == "\\" else 1
-            atom_end = min(end + 1, len(pattern))
-            quantifier_end = atom_end
-            if quantifier_end < len(pattern) and pattern[quantifier_end] in "*+?":
-                quantifier_end += 1
-            elif quantifier_end < len(pattern) and pattern[quantifier_end] == "{":
-                close = pattern.find("}", quantifier_end + 1)
-                if close >= 0:
-                    quantifier_end = close + 1
-            quantified = quantifier_end > atom_end
-            if quantified and previous_quantified is not None:
-                return True
-            previous_quantified = "<class>" if quantified else None
-            previous_group_quantified = False
-            index = quantifier_end
-            continue
-        if character in "^$|()":
-            previous_quantified = None
-            previous_group_quantified = False
-            index += 1
-            continue
-        token = character
-        quantifier_end = index + 1
-        if quantifier_end < len(pattern) and pattern[quantifier_end] in "*+?":
-            quantifier_end += 1
-        elif quantifier_end < len(pattern) and pattern[quantifier_end] == "{":
-            end = pattern.find("}", quantifier_end + 1)
-            if end >= 0:
-                quantifier_end = end + 1
-        if quantifier_end > index + 1:
-            if previous_group_quantified or (previous_quantified is not None and previous_quantified == token):
-                return True
-            previous_quantified = token
-            previous_group_quantified = False
-            index = quantifier_end
+                elif current == "]":
+                    atom_end += 1
+                    break
+                atom_end += 1
+            token = "<class>"
         else:
-            previous_quantified = None
-            previous_group_quantified = False
-            index += 1
+            atom_end = index + 1
+
+        quantifier_end = _quantifier_end(pattern, atom_end)
+        quantified_tokens = {token} if quantifier_end > atom_end else set()
+        nullable = quantifier_end > atom_end and _quantifier_allows_zero(pattern, atom_end)
+        if frames[-1].add_atom(quantified_tokens, quantified_tokens, nullable=nullable):
+            return True
+        index = quantifier_end
     return False
+
+
+def _quantifier_boundaries_overlap(previous: set[str], current: set[str]) -> bool:
+    """Return whether adjacent quantified boundaries can consume the same text."""
+    if not previous or not current:
+        return False
+    if "<group>" in current:
+        return True
+    if "<class>" in current:
+        return True
+    if "<group>" in previous:
+        return True
+    return bool(previous.intersection(current))
+
+
+def _group_content_start(pattern: str, start: int) -> tuple[int, bool]:
+    """Skip zero-width group prefix syntax and return the content offset."""
+    for prefix in ("?:", "?=", "?!", "?<=", "?<!", "?>"):
+        if pattern.startswith(prefix, start):
+            return start + len(prefix), prefix in {"?=", "?!", "?<=", "?<!"}
+    if pattern.startswith("?P<", start):
+        name_end = pattern.find(">", start + 3)
+        return (name_end + 1, False) if name_end >= 0 else (start, False)
+    if pattern.startswith("?#", start):
+        comment_end = pattern.find(")", start + 2)
+        return (comment_end, True) if comment_end >= 0 else (start, True)
+    if start < len(pattern) and pattern[start] == "?":
+        cursor = start + 1
+        while cursor < len(pattern) and pattern[cursor] in "aiLmsux-":
+            cursor += 1
+        if cursor < len(pattern) and pattern[cursor] == ":":
+            return cursor + 1, False
+        if cursor < len(pattern) and pattern[cursor] == ")":
+            return cursor, True
+    return start, False
+
+
+def _quantifier_end(pattern: str, atom_end: int) -> int:
+    """Return the first offset after an atom's optional quantifier."""
+    if atom_end >= len(pattern):
+        return atom_end
+    character = pattern[atom_end]
+    if character in "*+?":
+        end = atom_end + 1
+    elif character == "{":
+        end = atom_end + 1
+        while end < len(pattern) and pattern[end].isdigit():
+            end += 1
+        if end == atom_end + 1:
+            return atom_end
+        if end < len(pattern) and pattern[end] == ",":
+            end += 1
+            while end < len(pattern) and pattern[end].isdigit():
+                end += 1
+        if end >= len(pattern) or pattern[end] != "}":
+            return atom_end
+        end += 1
+    else:
+        return atom_end
+    if end < len(pattern) and pattern[end] == "?":
+        end += 1
+    return end
+
+
+def _quantifier_allows_zero(pattern: str, atom_end: int) -> bool:
+    """Return whether the quantifier at ``atom_end`` permits zero matches."""
+    character = pattern[atom_end]
+    if character in "*?":
+        return True
+    if character == "+":
+        return False
+    minimum_end = atom_end + 1
+    while minimum_end < len(pattern) and pattern[minimum_end].isdigit():
+        minimum_end += 1
+    return int(pattern[atom_end + 1 : minimum_end]) == 0
 
 
 def _linear_alternation_group(body: str) -> bool:

--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -26,6 +26,8 @@ def pattern_is_safe(pattern: str) -> bool:
     atom_has_alternation = False
     quantifier_pending = False
     in_character_class = False
+    character_class_has_item = False
+    character_class_may_negate = False
     escaped = False
     index = 0
 
@@ -49,6 +51,9 @@ def pattern_is_safe(pattern: str) -> bool:
             if character.isdigit():
                 return False
             escaped = False
+            if in_character_class:
+                character_class_has_item = True
+                character_class_may_negate = False
             atom_present = True
             atom_has_quantifier = False
             atom_has_alternation = False
@@ -60,8 +65,15 @@ def pattern_is_safe(pattern: str) -> bool:
             index += 1
             continue
         if in_character_class:
-            if character == "]":
+            if character == "^" and character_class_may_negate:
+                character_class_may_negate = False
+                index += 1
+                continue
+            if character == "]" and character_class_has_item:
                 in_character_class = False
+            else:
+                character_class_has_item = True
+                character_class_may_negate = False
             atom_present = True
             atom_has_quantifier = False
             atom_has_alternation = False
@@ -70,6 +82,8 @@ def pattern_is_safe(pattern: str) -> bool:
             continue
         if character == "[":
             in_character_class = True
+            character_class_has_item = False
+            character_class_may_negate = True
             atom_present = True
             atom_has_quantifier = False
             atom_has_alternation = False
@@ -139,19 +153,13 @@ def pattern_is_safe(pattern: str) -> bool:
             index += 1
             continue
         if character == "{" and atom_present:
-            end = index + 1
-            while end < len(pattern) and pattern[end].isdigit():
-                end += 1
-            if end > index + 1:
-                if end < len(pattern) and pattern[end] == ",":
-                    end += 1
-                    while end < len(pattern) and pattern[end].isdigit():
-                        end += 1
-                if end < len(pattern) and pattern[end] == "}":
-                    if not mark_quantifier():
-                        return False
-                    index = end + 1
-                    continue
+            end = _quantifier_end(pattern, index)
+            if end > index:
+                if not mark_quantifier():
+                    return False
+                quantifier_pending = False
+                index = end
+                continue
         # Ordinary literals, anchors, and group-prefix punctuation are
         # single regular atoms.
         atom_present = True
@@ -167,7 +175,7 @@ def pattern_is_safe(pattern: str) -> bool:
     # simple quantified atoms, while conservatively rejecting this higher-risk
     # subset before invoking ``re.search``.
     unanchored_complex = not pattern.startswith("^") and (
-        re.search(r"[)\]](?:[*+?]|\{\d)", pattern) is not None
+        re.search(r"[)\]](?:[*+?]|\{(?:\d+(?:,\d*)?|,\d*)\})", pattern) is not None
         or re.search(r"\([^)]*[+*?{][^)]*\)", pattern) is not None
     )
     return (
@@ -179,51 +187,170 @@ def pattern_is_safe(pattern: str) -> bool:
     )
 
 
+class _ConsumerSet:
+    """Conservative set of code points consumed by one regex boundary."""
+
+    _ASCII_LIMIT = 128
+    _ALL_ASCII = (1 << _ASCII_LIMIT) - 1
+
+    def __init__(
+        self,
+        ascii_mask: int = 0,
+        non_ascii_literals: set[int] | None = None,
+        *,
+        non_ascii_unknown: bool = False,
+    ) -> None:
+        self.ascii_mask = ascii_mask
+        self.non_ascii_literals = set() if non_ascii_literals is None else set(non_ascii_literals)
+        self.non_ascii_unknown = non_ascii_unknown
+
+    @classmethod
+    def any_character(cls) -> _ConsumerSet:
+        """Return the conservative universe of Python ``str`` characters."""
+        return cls(cls._ALL_ASCII, non_ascii_unknown=True)
+
+    @classmethod
+    def literal(cls, codepoint: int, *, ignore_case: bool = False) -> _ConsumerSet:
+        """Return one literal code point, or an unknown fold when needed."""
+        if ignore_case:
+            return cls.any_character()
+        if codepoint < cls._ASCII_LIMIT:
+            return cls(1 << codepoint)
+        return cls(non_ascii_literals={codepoint})
+
+    def copy(self) -> _ConsumerSet:
+        """Return an independent copy."""
+        return _ConsumerSet(
+            self.ascii_mask,
+            self.non_ascii_literals,
+            non_ascii_unknown=self.non_ascii_unknown,
+        )
+
+    def update(self, other: _ConsumerSet) -> None:
+        """Union another conservative consumer set into this one."""
+        self.ascii_mask |= other.ascii_mask
+        self.non_ascii_literals.update(other.non_ascii_literals)
+        self.non_ascii_unknown = self.non_ascii_unknown or other.non_ascii_unknown
+
+    def add_range(self, start: int, end: int, *, ignore_case: bool = False) -> None:
+        """Add a class range without expanding an unbounded Unicode interval."""
+        if ignore_case:
+            self.update(self.any_character())
+            return
+        if start > end:
+            self.update(self.any_character())
+            return
+        ascii_start = max(start, 0)
+        ascii_end = min(end, self._ASCII_LIMIT - 1)
+        if ascii_start <= ascii_end:
+            width = ascii_end - ascii_start + 1
+            self.ascii_mask |= ((1 << width) - 1) << ascii_start
+        if end >= self._ASCII_LIMIT:
+            if start == end:
+                self.non_ascii_literals.add(start)
+            else:
+                self.non_ascii_unknown = True
+
+    def is_empty(self) -> bool:
+        """Return whether the summary contains no possible consumer."""
+        return not self.ascii_mask and not self.non_ascii_literals and not self.non_ascii_unknown
+
+    def overlaps(self, other: _ConsumerSet) -> bool:
+        """Return whether the two summaries may consume a common code point."""
+        if self.is_empty() or other.is_empty():
+            return False
+        if self.ascii_mask & other.ascii_mask:
+            return True
+        if self.non_ascii_literals.intersection(other.non_ascii_literals):
+            return True
+        self_has_non_ascii = self.non_ascii_unknown or bool(self.non_ascii_literals)
+        other_has_non_ascii = other.non_ascii_unknown or bool(other.non_ascii_literals)
+        return (self.non_ascii_unknown and other_has_non_ascii) or (other.non_ascii_unknown and self_has_non_ascii)
+
+    def single_codepoint(self) -> int | None:
+        """Return the sole exact code point, if the summary proves one."""
+        if self.non_ascii_unknown:
+            return None
+        ascii_count = bin(self.ascii_mask).count("1")
+        if ascii_count + len(self.non_ascii_literals) != 1:
+            return None
+        if ascii_count:
+            return self.ascii_mask.bit_length() - 1
+        return next(iter(self.non_ascii_literals))
+
+
 class _BoundaryFrame:
-    """Track quantified boundaries for one regex sequence or group."""
+    """Track consuming and quantified edges for one sequence or group."""
 
     def __init__(self, *, zero_width: bool = False) -> None:
         self.zero_width = zero_width
-        self.first_tokens: set[str] = set()
-        self.last_tokens: set[str] = set()
+        self.first_consumers = _ConsumerSet()
+        self.last_consumers = _ConsumerSet()
+        self.leading_quantified = _ConsumerSet()
+        self.trailing_quantified = _ConsumerSet()
         self.nullable = False
-        self.branch_first: set[str] = set()
-        self.branch_last: set[str] = set()
+        self.branch_first = _ConsumerSet()
+        self.branch_last = _ConsumerSet()
+        self.branch_leading_quantified = _ConsumerSet()
+        self.branch_trailing_quantified = _ConsumerSet()
         self.branch_nullable = True
 
-    def add_atom(self, first_tokens: set[str], last_tokens: set[str], *, nullable: bool) -> bool:
-        """Add one atom and report whether its leading boundary overlaps."""
-        if _quantifier_boundaries_overlap(self.branch_last, first_tokens):
+    def add_atom(
+        self,
+        first_consumers: _ConsumerSet,
+        last_consumers: _ConsumerSet,
+        *,
+        nullable: bool,
+        leading_quantified: _ConsumerSet,
+        trailing_quantified: _ConsumerSet,
+    ) -> bool:
+        """Add one atom and report an ambiguous quantified boundary."""
+        if self.branch_trailing_quantified.overlaps(leading_quantified):
             return True
-        if self.branch_nullable:
-            self.branch_first.update(first_tokens)
+        prefix_nullable = self.branch_nullable
+        if prefix_nullable:
+            self.branch_first.update(first_consumers)
+            self.branch_leading_quantified.update(leading_quantified)
         if nullable:
-            self.branch_last.update(last_tokens)
+            self.branch_last.update(last_consumers)
+            self.branch_trailing_quantified.update(trailing_quantified)
         else:
-            self.branch_last = set(last_tokens)
-        self.branch_nullable = self.branch_nullable and nullable
+            self.branch_last = last_consumers.copy()
+            self.branch_trailing_quantified = trailing_quantified.copy()
+        self.branch_nullable = prefix_nullable and nullable
         return False
 
     def end_branch(self) -> None:
         """Merge the current alternative into the group's edge summary."""
-        self.first_tokens.update(self.branch_first)
-        self.last_tokens.update(self.branch_last)
+        self.first_consumers.update(self.branch_first)
+        self.last_consumers.update(self.branch_last)
+        self.leading_quantified.update(self.branch_leading_quantified)
+        self.trailing_quantified.update(self.branch_trailing_quantified)
         self.nullable = self.nullable or self.branch_nullable
-        self.branch_first = set()
-        self.branch_last = set()
+        self.branch_first = _ConsumerSet()
+        self.branch_last = _ConsumerSet()
+        self.branch_leading_quantified = _ConsumerSet()
+        self.branch_trailing_quantified = _ConsumerSet()
         self.branch_nullable = True
 
-    def finish(self) -> tuple[set[str], set[str], bool]:
-        """Return all quantified tokens exposed by the group's outer edges."""
+    def finish(self) -> tuple[_ConsumerSet, _ConsumerSet, bool, _ConsumerSet, _ConsumerSet]:
+        """Return the group's consuming and quantified edge summary."""
         self.end_branch()
         if self.zero_width:
-            return set(), set(), True
-        return self.first_tokens, self.last_tokens, self.nullable
+            return _ConsumerSet(), _ConsumerSet(), True, _ConsumerSet(), _ConsumerSet()
+        return (
+            self.first_consumers,
+            self.last_consumers,
+            self.nullable,
+            self.leading_quantified,
+            self.trailing_quantified,
+        )
 
 
 def _has_adjacent_quantifiers(pattern: str) -> bool:
     """Detect adjacent quantified atoms in one linear structural pass."""
     frames = [_BoundaryFrame()]
+    ignore_case = _pattern_may_ignore_case(pattern)
     index = 0
     while index < len(pattern):
         character = pattern[index]
@@ -235,14 +362,20 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
         if character == ")":
             if len(frames) == 1:
                 return False
-            first_tokens, last_tokens, nullable = frames.pop().finish()
+            first_consumers, last_consumers, nullable, leading_quantified, trailing_quantified = frames.pop().finish()
             atom_end = index + 1
             quantifier_end = _quantifier_end(pattern, atom_end)
             if quantifier_end > atom_end:
-                first_tokens = {"<group>"}
-                last_tokens = first_tokens
                 nullable = nullable or _quantifier_allows_zero(pattern, atom_end)
-            if frames[-1].add_atom(first_tokens, last_tokens, nullable=nullable):
+                leading_quantified = first_consumers.copy()
+                trailing_quantified = last_consumers.copy()
+            if frames[-1].add_atom(
+                first_consumers,
+                last_consumers,
+                nullable=nullable,
+                leading_quantified=leading_quantified,
+                trailing_quantified=trailing_quantified,
+            ):
                 return True
             index = quantifier_end
             continue
@@ -251,50 +384,192 @@ def _has_adjacent_quantifiers(pattern: str) -> bool:
             index += 1
             continue
         if character in "^$":
+            if frames[-1].add_atom(
+                _ConsumerSet(),
+                _ConsumerSet(),
+                nullable=True,
+                leading_quantified=_ConsumerSet(),
+                trailing_quantified=_ConsumerSet(),
+            ):
+                return True
             index += 1
             continue
 
-        token = character
         if character == "\\":
-            atom_end = min(index + 2, len(pattern))
-            token = pattern[index:atom_end]
+            atom_end, consumers, zero_width = _escaped_consumer(pattern, index, ignore_case=ignore_case)
         elif character == "[":
+            atom_end, consumers = _character_class_consumer(pattern, index, ignore_case=ignore_case)
+            zero_width = False
+        elif character == ".":
             atom_end = index + 1
-            escaped = False
-            while atom_end < len(pattern):
-                current = pattern[atom_end]
-                if escaped:
-                    escaped = False
-                elif current == "\\":
-                    escaped = True
-                elif current == "]":
-                    atom_end += 1
-                    break
-                atom_end += 1
-            token = "<class>"
+            consumers = _ConsumerSet.any_character()
+            zero_width = False
         else:
             atom_end = index + 1
+            consumers = _ConsumerSet.literal(ord(character), ignore_case=ignore_case)
+            zero_width = False
 
         quantifier_end = _quantifier_end(pattern, atom_end)
-        quantified_tokens = {token} if quantifier_end > atom_end else set()
-        nullable = quantifier_end > atom_end and _quantifier_allows_zero(pattern, atom_end)
-        if frames[-1].add_atom(quantified_tokens, quantified_tokens, nullable=nullable):
+        quantified = quantifier_end > atom_end
+        nullable = zero_width or (quantified and _quantifier_allows_zero(pattern, atom_end))
+        quantified_consumers = consumers.copy() if quantified else _ConsumerSet()
+        if frames[-1].add_atom(
+            consumers,
+            consumers,
+            nullable=nullable,
+            leading_quantified=quantified_consumers,
+            trailing_quantified=quantified_consumers,
+        ):
             return True
         index = quantifier_end
     return False
 
 
-def _quantifier_boundaries_overlap(previous: set[str], current: set[str]) -> bool:
-    """Return whether adjacent quantified boundaries can consume the same text."""
-    if not previous or not current:
-        return False
-    if "<group>" in current:
-        return True
-    if "<class>" in current:
-        return True
-    if "<group>" in previous:
-        return True
-    return bool(previous.intersection(current))
+def _pattern_may_ignore_case(pattern: str) -> bool:
+    """Return whether any inline flag enables case-insensitive matching."""
+    escaped = False
+    in_class = False
+    class_has_item = False
+    class_may_negate = False
+    index = 0
+    while index < len(pattern):
+        character = pattern[index]
+        if escaped:
+            escaped = False
+            if in_class:
+                class_has_item = True
+                class_may_negate = False
+            index += 1
+            continue
+        if character == "\\":
+            escaped = True
+            index += 1
+            continue
+        if in_class:
+            if character == "^" and class_may_negate:
+                class_may_negate = False
+            elif character == "]" and class_has_item:
+                in_class = False
+            else:
+                class_has_item = True
+                class_may_negate = False
+            index += 1
+            continue
+        if character == "[":
+            in_class = True
+            class_has_item = False
+            class_may_negate = True
+            index += 1
+            continue
+        if pattern.startswith("(?", index):
+            cursor = index + 2
+            while cursor < len(pattern) and pattern[cursor] in "aiLmsux-":
+                if pattern[cursor] == "i" and "-" not in pattern[index + 2 : cursor]:
+                    return True
+                cursor += 1
+        index += 1
+    return False
+
+
+_ASCII_DIGIT_MASK = ((1 << 10) - 1) << ord("0")
+_ASCII_SPACE_MASK = sum(1 << ord(character) for character in " \t\n\r\f\v")
+_ASCII_WORD_MASK = _ASCII_DIGIT_MASK | (((1 << 26) - 1) << ord("A")) | (((1 << 26) - 1) << ord("a")) | (1 << ord("_"))
+
+
+def _escaped_consumer(
+    pattern: str,
+    index: int,
+    *,
+    ignore_case: bool,
+    in_class: bool = False,
+) -> tuple[int, _ConsumerSet, bool]:
+    """Parse one escape into its conservative consumer and width."""
+    if index + 1 >= len(pattern):
+        return len(pattern), _ConsumerSet.any_character(), False
+    escaped = pattern[index + 1]
+    end = index + 2
+    if not in_class and escaped in "AbBZ":
+        return end, _ConsumerSet(), True
+    if in_class and escaped == "b":
+        return end, _ConsumerSet.literal(8, ignore_case=ignore_case), False
+    category_masks = {"d": _ASCII_DIGIT_MASK, "s": _ASCII_SPACE_MASK, "w": _ASCII_WORD_MASK}
+    if escaped in category_masks:
+        return end, _ConsumerSet(category_masks[escaped], non_ascii_unknown=True), False
+    if escaped in "DSW":
+        return end, _ConsumerSet.any_character(), False
+    simple_escapes = {"a": 7, "f": 12, "n": 10, "r": 13, "t": 9, "v": 11}
+    if escaped in simple_escapes:
+        return end, _ConsumerSet.literal(simple_escapes[escaped], ignore_case=ignore_case), False
+    widths = {"x": 2, "u": 4, "U": 8}
+    if escaped in widths:
+        digits_end = end + widths[escaped]
+        try:
+            codepoint = int(pattern[end:digits_end], 16)
+        except ValueError:
+            return min(digits_end, len(pattern)), _ConsumerSet.any_character(), False
+        return digits_end, _ConsumerSet.literal(codepoint, ignore_case=ignore_case), False
+    if escaped == "N" and end < len(pattern) and pattern[end] == "{":
+        name_end = pattern.find("}", end + 1)
+        return (name_end + 1 if name_end >= 0 else len(pattern)), _ConsumerSet.any_character(), False
+    if escaped.isalnum():
+        return end, _ConsumerSet.any_character(), False
+    return end, _ConsumerSet.literal(ord(escaped), ignore_case=ignore_case), False
+
+
+def _character_class_consumer(
+    pattern: str,
+    index: int,
+    *,
+    ignore_case: bool,
+) -> tuple[int, _ConsumerSet]:
+    """Parse a class, including a literal leading ``]``, into consumers."""
+    cursor = index + 1
+    negated = cursor < len(pattern) and pattern[cursor] == "^"
+    if negated:
+        cursor += 1
+    consumers = _ConsumerSet()
+    if cursor < len(pattern) and pattern[cursor] == "]":
+        consumers.update(_ConsumerSet.literal(ord("]"), ignore_case=ignore_case))
+        cursor += 1
+    while cursor < len(pattern):
+        if pattern[cursor] == "]":
+            return cursor + 1, _ConsumerSet.any_character() if negated else consumers
+        item_end, item_consumers = _class_element(pattern, cursor, ignore_case=ignore_case)
+        range_start = item_consumers.single_codepoint()
+        if (
+            item_end < len(pattern)
+            and pattern[item_end] == "-"
+            and item_end + 1 < len(pattern)
+            and pattern[item_end + 1] != "]"
+        ):
+            range_end_offset, range_consumers = _class_element(
+                pattern,
+                item_end + 1,
+                ignore_case=ignore_case,
+            )
+            range_end = range_consumers.single_codepoint()
+            if range_start is None or range_end is None:
+                consumers.update(_ConsumerSet.any_character())
+            else:
+                consumers.add_range(range_start, range_end, ignore_case=ignore_case)
+            cursor = range_end_offset
+            continue
+        consumers.update(item_consumers)
+        cursor = item_end
+    return len(pattern), _ConsumerSet.any_character()
+
+
+def _class_element(
+    pattern: str,
+    index: int,
+    *,
+    ignore_case: bool,
+) -> tuple[int, _ConsumerSet]:
+    """Parse one character-class element."""
+    if pattern[index] == "\\":
+        end, consumers, _ = _escaped_consumer(pattern, index, ignore_case=ignore_case, in_class=True)
+        return end, consumers
+    return index + 1, _ConsumerSet.literal(ord(pattern[index]), ignore_case=ignore_case)
 
 
 def _group_content_start(pattern: str, start: int) -> tuple[int, bool]:
@@ -328,14 +603,20 @@ def _quantifier_end(pattern: str, atom_end: int) -> int:
         end = atom_end + 1
     elif character == "{":
         end = atom_end + 1
+        minimum_start = end
         while end < len(pattern) and pattern[end].isdigit():
             end += 1
-        if end == atom_end + 1:
-            return atom_end
+        has_minimum = end > minimum_start
         if end < len(pattern) and pattern[end] == ",":
             end += 1
+            maximum_start = end
             while end < len(pattern) and pattern[end].isdigit():
                 end += 1
+            has_maximum = end > maximum_start
+            if not has_minimum and not has_maximum and (end >= len(pattern) or pattern[end] != "}"):
+                return atom_end
+        elif not has_minimum:
+            return atom_end
         if end >= len(pattern) or pattern[end] != "}":
             return atom_end
         end += 1
@@ -356,7 +637,8 @@ def _quantifier_allows_zero(pattern: str, atom_end: int) -> bool:
     minimum_end = atom_end + 1
     while minimum_end < len(pattern) and pattern[minimum_end].isdigit():
         minimum_end += 1
-    return int(pattern[atom_end + 1 : minimum_end]) == 0
+    minimum = pattern[atom_end + 1 : minimum_end]
+    return not minimum or int(minimum) == 0
 
 
 def _linear_alternation_group(body: str) -> bool:

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -161,6 +161,11 @@ Generated `tools.yaml` entries follow the modern contract:
   the tool script or handler validation instead of `anyOf`, `oneOf`, `allOf`,
   `not`, `if`/`then`/`else`, or dependent-schema keywords. When a complex
   schema is unavoidable, discovery must route through `describe` before call.
+- Published recipe `inputs_schema` references stay within one schema resource:
+  use `#`, a local JSON Pointer such as `#/$defs/name`, or a local `$anchor`
+  such as `#name`. Recipe admission rejects `$id`, `$dynamicRef`, and
+  `$dynamicAnchor`; external and resource-relative `$ref` values are not
+  supported by the dependency-free validator.
 - `execution` is `sync` or `async`; use `async` for deferred/long-running work.
 - `job_strategy` is `monolithic` (default), `chunked`, or `isolated`. Agents
   use it to select a safe execution and recovery workflow.

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -166,6 +166,10 @@ Generated `tools.yaml` entries follow the modern contract:
   such as `#name`. Recipe admission rejects `$id`, `$dynamicRef`, and
   `$dynamicAnchor`; external and resource-relative `$ref` values are not
   supported by the dependency-free validator.
+- A recipe `inputs_schema` may declare `$schema` only at the schema resource
+  root, and its value must be the absolute canonical Draft 2020-12 URI
+  `https://json-schema.org/draft/2020-12/schema`. Null, relative, unsupported,
+  and nested dialect declarations fail closed during recipe admission.
 - `execution` is `sync` or `async`; use `async` for deferred/long-running work.
 - `job_strategy` is `monolithic` (default), `chunked`, or `isolated`. Agents
   use it to select a safe execution and recovery workflow.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -968,6 +968,45 @@ class TestRegisterRecipesTools:
         pattern = "^(a|b)(c|d)(e|f)g$"
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aceg") == []
 
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^(a|aa)a(a|aa)a(a|aa)b$",
+            "^(?:a|aa)a(?:a|aa)a(?:a|aa)b$",
+            "^(a|)a(a|)a(a|)b$",
+        ],
+    )
+    def test_connected_ambiguity_chains_separated_by_fixed_consumers_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaaaab") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^(a|aa)a(a|aa)a(a|aa)b$",
+            "^(?:a|aa)a(?:a|aa)a(?:a|aa)b$",
+            "^(a|)a(a|)a(a|)b$",
+        ],
+    )
+    def test_pattern_properties_connected_ambiguity_chains_fail_closed(self, pattern: str) -> None:
+        schema = {"type": "object", "patternProperties": {pattern: {"type": "string"}}}
+        assert validate_recipe_inputs({"inputs_schema": schema}, {"aaaaab": "value"}) == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        ("pattern", "instance"),
+        [
+            ("^(a|aa)b(a|aa)c(a|aa)d$", "abacad"),
+            ("^(?:a|aa)b(?:a|aa)c(?:a|aa)d$", "abacad"),
+            ("^(a|)b(a|)c(a|)d$", "abacad"),
+            ("^(a|aa|b|bb)a(b|bb)c$", "aabc"),
+        ],
+    )
+    def test_disjoint_fixed_consumers_clear_ambiguous_overlap(self, pattern: str, instance: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, instance) == []
+
     def test_quantified_character_classes_are_bounded(self) -> None:
         pattern = "^[a-z]*[a-y]*$"
         started = time.perf_counter()
@@ -1142,6 +1181,47 @@ class TestRegisterRecipesTools:
             "skill": "connected-quantifiers-skill",
             "recipe": "connected-quantifiers",
             "inputs": {"value": "aaaa"},
+        }
+
+        validated = handlers["recipes__validate"](json.dumps(params))
+        applied = handlers["recipes__apply"](json.dumps(params))
+
+        assert validated["context"]["valid"] is False
+        assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+        assert applied["success"] is False
+        assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    def test_connected_ambiguity_rejection_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        recipe_path = tmp_path / "connected-ambiguity.yaml"
+        recipe_path.write_text(
+            json.dumps(
+                {
+                    "recipes": [
+                        {
+                            "name": "connected-ambiguity",
+                            "inputs_schema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"type": "string", "pattern": "^(a|aa)a(a|aa)a(a|aa)b$"},
+                                },
+                            },
+                            "steps": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        skill_dir = tmp_path / "connected-ambiguity-skill"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_path), nested=True)
+        md.name = "connected-ambiguity-skill"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+        params = {
+            "skill": "connected-ambiguity-skill",
+            "recipe": "connected-ambiguity",
+            "inputs": {"value": "aaaaab"},
         }
 
         validated = handlers["recipes__validate"](json.dumps(params))

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -763,6 +763,63 @@ class TestRegisterRecipesTools:
     def test_unanchored_pattern_uses_draft_search_semantics(self) -> None:
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": "foo"}}, "afoob") == []
 
+    @pytest.mark.parametrize("pattern", ["a+b", "^x|a+b"])
+    def test_unanchored_quantified_search_paths_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaab") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    def test_anchored_quantified_search_path_remains_supported(self) -> None:
+        assert (
+            validate_recipe_inputs(
+                {"inputs_schema": {"type": "string", "pattern": "^a+b$"}},
+                "aaab",
+            )
+            == []
+        )
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^(?i:(ab|AB)+)$",
+            "(?i)^(ab|AB)+$",
+        ],
+    )
+    def test_casefold_equivalent_quantified_alternations_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "abAB") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^(?i:(ab|cd)+)$",
+            "(?i)^(ab|cd)+$",
+        ],
+    )
+    def test_casefold_disjoint_quantified_alternations_remain_supported(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "abCD") == []
+
+    def test_scoped_casefold_disable_restores_disjointness(self) -> None:
+        pattern = "(?i)^(?-i:(ab|AB)+)$"
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "abAB") == []
+
+    @pytest.mark.parametrize("pattern", ["(?m)^a+$", "^(?x:a +)$"])
+    def test_unsupported_inline_flag_modes_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaa") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    def test_repeated_prefix_overlapping_alternation_chain_fails_closed(self) -> None:
+        pattern = "^(a|aa)(a|aa)(a|aa)b$"
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaaaaab") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    def test_disjoint_alternation_chain_remains_supported(self) -> None:
+        pattern = "^(a|b)(c|d)(e|f)g$"
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aceg") == []
+
     def test_quantified_character_classes_are_bounded(self) -> None:
         pattern = "^[a-z]*[a-y]*$"
         started = time.perf_counter()

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -303,6 +303,29 @@ class TestRegisterRecipesTools:
         server.register_handler.side_effect = lambda name, fn: handlers.__setitem__(name, fn)
         return server, handlers
 
+    def _make_recipe_handlers(
+        self,
+        tmp_path: Path,
+        *,
+        skill_name: str,
+        recipes: dict[str, dict[str, object]],
+    ) -> dict:
+        """Register an in-memory recipe pack and return its handlers."""
+        recipe_path = tmp_path / f"{skill_name}.yaml"
+        recipe_path.write_text(
+            json.dumps(
+                {"recipes": [{"name": name, "inputs_schema": schema, "steps": []} for name, schema in recipes.items()]}
+            ),
+            encoding="utf-8",
+        )
+        skill_dir = tmp_path / skill_name
+        skill_dir.mkdir()
+        metadata = _make_metadata(str(skill_dir), str(recipe_path), nested=True)
+        metadata.name = skill_name
+        server, handlers = self._make_server([metadata])
+        register_recipes_tools(server, skills=[metadata])
+        return handlers
+
     def test_registers_two_tools(self, recipes_md: Path, tmp_path: Path) -> None:
         skill_dir = tmp_path / "maya-scripting"
         skill_dir.mkdir()
@@ -1264,6 +1287,208 @@ class TestRegisterRecipesTools:
             assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
             assert applied["success"] is False
             assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^((a|aa)a)+$",
+            "^(?:(?:a|aa)a)+$",
+        ],
+    )
+    def test_quantified_wrappers_preserve_nested_ambiguity_at_admission(self, pattern: str) -> None:
+        pattern_schema = {"type": "string", "pattern": pattern}
+        pattern_properties_schema = {
+            "type": "object",
+            "patternProperties": {pattern: {"type": "string"}},
+        }
+
+        assert validate_recipe_inputs({"inputs_schema": pattern_schema}, "aaaa") == [
+            "$: Recipe input schema is invalid"
+        ]
+        assert validate_recipe_inputs({"inputs_schema": pattern_properties_schema}, {"aaaa": "value"}) == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^((a|aa)b)+$",
+            "^(?:(?:a|aa)b)+$",
+        ],
+    )
+    def test_quantified_wrappers_allow_disjoint_fixed_consumer_control(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "abaab") == []
+        assert (
+            validate_recipe_inputs(
+                {
+                    "inputs_schema": {
+                        "type": "object",
+                        "patternProperties": {pattern: {"type": "string"}},
+                    }
+                },
+                {"abaab": "value"},
+            )
+            == []
+        )
+
+    def test_quantified_wrapper_rejection_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        pattern = "^((a|aa)a)+$"
+        handlers = self._make_recipe_handlers(
+            tmp_path,
+            skill_name="quantified-wrapper-skill",
+            recipes={
+                "pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": pattern}},
+                },
+                "pattern-properties": {
+                    "type": "object",
+                    "patternProperties": {pattern: {"type": "string"}},
+                },
+            },
+        )
+        inputs_by_recipe = {
+            "pattern": {"value": "aaaa"},
+            "pattern-properties": {"aaaa": "value"},
+        }
+
+        for recipe_name, inputs in inputs_by_recipe.items():
+            params = {"skill": "quantified-wrapper-skill", "recipe": recipe_name, "inputs": inputs}
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            assert validated["context"]["valid"] is False
+            assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+            assert applied["success"] is False
+            assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    def test_contains_annotation_branch_work_is_linear(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        original_merge = _RecipeSchemaValidator._merge_annotations
+        merged_work = 0
+
+        def counted_merge(
+            validator: _RecipeSchemaValidator,
+            source: dict[str, dict[str, set[object]]],
+        ) -> None:
+            nonlocal merged_work
+            merged_work += sum(len(paths) + sum(len(values) for values in paths.values()) for paths in source.values())
+            original_merge(validator, source)
+
+        monkeypatch.setattr(_RecipeSchemaValidator, "_merge_annotations", counted_merge)
+        schema = {
+            "type": "array",
+            "contains": {
+                "type": "object",
+                "required": ["matched"],
+                "properties": {"matched": {"const": True}},
+            },
+        }
+        work_by_size: list[tuple[int, int]] = []
+
+        for size in (4, 8, 16):
+            merged_work = 0
+            values = [{"matched": True} for _ in range(size)]
+            assert validate_recipe_inputs({"inputs_schema": {**schema, "minContains": size}}, values) == []
+            work_by_size.append((size, merged_work))
+
+        assert all(work <= size * 16 for size, work in work_by_size), work_by_size
+
+    def test_contains_annotations_preserve_structure_and_validate_apply_parity(self, tmp_path: Path) -> None:
+        schema = {
+            "type": "object",
+            "required": ["values"],
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "contains": {
+                        "type": "object",
+                        "required": ["matched"],
+                        "properties": {"matched": {"const": True}},
+                    },
+                    "minContains": 2,
+                    "unevaluatedItems": False,
+                }
+            },
+            "additionalProperties": False,
+        }
+        valid_inputs = {"values": [{"matched": True}, {"matched": True}]}
+        invalid_inputs = {"values": [{"matched": True}, {"matched": False}]}
+        assert validate_recipe_inputs({"inputs_schema": schema}, valid_inputs) == []
+        assert validate_recipe_inputs({"inputs_schema": schema}, invalid_inputs)
+
+        handlers = self._make_recipe_handlers(
+            tmp_path,
+            skill_name="contains-annotation-skill",
+            recipes={"contains": schema},
+        )
+        for inputs, expected_valid in ((valid_inputs, True), (invalid_inputs, False)):
+            params = {"skill": "contains-annotation-skill", "recipe": "contains", "inputs": inputs}
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            assert validated["context"]["valid"] is expected_valid
+            assert applied["success"] is expected_valid
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            {"$schema": None},
+            {"$schema": []},
+            {"$schema": "https://json-schema.org/draft/2019-09/schema"},
+            {"$schema": "draft/2020-12/schema"},
+            {"$schema": "urn:example:unsupported-dialect"},
+            {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "type": "string",
+                    }
+                },
+            },
+        ],
+    )
+    def test_schema_dialect_declaration_fails_closed(self, schema: dict[str, object]) -> None:
+        assert validate_recipe_inputs({"inputs_schema": schema}, {}) == ["$: Recipe input schema is invalid"]
+
+    def test_supported_schema_dialect_is_allowed_only_at_resource_root(self) -> None:
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"value": {"type": "string"}},
+        }
+        assert validate_recipe_inputs({"inputs_schema": schema}, {"value": "ok"}) == []
+
+    def test_schema_dialect_admission_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        supported = "https://json-schema.org/draft/2020-12/schema"
+        handlers = self._make_recipe_handlers(
+            tmp_path,
+            skill_name="schema-dialect-skill",
+            recipes={
+                "valid-root": {
+                    "$schema": supported,
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                },
+                "invalid-null": {"$schema": None},
+                "invalid-relative": {"$schema": "draft/2020-12/schema"},
+                "invalid-dialect": {"$schema": "https://json-schema.org/draft/2019-09/schema"},
+                "invalid-nested": {
+                    "type": "object",
+                    "properties": {"value": {"$schema": supported, "type": "string"}},
+                },
+            },
+        )
+
+        for recipe_name in ("valid-root", "invalid-null", "invalid-relative", "invalid-dialect", "invalid-nested"):
+            params = {
+                "skill": "schema-dialect-skill",
+                "recipe": recipe_name,
+                "inputs": {"value": "ok"},
+            }
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            expected_valid = recipe_name == "valid-root"
+            assert validated["context"]["valid"] is expected_valid
+            assert applied["success"] is expected_valid
 
     def test_local_anchor_reference_is_supported(self) -> None:
         schema = {"$defs": {"name": {"$anchor": "name", "type": "string"}}, "$ref": "#name"}

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -701,6 +701,65 @@ class TestRegisterRecipesTools:
                 "$: Recipe input schema is invalid"
             ]
 
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^a{,}a+$",
+            "^a{,2}a+$",
+            "^a{2,}a+$",
+            "^a{1,2}a+$",
+            "^a{,}?a+$",
+            "^a{,2}?a+$",
+            "^a{2,}?a+$",
+            "^a{1,2}?a+$",
+        ],
+    )
+    def test_braced_quantifier_forms_are_admitted_conservatively(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aa") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^a{,}b+$",
+            "^a{,2}b+$",
+            "^a{2,}b+$",
+            "^a{1,2}b+$",
+            "^a{,}?b+$",
+            "^a{,2}?b+$",
+            "^a{2,}?b+$",
+            "^a{1,2}?b+$",
+        ],
+    )
+    def test_braced_quantifier_forms_keep_disjoint_boundaries(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aab") == []
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^a+.+b$",
+            r"^\w+\d+z$",
+            r"^a+\Ba+z$",
+            "^a+[]a]+z$",
+        ],
+    )
+    def test_overlapping_consumers_and_zero_width_assertions_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaaz") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        ("pattern", "instance"),
+        [
+            ("^[a-z]+[0-9]+$", "abc123"),
+            ("^(ab)+c+$", "ababcc"),
+            ("^[]]+[a]+$", "]aaa"),
+        ],
+    )
+    def test_disjoint_quantified_boundaries_remain_supported(self, pattern: str, instance: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, instance) == []
+
     def test_unanchored_pattern_uses_draft_search_semantics(self) -> None:
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": "foo"}}, "afoob") == []
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -810,6 +810,52 @@ class TestRegisterRecipesTools:
             "$: Recipe input schema is invalid"
         ]
 
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^(a)(?(1)(a|aa)|x)+b$",
+            "^(?P<lead>a)(?(lead)b|c)$",
+        ],
+    )
+    def test_conditional_groups_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaab") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    def test_pattern_properties_conditional_groups_fail_closed(self) -> None:
+        schema = {
+            "type": "object",
+            "patternProperties": {"^(a)(?(1)(a|aa)|x)+b$": {"type": "string"}},
+        }
+        assert validate_recipe_inputs({"inputs_schema": schema}, {"aaab": "value"}) == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^(a|)+$",
+            "^(a|(?=a))+$",
+            "^((a|))+$",
+            "^(a|(?:))+$",
+        ],
+    )
+    def test_nullable_quantified_groups_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "a") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        ("pattern", "instance"),
+        [
+            ("^(?:ab)+$", "abab"),
+            ("^(?P<chunk>ab)+$", "abab"),
+            ("^(?=a)a+$", "aaa"),
+        ],
+    )
+    def test_supported_group_forms_remain_admitted(self, pattern: str, instance: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, instance) == []
+
     def test_repeated_prefix_overlapping_alternation_chain_fails_closed(self) -> None:
         pattern = "^(a|aa)(a|aa)(a|aa)b$"
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaaaaab") == [

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -548,6 +548,62 @@ class TestRegisterRecipesTools:
             "$.child: Missing required property 'value'"
         ]
 
+    @pytest.mark.parametrize(
+        ("schema", "instance"),
+        [
+            ({"examples": [{"type": "integer"}], "$ref": "#/examples/0"}, 1),
+            (
+                {
+                    "type": "object",
+                    "examples": [{"type": "integer"}],
+                    "properties": {"value": {"$ref": "#/examples/0"}},
+                },
+                {"value": 1},
+            ),
+        ],
+    )
+    def test_local_refs_must_target_schema_locations(self, schema: dict[str, object], instance: object) -> None:
+        assert validate_recipe_inputs({"inputs_schema": schema}, instance) == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        ("target", "instance"),
+        [
+            ({"type": "string", "pattern": "^(a+)+$"}, "a"),
+            (
+                {"type": "object", "patternProperties": {"^(a+)+$": {"type": "string"}}},
+                {"a": "value"},
+            ),
+        ],
+    )
+    def test_local_ref_annotation_targets_cannot_bypass_pattern_admission(
+        self, target: dict[str, object], instance: object
+    ) -> None:
+        schema = {"examples": [target], "$ref": "#/examples/0"}
+        assert validate_recipe_inputs({"inputs_schema": schema}, instance) == ["$: Recipe input schema is invalid"]
+
+    def test_local_ref_annotation_target_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        schema = {"examples": [{"type": "object"}], "$ref": "#/examples/0"}
+        recipe_path = tmp_path / "annotation-ref.yaml"
+        recipe_path.write_text(
+            json.dumps({"recipes": [{"name": "annotation-ref", "inputs_schema": schema, "steps": []}]}),
+            encoding="utf-8",
+        )
+        skill_dir = tmp_path / "annotation-ref-skill"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_path), nested=True)
+        md.name = "annotation-ref-skill"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+        params = {"skill": "annotation-ref-skill", "recipe": "annotation-ref", "inputs": {}}
+
+        validated = handlers["recipes__validate"](json.dumps(params))
+        applied = handlers["recipes__apply"](json.dumps(params))
+
+        assert validated["context"]["valid"] is False
+        assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+        assert applied["success"] is False
+        assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
     def test_unevaluated_keywords_and_json_number_semantics(self) -> None:
         schema = {
             "type": "object",
@@ -859,6 +915,21 @@ class TestRegisterRecipesTools:
     def test_repeated_prefix_overlapping_alternation_chain_fails_closed(self) -> None:
         pattern = "^(a|aa)(a|aa)(a|aa)b$"
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaaaaab") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize("pattern", ["^(a|)(a|)(a|)b$", "^(?:a|)(?:a|)(?:a|)b$"])
+    def test_nullable_alternative_chains_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaab") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    def test_pattern_properties_nullable_alternative_chain_fails_closed(self) -> None:
+        schema = {
+            "type": "object",
+            "patternProperties": {"^(a|)(a|)(a|)b$": {"type": "string"}},
+        }
+        assert validate_recipe_inputs({"inputs_schema": schema}, {"aaab": "value"}) == [
             "$: Recipe input schema is invalid"
         ]
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -695,6 +695,12 @@ class TestRegisterRecipesTools:
         )
         assert errors == []
 
+    def test_grouped_adjacent_quantifiers_are_rejected_during_admission(self) -> None:
+        for pattern in ("^(a*)a*$", "^(a*)(a*)$"):
+            assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "a") == [
+                "$: Recipe input schema is invalid"
+            ]
+
     def test_unanchored_pattern_uses_draft_search_semantics(self) -> None:
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": "foo"}}, "afoob") == []
 
@@ -840,6 +846,39 @@ class TestRegisterRecipesTools:
         assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
         assert applied["success"] is False
         assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    def test_id_rejection_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        schemas = {
+            "root-resource": {"$id": "recipe.json", "type": "object"},
+            "nested-resource": {
+                "type": "object",
+                "properties": {"child": {"$id": "nested.json", "type": "object"}},
+            },
+            "invalid-id-null": {"$id": None},
+            "invalid-id-array": {"$id": []},
+        }
+        recipe_path = tmp_path / "id.yaml"
+        recipe_path.write_text(
+            json.dumps(
+                {"recipes": [{"name": name, "inputs_schema": schema, "steps": []} for name, schema in schemas.items()]}
+            ),
+            encoding="utf-8",
+        )
+        skill_dir = tmp_path / "id-skill"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_path), nested=True)
+        md.name = "id-skill"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+
+        for recipe_name in schemas:
+            params = {"skill": "id-skill", "recipe": recipe_name, "inputs": {}}
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            assert validated["context"]["valid"] is False
+            assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+            assert applied["success"] is False
+            assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
 
     def test_local_anchor_reference_is_supported(self) -> None:
         schema = {"$defs": {"name": {"$anchor": "name", "type": "string"}}, "$ref": "#name"}

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -816,6 +816,37 @@ class TestRegisterRecipesTools:
     def test_disjoint_quantified_boundaries_remain_supported(self, pattern: str, instance: str) -> None:
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, instance) == []
 
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^a+aa+$",
+            "^a+(a|aa)a+$",
+            "^a+(?:a|aa)a+$",
+        ],
+    )
+    def test_connected_quantifiers_separated_by_fixed_consumers_fail_closed(self, pattern: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aaaa") == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize("pattern", ["^a+(a|aa)a+$", "^a+(?:a|aa)a+$"])
+    def test_pattern_properties_connected_quantifier_sandwiches_fail_closed(self, pattern: str) -> None:
+        schema = {"type": "object", "patternProperties": {pattern: {"type": "string"}}}
+        assert validate_recipe_inputs({"inputs_schema": schema}, {"aaaa": "value"}) == [
+            "$: Recipe input schema is invalid"
+        ]
+
+    @pytest.mark.parametrize(
+        ("pattern", "instance"),
+        [
+            ("^a+bb+$", "abbb"),
+            ("^a+(?:b|cc)d+$", "abdd"),
+            ("^(a|b)+ab+$", "aabb"),
+        ],
+    )
+    def test_disjoint_fixed_consumers_clear_quantified_overlap(self, pattern: str, instance: str) -> None:
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, instance) == []
+
     def test_unanchored_pattern_uses_draft_search_semantics(self) -> None:
         assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": "foo"}}, "afoob") == []
 
@@ -1075,6 +1106,47 @@ class TestRegisterRecipesTools:
         params = {"skill": "dynamic-skill", "recipe": "dynamic", "inputs": {"secret": "redacted"}}
         validated = handlers["recipes__validate"](json.dumps(params))
         applied = handlers["recipes__apply"](json.dumps(params))
+        assert validated["context"]["valid"] is False
+        assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+        assert applied["success"] is False
+        assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    def test_connected_quantifier_rejection_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        recipe_path = tmp_path / "connected-quantifiers.yaml"
+        recipe_path.write_text(
+            json.dumps(
+                {
+                    "recipes": [
+                        {
+                            "name": "connected-quantifiers",
+                            "inputs_schema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"type": "string", "pattern": "^a+(a|aa)a+$"},
+                                },
+                            },
+                            "steps": [],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        skill_dir = tmp_path / "connected-quantifiers-skill"
+        skill_dir.mkdir()
+        md = _make_metadata(str(skill_dir), str(recipe_path), nested=True)
+        md.name = "connected-quantifiers-skill"
+        server, handlers = self._make_server([md])
+        register_recipes_tools(server, skills=[md])
+        params = {
+            "skill": "connected-quantifiers-skill",
+            "recipe": "connected-quantifiers",
+            "inputs": {"value": "aaaa"},
+        }
+
+        validated = handlers["recipes__validate"](json.dumps(params))
+        applied = handlers["recipes__apply"](json.dumps(params))
+
         assert validated["context"]["valid"] is False
         assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
         assert applied["success"] is False


### PR DESCRIPTION
## Summary

- reject overlapping quantified boundaries exposed through grouped and nullable regex structure in a single linear admission scan
- reject `$id` at every schema depth until resource-relative reference scope is supported, with validate/apply parity
- document the same-resource local `$ref` contract and fail-closed resource identifiers
- stabilize the challenger startup-readback regression test with asynchronous, backed-off registry reads under loaded workspace test runs

## Validation

- `python -m pytest tests/test_recipes.py -q` (75 passed)
- focused gateway startup-readback regression test (10 consecutive passes)
- `vx just check-py37-syntax`
- `vx just check-python-support`
- real Python 3.7 regex admission smoke
- `vx just preflight` (3,787 workspace tests passed; all Rust doctests passed)
- `vx just lint`
- `npm run docs:build`
- full local Python suite on the initial locked base: 10,829 passed, 94 skipped, 3 xfailed; two pre-existing Windows-only failures were `test_install_plan_accepts_version_filter` and `test_bounded_runner_fails_closed_on_windows_normal_daemon`
- creator/skilling guidance checked; no update is required because adapter and skill execution contracts are unchanged
