### PR TITLE
feat(catalog): add OBS adapter install plan

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1245,7 +1245,7 @@ entries:
                     .is_some_and(|install| install.install_type == "pip")
             })
             .collect::<Vec<_>>();
-        assert_eq!(pip_entries.len(), 31);
+        assert_eq!(pip_entries.len(), 32);
         assert!(pip_entries.iter().all(|entry| {
             let install = entry.install.as_ref().unwrap();
             install
@@ -1267,6 +1267,7 @@ entries:
                 "dcc_mcp_illustrator.cli:main",
             ),
             ("dcc-mcp-comfyui", "comfyui", "dcc_mcp_comfyui.cli:main"),
+            ("dcc-mcp-obs", "obs", "dcc_mcp_obs:ObsMcpServer"),
             (
                 "dcc-mcp-touchdesigner",
                 "touchdesigner",

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -916,7 +916,7 @@ mod tests {
         let catalog = service.dcc_types(None).unwrap();
 
         assert!(catalog.custom_types_supported);
-        assert_eq!(catalog.dcc_types.len(), 35);
+        assert_eq!(catalog.dcc_types.len(), 36);
         for alias in ["after effects", "after-effects", "comfy-ui"] {
             assert!(
                 catalog
@@ -943,6 +943,7 @@ mod tests {
             ("krita", "dcc-mcp-krita"),
             ("mari", "dcc-mcp-mari"),
             ("material-maker", "dcc-mcp-material-maker"),
+            ("obs", "dcc-mcp-obs"),
             ("openscad", "dcc-mcp-openscad"),
             ("powerpoint", "dcc-mcp-PowerPoint"),
             ("renderdoc", "dcc-mcp-renderdoc"),

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1870,7 +1870,7 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
-    assert_eq!(types.len(), 35);
+    assert_eq!(types.len(), 36);
     for expected in [
         "aftereffects",
         "c4d",
@@ -1883,6 +1883,7 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
         "mari",
         "marmoset",
         "material-maker",
+        "obs",
         "openusd",
         "openscad",
         "powerpoint",

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -304,6 +304,23 @@ entries:
       sha256: "f8d0290c825c6e167acade9d1fbdaafc2c5e42edc06eaca6506acde251d4aa17"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-renderdoc/main/README.md"
 
+  - name: "dcc-mcp-obs"
+    description: "Native OBS Studio adapter with exact-process scene and source inspection plus typed recording control"
+    dcc: ["obs"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-obs"
+    issues_url: "https://github.com/dcc-mcp/dcc-mcp-obs/issues"
+    tags: ["adapter", "obs", "official", "pip", "recording", "streaming", "broadcast"]
+    version: "1.1.0"
+    min_core_version: "0.20.14"
+    maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-obs"
+      url: "https://files.pythonhosted.org/packages/cc/6e/fd6b04280ab4de5c1839cf7449f894b10e5cc9184fdefb34e073a214aa1a/dcc_mcp_obs-1.1.0-py3-none-any.whl"
+      sha256: "d407127d5b200df29a6cab0a5ed6546a03a6c5a8f93b617d0dd034442f0c6b7a"
+      entry_point: "dcc_mcp_obs:ObsMcpServer"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-obs/main/docs/install.md"
+
   - name: "dcc-mcp-substance3d-designer"
     description: "Substance 3D Designer adapter for DCC-MCP"
     dcc: ["substance3d_designer"]

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -53,6 +53,7 @@ submit a PR updating this matrix before the release PR merges.
 | Katana | [dcc-mcp-katana](https://github.com/dcc-mcp/dcc-mcp-katana) | 0.4.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | MotionBuilder | [dcc-mcp-mobu](https://github.com/dcc-mcp/dcc-mcp-mobu) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | RenderDoc | [dcc-mcp-renderdoc](https://github.com/dcc-mcp/dcc-mcp-renderdoc) | 0.3.0 | >=0.19.45,<1.0.0 | — | Headless CLI adapter | 2026-07 |
+| OBS Studio | [dcc-mcp-obs](https://github.com/dcc-mcp/dcc-mcp-obs) | 1.1.0 | >=0.20.14,<1.0.0 | 28+ | In-process native plugin + authenticated loopback WebSocket sidecar | 2026-08 |
 | Substance 3D Designer | [dcc-mcp-substance3d-designer](https://github.com/dcc-mcp/dcc-mcp-substance3d-designer) | 0.3.0 | >=0.19.45,<1.0.0 | — | Host bridge | — |
 | Substance 3D Painter | [dcc-mcp-substance3d-painter](https://github.com/dcc-mcp/dcc-mcp-substance3d-painter) | 0.1.3 | >=0.19.3,<1.0.0 | — | Host bridge | — |
 | Godot | [dcc-mcp-godot](https://github.com/dcc-mcp/dcc-mcp-godot) | 0.4.0 | >=0.19.45,<1.0.0 | 4.x | EditorPlugin + runtime bridge | 2026-07 |

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -34,6 +34,27 @@ def test_recent_adapter_releases_are_current() -> None:
     assert shogun["install"]["instructions_url"].endswith("/main/install.md")
 
 
+def test_obs_release_is_available_to_the_install_planner() -> None:
+    entries = {entry["name"]: entry for entry in _entries()}
+    obs = entries["dcc-mcp-obs"]
+
+    assert obs["dcc"] == ["obs"]
+    assert obs["version"] == "1.1.0"
+    assert obs["min_core_version"] == "0.20.14"
+    assert obs["install"] == {
+        "type": "pip",
+        "pip_package": "dcc-mcp-obs",
+        "url": (
+            "https://files.pythonhosted.org/packages/cc/6e/"
+            "fd6b04280ab4de5c1839cf7449f894b10e5cc9184fdefb34e073a214aa1a/"
+            "dcc_mcp_obs-1.1.0-py3-none-any.whl"
+        ),
+        "sha256": "d407127d5b200df29a6cab0a5ed6546a03a6c5a8f93b617d0dd034442f0c6b7a",
+        "entry_point": "dcc_mcp_obs:ObsMcpServer",
+        "instructions_url": ("https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-obs/main/docs/install.md"),
+    }
+
+
 def test_skill_only_packages_are_not_pip_adapters() -> None:
     entry_names = {entry["name"] for entry in _entries()}
 


### PR DESCRIPTION
Summary: add published OBS 1.1.0 to the built-in adapter catalog with its immutable PyPI wheel and SHA-256; expose obs through the dcc-types/install planner and synchronize the compatibility matrix; add catalog and CLI regression coverage. Validation: vx just preflight (3,787 nextest cases plus doc tests); vx just lint; cargo test -p dcc-mcp-cli; uv run pytest tests/test_public_adapter_catalog.py tests/test_install_sop_contract.py -q (21 passed); non-mutating dcc-mcp-cli OBS install-plan readback; independently recomputed wheel SHA-256. Skill guidance: no update required because this changes catalog metadata and regression contracts only.