### PR TITLE
test(gateway): prevent challenger poll starvation

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -1294,7 +1294,10 @@ mod tests {
             .is_empty()
         {
             assert!(tokio::time::Instant::now() < deadline);
-            tokio::task::yield_now().await;
+            // Leave the blocking registry worker enough time to acquire the
+            // in-process write lock. A tight synchronous read loop can starve
+            // the registration it is waiting to observe on loaded runners.
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
         challenger.abort();
         drop(occupied);


### PR DESCRIPTION
## Summary

- replace tight synchronous registry polling in the startup-readback challenger test with a short async backoff
- preserve the 8-second deadline and the registry-mutation contract while allowing the blocking registry writer to run
- keep the change test-only; no production gateway behavior changes

## Red to green

- before: 1 exact selected test failed at the 8.12-second deadline
- after: 5 consecutive exact selected runs passed in 0.13-0.15 seconds each

## Validation

- vx just preflight: 3787/3787 nextest tests plus doctests passed
- vx just lint
- exact test repeated 5 times with a positive selected-test count

No DCC-MCP Creator guidance update is needed for this test-only stabilization.