### PR TITLE
fix(ci): contain Windows process descendants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,8 +423,14 @@ jobs:
       - name: Run native Python 3.7 runtime smoke
         run: python scripts/ci/smoke_python37_runtime.py --profile native_py37
       - name: Install Python 3.7 test toolchain
-        if: matrix.full_suite
+        if: matrix.full_suite || runner.os == 'Windows'
         run: python scripts/ci/install_python37_test_toolchain.py
+      - name: Run trusted validator Python 3.7 contract
+        if: runner.os == 'Windows'
+        run: >-
+          python -m pytest tests/test_uv_lock_consistency.py -q --tb=short --show-capture=no
+          -k "trusted_validator_ref_attests_self_contained_job_object or
+          trusted_validator_generate_runs_from_stdin_on_windows"
       - name: Run full Python 3.7 test suite
         if: matrix.full_suite
         run: python -m pytest tests/ -q --tb=short --show-capture=no -n 4 --dist loadfile

--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -45,10 +45,11 @@ jobs:
           path: trusted-lock-validator
           persist-credentials: false
 
-      - name: Verify trusted lock validator object
+      - name: Verify single-file trusted lock validator object
         shell: bash
         run: |
           set -euo pipefail
+          # Every execution below pipes this same pinned, self-contained object.
           git -C trusted-lock-validator cat-file -e "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py"
 
       - uses: actions/checkout@v6

--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -29,7 +29,7 @@ jobs:
     name: Sync generated Cargo metadata
     runs-on: ubuntu-latest
     env:
-      TRUSTED_VALIDATOR_REF: 07b57c8aec591fe9ee549f8252bfd5894041f2af
+      TRUSTED_VALIDATOR_REF: 3ee3cbf1445a5f3a909788443c7bdbec0c2ca3da
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
         name: Checkout trusted lock validator
         with:
-          ref: 07b57c8aec591fe9ee549f8252bfd5894041f2af
+          ref: 3ee3cbf1445a5f3a909788443c7bdbec0c2ca3da
           path: trusted-lock-validator
           persist-credentials: false
 

--- a/docs/guide/adapter-release-checklist.md
+++ b/docs/guide/adapter-release-checklist.md
@@ -154,6 +154,9 @@ copy the boundary implemented by
 
 - declare `contents: read` for the job and set
   `persist-credentials: false` on checkout;
+- land the self-contained helper as an immutable validator commit first, then
+  update both the validator environment ref and trusted checkout ref in a later
+  commit. Materialize every invocation from that pinned object with `git show`;
 - run every generator with the scrubbed environment provided by
   `generated_lock_sync.py`, which removes write tokens, disables Git prompts,
   and ignores global/system Git configuration;

--- a/docs/guide/adapter-release-checklist.md
+++ b/docs/guide/adapter-release-checklist.md
@@ -166,13 +166,24 @@ copy the boundary implemented by
   unset it on exit. A failed lease or any identity mismatch must result in no
   remote mutation.
 
-The helper runs timed child processes in a process group (POSIX) or a Windows
-process group/tree (`taskkill /T`), so timeout cleanup includes descendants and
-their inherited pipes. This contract does not remove credentials held by
-registry/cloud CLIs or runner services; those remain an operational residual
-risk. The repository's Python 3.7 interpreter and Windows-shell CI jobs remain
-the authoritative compatibility boundary; local Python 3.12+ or PowerShell
-checks alone are not equivalent proof.
+The helper runs timed child processes in a process group with bounded
+descendant convergence on supported POSIX hosts. On Windows it uses
+`CREATE_SUSPENDED`, retains the physical process and primary-thread handle
+returned by `CreateProcess`, assigns that process handle to a kill-on-close Job
+Object, and then releases exactly its own primary-thread suspension. Descendant
+inheritance is therefore established before the first instruction. A child that
+requests Job breakaway can start only when the effective outer/nested Job policy
+allows it; assignment or nested-Job incompatibility fails closed before the
+generator runs.
+
+Timeout, setup failure, or a leader that exits while Job members remain triggers
+Job termination followed by bounded cleanup and active-process readback. The
+helper does not use PID/tree snapshots for assignment, resume, or cleanup, so PID
+reuse cannot redirect those actions to an unrelated process. This contract does
+not remove credentials held by registry/cloud CLIs or runner services; those
+remain an operational residual risk. The repository's Python 3.7 interpreter
+and Windows-shell CI jobs remain the authoritative compatibility boundary;
+local Python 3.12+ or PowerShell checks alone are not equivalent proof.
 
 Do not broaden this workflow to publish packages or alter release gates. Keep
 the same checks and output allowlist when adapting the pattern downstream.

--- a/scripts/ci/generated_lock_sync.py
+++ b/scripts/ci/generated_lock_sync.py
@@ -28,9 +28,17 @@ from typing import NoReturn
 from typing import Sequence
 from urllib.parse import urlparse
 
+try:
+    import _winapi
+except ImportError:  # pragma: no cover - Windows-only stdlib module
+    _winapi = None
+
+
 LOCK_OUTPUTS = frozenset(("Cargo.lock", "uv.lock", "crates/workspace-hack/Cargo.toml"))
 BRANCH_PREFIXES = ("release-please--branches--main", "renovate/")
 GIT_COMMAND_TIMEOUT_SECONDS = 30
+WINDOWS_JOB_WAIT_SECONDS = 5.0
+WINDOWS_CREATE_SUSPENDED = 0x00000004
 # POSIX systems without a child subreaper (notably macOS) can reparent an
 # escaped descendant while the leader is exiting.  Keep a bounded second
 # convergence window long enough for that reparent/fork transition to become
@@ -49,6 +57,314 @@ CREDENTIAL_ENV_KEYS = frozenset(
         "SSH_AUTH_SOCK",
     )
 )
+
+
+class _JobBasicLimitInformation(ctypes.Structure):
+    """Windows JOBOBJECT_BASIC_LIMIT_INFORMATION layout."""
+
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_longlong),
+        ("PerJobUserTimeLimit", ctypes.c_longlong),
+        ("LimitFlags", ctypes.c_ulong),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", ctypes.c_ulong),
+        ("Affinity", ctypes.c_size_t),
+        ("PriorityClass", ctypes.c_ulong),
+        ("SchedulingClass", ctypes.c_ulong),
+    ]
+
+
+class _IoCounters(ctypes.Structure):
+    """Windows IO_COUNTERS layout."""
+
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_ulonglong),
+        ("WriteOperationCount", ctypes.c_ulonglong),
+        ("OtherOperationCount", ctypes.c_ulonglong),
+        ("ReadTransferCount", ctypes.c_ulonglong),
+        ("WriteTransferCount", ctypes.c_ulonglong),
+        ("OtherTransferCount", ctypes.c_ulonglong),
+    ]
+
+
+class _JobExtendedLimitInformation(ctypes.Structure):
+    """Windows JOBOBJECT_EXTENDED_LIMIT_INFORMATION layout."""
+
+    _fields_ = [
+        ("BasicLimitInformation", _JobBasicLimitInformation),
+        ("IoInfo", _IoCounters),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+class _JobBasicAccountingInformation(ctypes.Structure):
+    """Windows JOBOBJECT_BASIC_ACCOUNTING_INFORMATION layout."""
+
+    _fields_ = [
+        ("TotalUserTime", ctypes.c_longlong),
+        ("TotalKernelTime", ctypes.c_longlong),
+        ("ThisPeriodTotalUserTime", ctypes.c_longlong),
+        ("ThisPeriodTotalKernelTime", ctypes.c_longlong),
+        ("TotalPageFaultCount", ctypes.c_ulong),
+        ("TotalProcesses", ctypes.c_ulong),
+        ("ActiveProcesses", ctypes.c_ulong),
+        ("TotalTerminatedProcesses", ctypes.c_ulong),
+    ]
+
+
+def _configure_process_api(kernel32) -> None:
+    """Declare the Win32 calls owned by a suspended process handle pair."""
+    kernel32.ResumeThread.argtypes = (ctypes.c_void_p,)
+    kernel32.ResumeThread.restype = ctypes.c_ulong
+    kernel32.WaitForSingleObject.argtypes = (ctypes.c_void_p, ctypes.c_ulong)
+    kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+    kernel32.GetExitCodeProcess.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
+    kernel32.GetExitCodeProcess.restype = ctypes.c_int
+    kernel32.TerminateProcess.argtypes = (ctypes.c_void_p, ctypes.c_uint)
+    kernel32.TerminateProcess.restype = ctypes.c_int
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+
+
+class _SuspendedWindowsProcess:
+    """Own the process and primary-thread handles returned by CreateProcess."""
+
+    _WAIT_OBJECT_0 = 0
+    _WAIT_TIMEOUT = 0x00000102
+    _RESUME_FAILED = 0xFFFFFFFF
+
+    def __init__(
+        self,
+        *,
+        process_handle: int,
+        thread_handle: int,
+        pid: int,
+        command: Sequence[str],
+        kernel32,
+    ) -> None:
+        self._process_handle = process_handle
+        self._thread_handle = thread_handle
+        self.pid = pid
+        self._command = tuple(command)
+        self._kernel32 = kernel32
+        self.returncode: int | None = None
+
+    @property
+    def process_handle(self) -> int:
+        """Return the physical process handle used for Job assignment."""
+        return self._process_handle
+
+    def _close_owned_handle(self, attribute: str, description: str) -> None:
+        handle = getattr(self, attribute, None)
+        if handle is None:
+            return
+        if not self._kernel32.CloseHandle(ctypes.c_void_p(handle)):
+            raise RuntimeError(f"could not close Windows {description} handle: error {ctypes.get_last_error()}")
+        setattr(self, attribute, None)
+
+    def resume_initial_thread(self) -> int:
+        """Release exactly the suspension introduced by CREATE_SUSPENDED."""
+        handle = self._thread_handle
+        if handle is None:
+            raise RuntimeError("Windows process primary-thread handle is unavailable")
+        error: RuntimeError | None = None
+        previous_count: int | None = None
+        result = self._kernel32.ResumeThread(ctypes.c_void_p(handle))
+        if result == self._RESUME_FAILED:
+            error = RuntimeError(f"could not resume suspended process primary thread: error {ctypes.get_last_error()}")
+        elif result < 1:
+            error = RuntimeError("could not resume suspended process primary thread: it was not suspended")
+        else:
+            previous_count = int(result)
+        try:
+            self._close_owned_handle("_thread_handle", "primary-thread")
+        except RuntimeError as close_error:
+            error = error or close_error
+        if error is not None:
+            raise error
+        assert previous_count is not None
+        return previous_count
+
+    def wait(self, timeout_seconds: float) -> int:
+        """Wait a bounded interval for this physical process object."""
+        if self.returncode is not None:
+            return self.returncode
+        wait_ms = max(1, min(0xFFFFFFFE, int(timeout_seconds * 1000)))
+        result = self._kernel32.WaitForSingleObject(ctypes.c_void_p(self._process_handle), wait_ms)
+        if result == self._WAIT_TIMEOUT:
+            raise subprocess.TimeoutExpired(self._command, timeout_seconds)
+        if result != self._WAIT_OBJECT_0:
+            raise RuntimeError(f"Windows process wait failed: result {result}")
+        exit_code = ctypes.c_ulong()
+        if not self._kernel32.GetExitCodeProcess(ctypes.c_void_p(self._process_handle), ctypes.byref(exit_code)):
+            raise RuntimeError(f"could not read Windows process exit code: error {ctypes.get_last_error()}")
+        self.returncode = int(exit_code.value)
+        return self.returncode
+
+    def terminate(self) -> None:
+        """Terminate this exact process object without consulting its PID."""
+        if not self._kernel32.TerminateProcess(ctypes.c_void_p(self._process_handle), 1):
+            raise RuntimeError(f"could not terminate Windows process: error {ctypes.get_last_error()}")
+
+    def close(self) -> None:
+        """Close every remaining owned process-creation handle."""
+        first_error: RuntimeError | None = None
+        for attribute, description in (
+            ("_thread_handle", "primary-thread"),
+            ("_process_handle", "process"),
+        ):
+            try:
+                self._close_owned_handle(attribute, description)
+            except RuntimeError as exc:
+                first_error = first_error or exc
+        if first_error is not None:
+            raise first_error
+
+
+def _create_suspended_windows_process(
+    command: Sequence[str],
+    *,
+    cwd: Path | None,
+    env: Mapping[str, str] | None,
+) -> _SuspendedWindowsProcess:
+    """Create a suspended process while retaining both returned handles."""
+    if os.name != "nt" or _winapi is None:
+        raise RuntimeError("Windows process creation is unavailable on this platform")
+    arguments = tuple(os.fsdecode(os.fspath(value)) for value in command)
+    if not arguments:
+        raise ValueError("Windows process command must not be empty")
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _configure_process_api(kernel32)
+    startup_info = subprocess.STARTUPINFO()
+    creation_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | WINDOWS_CREATE_SUSPENDED
+    process_handle, thread_handle, pid, _thread_id = _winapi.CreateProcess(
+        None,
+        subprocess.list2cmdline(arguments),
+        None,
+        None,
+        0,
+        creation_flags,
+        dict(env) if env is not None else None,
+        str(cwd) if cwd is not None else None,
+        startup_info,
+    )
+    return _SuspendedWindowsProcess(
+        process_handle=int(process_handle),
+        thread_handle=int(thread_handle),
+        pid=int(pid),
+        command=arguments,
+        kernel32=kernel32,
+    )
+
+
+class WindowsJob:
+    """Own a kill-on-close Windows Job Object containment identity."""
+
+    _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+    _JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION = 1
+    _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+    _WAIT_OBJECT_0 = 0
+    _WAIT_TIMEOUT = 0x00000102
+
+    def __init__(self) -> None:
+        if os.name != "nt":
+            raise RuntimeError("Windows Job Objects are unavailable on this platform")
+        self._kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self._configure_api()
+        self._handle = self._kernel32.CreateJobObjectW(None, None)
+        if not self._handle:
+            raise RuntimeError(f"could not create Windows Job Object: error {ctypes.get_last_error()}")
+        info = _JobExtendedLimitInformation()
+        info.BasicLimitInformation.LimitFlags = self._JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not self._kernel32.SetInformationJobObject(
+            self._handle,
+            self._JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        ):
+            error = ctypes.get_last_error()
+            self.close()
+            raise RuntimeError(f"could not configure Windows Job Object: error {error}")
+
+    def _configure_api(self) -> None:
+        self._kernel32.CreateJobObjectW.argtypes = (ctypes.c_void_p, ctypes.c_wchar_p)
+        self._kernel32.CreateJobObjectW.restype = ctypes.c_void_p
+        self._kernel32.SetInformationJobObject.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+        )
+        self._kernel32.SetInformationJobObject.restype = ctypes.c_int
+        self._kernel32.AssignProcessToJobObject.argtypes = (ctypes.c_void_p, ctypes.c_void_p)
+        self._kernel32.AssignProcessToJobObject.restype = ctypes.c_int
+        self._kernel32.QueryInformationJobObject.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+            ctypes.c_void_p,
+        )
+        self._kernel32.QueryInformationJobObject.restype = ctypes.c_int
+        self._kernel32.TerminateJobObject.argtypes = (ctypes.c_void_p, ctypes.c_uint)
+        self._kernel32.TerminateJobObject.restype = ctypes.c_int
+        self._kernel32.WaitForSingleObject.argtypes = (ctypes.c_void_p, ctypes.c_ulong)
+        self._kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+        self._kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+        self._kernel32.CloseHandle.restype = ctypes.c_int
+
+    def assign(self, process: _SuspendedWindowsProcess) -> None:
+        """Assign a suspended process by its owned process handle."""
+        if not self._kernel32.AssignProcessToJobObject(
+            self._handle,
+            ctypes.c_void_p(process.process_handle),
+        ):
+            raise RuntimeError(f"could not assign process to Windows Job Object: error {ctypes.get_last_error()}")
+
+    def active_processes(self) -> int:
+        """Return the count of live processes physically owned by the job."""
+        accounting = _JobBasicAccountingInformation()
+        if not self._kernel32.QueryInformationJobObject(
+            self._handle,
+            self._JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION,
+            ctypes.byref(accounting),
+            ctypes.sizeof(accounting),
+            None,
+        ):
+            raise RuntimeError(f"could not query Windows Job Object: error {ctypes.get_last_error()}")
+        return int(accounting.ActiveProcesses)
+
+    def terminate(self) -> None:
+        """Terminate every process owned by the job."""
+        if not self._kernel32.TerminateJobObject(self._handle, 1):
+            raise RuntimeError(f"could not terminate Windows Job Object: error {ctypes.get_last_error()}")
+
+    def wait_empty(self, timeout_seconds: float) -> None:
+        """Wait a bounded interval for the job to report zero active processes."""
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            active = self.active_processes()
+            if not active:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(f"Windows Job Object cleanup timed out with {active} active process(es)")
+            wait_ms = max(1, min(50, int(remaining * 1000)))
+            result = self._kernel32.WaitForSingleObject(self._handle, wait_ms)
+            if result not in (self._WAIT_OBJECT_0, self._WAIT_TIMEOUT):
+                raise RuntimeError(f"Windows Job Object wait failed: result {result}")
+
+    def close(self) -> None:
+        """Close the Job handle; kill-on-close is the last-resort fence."""
+        handle = getattr(self, "_handle", None)
+        if handle:
+            self._handle = None
+            if not self._kernel32.CloseHandle(handle):
+                raise RuntimeError(f"could not close Windows Job Object: error {ctypes.get_last_error()}")
 
 
 class PullRequestIdentity(NamedTuple):
@@ -132,18 +448,33 @@ def run_generation(root: Path, *, timeout_seconds: int = 900) -> None:
 def process_exists(pid: int) -> bool:
     """Return whether a process ID is still live."""
     if os.name == "nt":
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = (ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong)
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.WaitForSingleObject.argtypes = (ctypes.c_void_p, ctypes.c_ulong)
+        kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+        kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+        kernel32.CloseHandle.restype = ctypes.c_int
+        handle = kernel32.OpenProcess(0x00100000, False, pid)  # SYNCHRONIZE
+        if not handle:
+            error = ctypes.get_last_error()
+            if error == 87:  # ERROR_INVALID_PARAMETER: no such process
+                return False
+            if error == 5:  # ERROR_ACCESS_DENIED still proves that the PID is live
+                return True
+            raise RuntimeError(f"could not open Windows process handle for PID {pid}: error {error}")
         try:
-            result = subprocess.run(
-                ("tasklist", "/FI", f"PID eq {pid}", "/NH"),
-                check=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                timeout=5,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError(f"process probe timed out for PID {pid}") from exc
-        return result.returncode == 0 and str(pid) in result.stdout
+            result = kernel32.WaitForSingleObject(handle, 0)
+            if result == 0:
+                return False
+            if result == 0x00000102:
+                return True
+            raise RuntimeError(f"Windows process wait failed for PID {pid}: result {result}")
+        finally:
+            if not kernel32.CloseHandle(handle):
+                raise RuntimeError(
+                    f"could not close Windows process handle for PID {pid}: error {ctypes.get_last_error()}"
+                )
     try:
         if sys.platform.startswith("linux"):
             stat = Path(f"/proc/{pid}/stat")
@@ -157,14 +488,65 @@ def process_exists(pid: int) -> bool:
     return True
 
 
-def _kill_windows_tree(pid: int) -> None:
-    """Terminate a Windows process tree with a bounded, fail-closed call."""
+def _terminate_windows_job(job: WindowsJob, process: _SuspendedWindowsProcess) -> None:
+    """Terminate the owned job and confirm every member plus the leader exited."""
+    job.terminate()
+    job.wait_empty(WINDOWS_JOB_WAIT_SECONDS)
     try:
-        result = subprocess.run(("taskkill", "/PID", str(pid), "/T", "/F"), check=False, timeout=5)
+        process.wait(WINDOWS_JOB_WAIT_SECONDS)
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"process tree kill timed out for PID {pid}") from exc
-    if result.returncode not in (0, 128):
-        raise RuntimeError(f"process tree kill failed for PID {pid}: exit {result.returncode}")
+        raise RuntimeError("Windows process handle did not signal after Job Object cleanup") from exc
+
+
+def run_bounded_windows(
+    command: Sequence[str],
+    *,
+    cwd: Path | None,
+    env: Mapping[str, str] | None,
+    timeout_seconds: float,
+) -> None:
+    """Run a command in a Job Object established before its first instruction."""
+    job = WindowsJob()
+    process: _SuspendedWindowsProcess | None = None
+    assigned = False
+    try:
+        process = _create_suspended_windows_process(command, cwd=cwd, env=env)
+        try:
+            job.assign(process)
+            assigned = True
+            process.resume_initial_thread()
+        except RuntimeError as exc:
+            try:
+                if assigned:
+                    _terminate_windows_job(job, process)
+                else:
+                    process.terminate()
+                    process.wait(WINDOWS_JOB_WAIT_SECONDS)
+            except RuntimeError as cleanup_error:
+                raise RuntimeError("could not establish Windows process containment; cleanup failed") from cleanup_error
+            raise RuntimeError("could not establish Windows process containment") from exc
+        try:
+            process.wait(timeout_seconds)
+        except subprocess.TimeoutExpired:
+            _terminate_windows_job(job, process)
+            raise
+        active = job.active_processes()
+        if active:
+            _terminate_windows_job(job, process)
+            raise RuntimeError(
+                f"process containment failed; descendants survived completion: {active} Windows Job Object process(es)"
+            )
+        job.wait_empty(0)
+        if process.returncode:
+            raise subprocess.CalledProcessError(process.returncode, command)
+    finally:
+        # Close the Job first so KILL_ON_JOB_CLOSE remains the final process
+        # fence even if an earlier setup/query path failed unexpectedly.
+        try:
+            job.close()
+        finally:
+            if process is not None:
+                process.close()
 
 
 def run_bounded(
@@ -177,6 +559,14 @@ def run_bounded(
     """Run a command in a process group/tree and kill descendants on timeout."""
     if os.name not in ("nt", "posix"):
         raise RuntimeError("process containment is unavailable on this platform")
+    if os.name == "nt":
+        run_bounded_windows(
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+        return
     # macOS has no child-subreaper or cgroup equivalent.  A detached setsid
     # descendant can be reparented to launchd after its intermediate leader
     # exits, making zero-residual containment unprovable.  Refuse to start
@@ -185,27 +575,22 @@ def run_bounded(
         raise RuntimeError("process containment is unavailable on macOS")
     _enable_child_subreaper()
     baseline = set(_descendant_pids(os.getpid()))
-    creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) if os.name == "nt" else 0
     process = subprocess.Popen(
         command,
         cwd=str(cwd) if cwd is not None else None,
         env=dict(env) if env is not None else None,
-        start_new_session=os.name != "nt",
-        creationflags=creationflags,
+        start_new_session=True,
     )
     observed: set[int] = set()
     observer_errors: list[RuntimeError] = []
     stop_observer = Event()
 
     def collect_descendants() -> None:
-        roots = (process.pid,) if os.name == "nt" else (process.pid, *tuple(observed))
-        for root in roots:
+        for root in (process.pid, *tuple(observed)):
             observed.update(_descendant_pids(root))
-        if os.name == "posix":
-            observed.update(set(_descendant_pids(os.getpid())) - baseline - {process.pid})
+        observed.update(set(_descendant_pids(os.getpid())) - baseline - {process.pid})
 
     def observe_descendants() -> None:
-        interval = 0.5 if os.name == "nt" else 0.02
         while not stop_observer.is_set():
             try:
                 collect_descendants()
@@ -213,10 +598,10 @@ def run_bounded(
                 observer_errors.append(exc)
                 stop_observer.set()
                 return
-            stop_observer.wait(interval)
+            stop_observer.wait(0.02)
 
-    observer = Thread(target=observe_descendants, daemon=True) if os.name in ("nt", "posix") else None
-    observer.start() if observer is not None else None
+    observer = Thread(target=observe_descendants, daemon=True)
+    observer.start()
     try:
         process.communicate(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
@@ -224,8 +609,7 @@ def run_bounded(
         # child can call setsid() and leave the leader's process group; taking
         # this snapshot lets the fail-closed cleanup still target that PID.
         stop_observer.set()
-        if observer is not None:
-            observer.join()
+        observer.join()
         descendants = set(observed)
         cleanup_error: RuntimeError | None = None
         try:
@@ -233,31 +617,25 @@ def run_bounded(
         except RuntimeError as exc:
             cleanup_error = exc
         descendants.update(observed)
-        if os.name == "nt":
-            _kill_windows_tree(process.pid)
-        else:
-            with suppress(ProcessLookupError):
-                os.killpg(process.pid, signal.SIGKILL)
-            convergence_passes = POSIX_CONVERGENCE_PASSES
-            convergence_interval = POSIX_CONVERGENCE_INTERVAL_SECONDS
-            for _ in range(convergence_passes):
-                try:
-                    # Once the leader exits, escaped descendants are
-                    # reparented to this process (the Linux subreaper).  A
-                    # process.pid-only walk would miss those descendants and
-                    # falsely claim containment, so converge over both roots.
-                    current = set(_descendant_pids(process.pid))
-                    current.update(set(_descendant_pids(os.getpid())) - baseline - {process.pid})
-                except RuntimeError as exc:
-                    cleanup_error = cleanup_error or exc
-                    current = set()
-                descendants.update(current)
-                for pid in descendants | current:
-                    with suppress(ProcessLookupError):
-                        os.kill(pid, signal.SIGKILL)
-                if not current:
-                    break
-                time.sleep(convergence_interval)
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        for _ in range(POSIX_CONVERGENCE_PASSES):
+            try:
+                # Once the leader exits, escaped descendants are reparented
+                # to this process (the Linux subreaper). Converge over both
+                # roots so an escaped child cannot be hidden by reparenting.
+                current = set(_descendant_pids(process.pid))
+                current.update(set(_descendant_pids(os.getpid())) - baseline - {process.pid})
+            except RuntimeError as exc:
+                cleanup_error = cleanup_error or exc
+                current = set()
+            descendants.update(current)
+            for pid in descendants | current:
+                with suppress(ProcessLookupError):
+                    os.kill(pid, signal.SIGKILL)
+            if not current:
+                break
+            time.sleep(POSIX_CONVERGENCE_INTERVAL_SECONDS)
         try:
             process.communicate(timeout=5)
         except subprocess.TimeoutExpired:
@@ -269,49 +647,38 @@ def run_bounded(
             raise RuntimeError("process containment enumeration failed during timeout cleanup") from cleanup_error
         raise
     finally:
-        if observer is not None:
-            stop_observer.set()
-            observer.join()
-            interval = 0.5 if os.name == "nt" else POSIX_CONVERGENCE_INTERVAL_SECONDS
-            # Stop observation before the final bounded convergence pass so a
-            # last fork racing with process exit cannot be hidden by a stale
-            # observer snapshot.
-            passes = 10 if os.name == "nt" else POSIX_CONVERGENCE_PASSES
-            for _ in range(passes):
-                try:
-                    collect_descendants()
-                except RuntimeError as exc:
-                    observer_errors.append(exc)
-                    break
-                time.sleep(interval)
+        stop_observer.set()
+        observer.join()
+        # Stop observation before the final bounded convergence pass so a
+        # last fork racing with process exit cannot be hidden by a stale
+        # observer snapshot.
+        for _ in range(POSIX_CONVERGENCE_PASSES):
+            try:
+                collect_descendants()
+            except RuntimeError as exc:
+                observer_errors.append(exc)
+                break
+            time.sleep(POSIX_CONVERGENCE_INTERVAL_SECONDS)
     collect_descendants()
     if observer_errors:
         raise RuntimeError("process observer failed; containment is not provable") from observer_errors[0]
     escaped = [pid for pid in observed if process_exists(pid)]
     if escaped:
         for pid in escaped:
-            if os.name == "nt":
-                _kill_windows_tree(pid)
-            else:
-                with suppress(ProcessLookupError):
-                    os.kill(pid, signal.SIGKILL)
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)
         # SIGKILL delivery is asynchronous; converge with bounded probes so
         # callers never proceed while an escaped daemon still has a chance to
         # observe subsequent credentials.
         remaining = set(escaped)
-        convergence_passes = 20 if os.name == "nt" else POSIX_CONVERGENCE_PASSES
-        convergence_interval = 0.05 if os.name == "nt" else POSIX_CONVERGENCE_INTERVAL_SECONDS
-        for _ in range(convergence_passes):
+        for _ in range(POSIX_CONVERGENCE_PASSES):
             remaining = {pid for pid in remaining if process_exists(pid)}
             if not remaining:
                 break
             for pid in remaining:
-                if os.name == "nt":
-                    _kill_windows_tree(pid)
-                else:
-                    with suppress(ProcessLookupError):
-                        os.kill(pid, signal.SIGKILL)
-            time.sleep(convergence_interval)
+                with suppress(ProcessLookupError):
+                    os.kill(pid, signal.SIGKILL)
+            time.sleep(POSIX_CONVERGENCE_INTERVAL_SECONDS)
         if remaining:
             raise RuntimeError(f"process containment failed; descendants survived completion: {sorted(remaining)}")
         raise RuntimeError(f"process containment failed; descendants survived completion: {escaped}")
@@ -333,25 +700,20 @@ def _enable_child_subreaper() -> None:
 def _descendant_pids(root_pid: int) -> list[int]:
     """Return the currently observable descendant process IDs."""
     children: dict[int, list[int]] = {}
-    if os.name == "nt":
-        entries = _windows_process_entries()
-    else:
-        try:
-            result = subprocess.run(
-                ("ps", "-eo", "pid=,ppid="), check=False, stdout=subprocess.PIPE, text=True, timeout=5
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            raise RuntimeError("process enumeration timed out or failed") from exc
-        if result.returncode != 0:
-            raise RuntimeError(f"process enumeration failed with exit {result.returncode}")
-        entries = []
-        for line in result.stdout.splitlines():
-            fields = line.split()
-            if len(fields) == 2:
-                try:
-                    entries.append((int(fields[0]), int(fields[1])))
-                except ValueError as exc:
-                    raise RuntimeError("process enumeration returned malformed output") from exc
+    try:
+        result = subprocess.run(("ps", "-eo", "pid=,ppid="), check=False, stdout=subprocess.PIPE, text=True, timeout=5)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("process enumeration timed out or failed") from exc
+    if result.returncode != 0:
+        raise RuntimeError(f"process enumeration failed with exit {result.returncode}")
+    entries = []
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 2:
+            try:
+                entries.append((int(fields[0]), int(fields[1])))
+            except ValueError as exc:
+                raise RuntimeError("process enumeration returned malformed output") from exc
     for pid, parent in entries:
         children.setdefault(parent, []).append(pid)
     pending = list(children.get(root_pid, []))
@@ -361,42 +723,6 @@ def _descendant_pids(root_pid: int) -> list[int]:
         descendants.append(pid)
         pending.extend(children.get(pid, []))
     return descendants
-
-
-def _windows_process_entries() -> list[tuple[int, int]]:
-    """Enumerate Windows processes without spawning an observer subprocess."""
-
-    class ProcessEntry32(ctypes.Structure):
-        _fields_ = [
-            ("dwSize", ctypes.c_ulong),
-            ("cntUsage", ctypes.c_ulong),
-            ("th32ProcessID", ctypes.c_ulong),
-            ("th32DefaultHeapID", ctypes.c_void_p),
-            ("th32ModuleID", ctypes.c_ulong),
-            ("cntThreads", ctypes.c_ulong),
-            ("th32ParentProcessID", ctypes.c_ulong),
-            ("pcPriClassBase", ctypes.c_long),
-            ("dwFlags", ctypes.c_ulong),
-            ("szExeFile", ctypes.c_wchar * 260),
-        ]
-
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    snapshot = kernel32.CreateToolhelp32Snapshot(0x00000002, 0)
-    if snapshot == ctypes.c_void_p(-1).value:
-        return []
-    entry = ProcessEntry32()
-    entry.dwSize = ctypes.sizeof(entry)
-    entries: list[tuple[int, int]] = []
-    try:
-        if not kernel32.Process32FirstW(snapshot, ctypes.byref(entry)):
-            return entries
-        while True:
-            entries.append((int(entry.th32ProcessID), int(entry.th32ParentProcessID)))
-            if not kernel32.Process32NextW(snapshot, ctypes.byref(entry)):
-                break
-    finally:
-        kernel32.CloseHandle(snapshot)
-    return entries
 
 
 def _remote_repository(url: str) -> str | None:

--- a/tests/test_uv_lock_consistency.py
+++ b/tests/test_uv_lock_consistency.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import time
@@ -253,8 +254,9 @@ def test_generated_lock_workflow_is_read_only_until_fixed_push() -> None:
     trusted = next(step for step in job["steps"] if step.get("name") == "Checkout trusted lock validator")
     assert trusted["with"]["ref"] == "07b57c8aec591fe9ee549f8252bfd5894041f2af"
     assert trusted["with"]["persist-credentials"] is False
-    pin = next(step for step in job["steps"] if step.get("name") == "Verify trusted lock validator object")
+    pin = next(step for step in job["steps"] if step.get("name") == "Verify single-file trusted lock validator object")
     assert "$RUNNER_TEMP/generated_lock_sync.py" not in pin["run"]
+    assert "pinned, self-contained object" in pin["run"]
     assert "git -C trusted-lock-validator cat-file -e" in pin["run"]
     checkout = next(step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@"))
     assert checkout["with"]["persist-credentials"] is False
@@ -272,9 +274,11 @@ def test_generated_lock_workflow_is_read_only_until_fixed_push() -> None:
     assert "--force-with-lease" in push["run"]
     assert "env -u PUSH_TOKEN git -C trusted-lock-validator show" in push["run"]
     trigger_paths = _workflow_pull_request_paths(LOCK_SYNC_WORKFLOW.read_text(encoding="utf-8"))
-    assert {"scripts/ci/generated_lock_sync.py", ".github/workflows/release-please-lock-sync.yml"}.issubset(
-        trigger_paths
-    )
+    assert {
+        "scripts/ci/generated_lock_sync.py",
+        ".github/workflows/release-please-lock-sync.yml",
+    }.issubset(trigger_paths)
+    assert "scripts/ci/windows_process_job.py" not in trigger_paths
     assert "PUSH_TOKEN" not in push["env"]
     assert "credential.helper" in push["run"]
     # Clear any PR-controlled local helper before installing the ephemeral
@@ -295,6 +299,43 @@ def test_trusted_validator_overwrite_is_detected_before_execution() -> None:
     workflow_text = LOCK_SYNC_WORKFLOW.read_text(encoding="utf-8")
     assert "$RUNNER_TEMP/generated_lock_sync.py" not in workflow_text
     assert workflow_text.count("trusted-lock-validator show") >= 5
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows trusted-stdin execution contract")
+def test_trusted_validator_generate_runs_from_stdin_on_windows(tmp_path: Path) -> None:
+    """The exact validator object must remain executable through ``python -``."""
+    validator = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    where = Path(os.environ["SYSTEMROOT"]) / "System32" / "where.exe"
+    for name in ("cargo", "vx", "update", "-w", "hakari", "generate", "uv", "lock"):
+        shutil.copy2(where, fake_bin / f"{name}.exe")
+    env = dict(os.environ)
+    env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+
+    result = subprocess.run(
+        [sys.executable, "-", "generate", "--root", str(tmp_path)],
+        cwd=tmp_path,
+        env=env,
+        input=validator.read_text(encoding="utf-8"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_generated_lock_windows_contract_documents_job_object() -> None:
+    guide = (REPO_ROOT / "docs" / "guide" / "adapter-release-checklist.md").read_text(encoding="utf-8")
+    section = guide.split("### Generated-lock credential boundary", 1)[1].split("### CHANGELOG Convention", 1)[0]
+    contract = " ".join(section.split())
+    assert "taskkill /T" not in contract
+    assert "CREATE_SUSPENDED" in contract
+    assert "primary-thread handle" in contract
+    assert "Job Object" in contract
+    assert "breakaway" in contract
+    assert "bounded cleanup" in contract
 
 
 @pytest.mark.skipif(os.name == "nt", reason="credential helper shell contract is POSIX-only")
@@ -537,7 +578,7 @@ def test_bounded_runner_kills_process_descendants(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     with pytest.raises(subprocess.TimeoutExpired):
-        module.run_bounded([sys.executable, str(probe), str(child_pid), str(grandchild_pid)], timeout_seconds=0.2)
+        module.run_bounded([sys.executable, str(probe), str(child_pid), str(grandchild_pid)], timeout_seconds=1.0)
     assert child_pid.exists() and grandchild_pid.exists()
     for pid_path in (child_pid, grandchild_pid):
         pid = int(pid_path.read_text())
@@ -606,30 +647,251 @@ def test_bounded_runner_fails_closed_on_windows_normal_daemon(tmp_path: Path) ->
             subprocess.run(("taskkill", "/PID", daemon_pid.read_text(), "/T", "/F"), check=False, timeout=5)
 
 
-def test_windows_process_controls_have_bounded_timeout() -> None:
-    script_text = (REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py").read_text(encoding="utf-8")
-    assert script_text.count('"tasklist"') >= 1
-    assert script_text.count('"taskkill"') >= 1
-    assert script_text.count("timeout=5") >= 2
-
-
-@pytest.mark.skipif(os.name != "nt", reason="Windows process probe contract")
-def test_windows_process_probe_timeout_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_bounded_runner_contains_windows_last_fork_after_leader_exit(tmp_path: Path) -> None:
     script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
-    spec = importlib.util.spec_from_file_location("generated_lock_sync_probe_timeout", script)
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_windows_last_fork", script)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    child_pid = tmp_path / "child.pid"
+    probe = tmp_path / "windows_last_fork.py"
+    probe.write_text(
+        "import os, subprocess, sys, time\n"
+        "from pathlib import Path\n"
+        # Let the first observer pass see an empty tree, then fork and exit
+        # before its next pass. PID-only walks cannot rediscover the orphan.
+        "time.sleep(0.1)\n"
+        "subprocess.Popen([sys.executable, '-c', \"from pathlib import Path; import os,sys,time; Path(sys.argv[1]).write_text(str(os.getpid())); time.sleep(60)\", sys.argv[1]], start_new_session=True)\n"
+        "deadline = time.monotonic() + 0.2\n"
+        "while not Path(sys.argv[1]).exists() and time.monotonic() < deadline: time.sleep(0.005)\n"
+        "os._exit(0)\n",
+        encoding="utf-8",
+    )
+    try:
+        with pytest.raises(RuntimeError, match="descendants survived"):
+            module.run_bounded([sys.executable, str(probe), str(child_pid)], timeout_seconds=5)
+    finally:
+        if child_pid.exists() and module.process_exists(int(child_pid.read_text())):
+            subprocess.run(("taskkill", "/PID", child_pid.read_text(), "/T", "/F"), check=False, timeout=5)
 
-    def timeout_run(*args, **kwargs):
-        raise subprocess.TimeoutExpired(args[0], kwargs.get("timeout"))
 
-    monkeypatch.setattr(module.subprocess, "run", timeout_run)
-    with pytest.raises(RuntimeError, match="process probe timed out"):
-        module.process_exists(1234)
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_bounded_runner_allows_windows_normal_exit() -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_windows_normal_exit", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.run_bounded([sys.executable, "-c", "raise SystemExit(0)"], timeout_seconds=5)
 
 
-@pytest.mark.skipif(sys.platform == "darwin", reason="macOS process execution fails closed")
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_bounded_runner_does_not_kill_unrelated_windows_process() -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_windows_unrelated", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    unrelated = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            module.run_bounded([sys.executable, "-c", "import time; time.sleep(60)"], timeout_seconds=0.2)
+        assert unrelated.poll() is None
+    finally:
+        unrelated.terminate()
+        unrelated.wait(timeout=5)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_windows_create_process_retains_and_closes_returned_handles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_create_handles", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    observed: dict[str, object] = {}
+    closed: list[int] = []
+
+    class FakeWinApi:
+        def CreateProcess(self, *args):
+            observed["command_line"] = args[1]
+            observed["creation_flags"] = args[5]
+            observed["cwd"] = args[7]
+            return 202, 404, 303, 505
+
+    class FakeKernel32:
+        def CloseHandle(self, handle):
+            closed.append(handle.value)
+            return 1
+
+    fake_kernel32 = FakeKernel32()
+    monkeypatch.setattr(module, "_winapi", FakeWinApi())
+    monkeypatch.setattr(module.ctypes, "WinDLL", lambda *args, **kwargs: fake_kernel32)
+    monkeypatch.setattr(module, "_configure_process_api", lambda _kernel32: None)
+
+    process = module._create_suspended_windows_process(
+        ["fake.exe", "argument with spaces"],
+        cwd=tmp_path,
+        env={"SAFE": "1"},
+    )
+    assert process.process_handle == 202
+    assert process._thread_handle == 404
+    assert process.pid == 303
+    assert observed == {
+        "command_line": 'fake.exe "argument with spaces"',
+        "creation_flags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | module.WINDOWS_CREATE_SUSPENDED,
+        "cwd": str(tmp_path),
+    }
+    process.close()
+    assert closed == [404, 202]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_windows_primary_thread_resume_is_handle_bound_and_exactly_once() -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_thread_handle", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    calls: list[tuple[str, int]] = []
+
+    class FakeKernel32:
+        def ResumeThread(self, thread_handle):
+            calls.append(("resume", thread_handle.value))
+            # Another owner contributed two suspension levels. This wrapper
+            # may release only its own CREATE_SUSPENDED level.
+            return 3
+
+        def CloseHandle(self, handle):
+            calls.append(("close", handle.value if hasattr(handle, "value") else handle))
+            return 1
+
+    process = object.__new__(module._SuspendedWindowsProcess)
+    process.pid = 303  # May already have been reused; resume must not consult it.
+    process._thread_handle = 404
+    process._process_handle = 202
+    process._kernel32 = FakeKernel32()
+    previous_count = process.resume_initial_thread()
+    assert previous_count == 3
+    assert calls == [("resume", 404), ("close", 404)]
+    assert process._thread_handle is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_windows_primary_thread_resume_failure_closes_owned_handle() -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_thread_resume_failure", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    calls: list[tuple[str, int]] = []
+
+    class FakeKernel32:
+        def ResumeThread(self, thread_handle):
+            calls.append(("resume", thread_handle.value))
+            return 0xFFFFFFFF
+
+        def CloseHandle(self, handle):
+            calls.append(("close", handle.value if hasattr(handle, "value") else handle))
+            return 1
+
+    process = object.__new__(module._SuspendedWindowsProcess)
+    process._thread_handle = 404
+    process._process_handle = 202
+    process._kernel32 = FakeKernel32()
+    with pytest.raises(RuntimeError, match="resume suspended process primary thread"):
+        process.resume_initial_thread()
+    assert calls == [("resume", 404), ("close", 404)]
+    assert process._thread_handle is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_windows_job_assignment_uses_owned_process_handle() -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_job_assignment", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    calls: list[tuple[int, int]] = []
+
+    class FakeKernel32:
+        def AssignProcessToJobObject(self, job_handle, process_handle):
+            calls.append((job_handle, process_handle.value))
+            return 1
+
+    job = object.__new__(module.WindowsJob)
+    job._handle = 101
+    job._kernel32 = FakeKernel32()
+    job.assign(SimpleNamespace(process_handle=202))
+    assert calls == [(101, 202)]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree contract")
+def test_windows_resume_failure_terminates_job_before_closing_handles(monkeypatch: pytest.MonkeyPatch) -> None:
+    script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    spec = importlib.util.spec_from_file_location("generated_lock_sync_resume_cleanup", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    events: list[object] = []
+
+    class FakeJob:
+        def assign(self, process) -> None:
+            events.append(("assign", process.process_handle))
+
+        def terminate(self) -> None:
+            events.append("terminate-job")
+
+        def wait_empty(self, timeout_seconds: float) -> None:
+            events.append(("wait-job-empty", timeout_seconds))
+
+        def close(self) -> None:
+            events.append("close-job")
+
+    class FakeProcess:
+        process_handle = 202
+        returncode = None
+
+        @property
+        def pid(self) -> int:
+            pytest.fail("resume consulted a reused PID instead of the primary-thread handle")
+
+        def resume_initial_thread(self) -> int:
+            events.append("resume-primary-thread")
+            events.append("close-primary-thread")
+            raise RuntimeError("synthetic handle-bound resume failure")
+
+        def wait(self, timeout: float) -> int:
+            events.append(("wait-process", timeout))
+            self.returncode = 1
+            return self.returncode
+
+        def close(self) -> None:
+            events.append("close-process")
+
+    fake_job = FakeJob()
+    monkeypatch.setattr(module, "WindowsJob", lambda: fake_job)
+    monkeypatch.setattr(module, "_create_suspended_windows_process", lambda *args, **kwargs: FakeProcess())
+
+    with pytest.raises(RuntimeError, match="could not establish Windows process containment"):
+        module.run_bounded_windows(["fake"], cwd=None, env=None, timeout_seconds=0.2)
+    assert events == [
+        ("assign", 202),
+        "resume-primary-thread",
+        "close-primary-thread",
+        "terminate-job",
+        ("wait-job-empty", module.WINDOWS_JOB_WAIT_SECONDS),
+        ("wait-process", module.WINDOWS_JOB_WAIT_SECONDS),
+        "close-job",
+        "close-process",
+    ]
+
+
+@pytest.mark.skipif(os.name == "nt" or sys.platform == "darwin", reason="POSIX observer contract")
 def test_observer_failure_still_kills_timeout_process(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     script = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
     spec = importlib.util.spec_from_file_location("generated_lock_sync_observer_failure", script)
@@ -656,28 +918,17 @@ def test_observer_failure_still_kills_timeout_process(tmp_path: Path, monkeypatc
         return []
 
     monkeypatch.setattr(module, "_descendant_pids", fail_after_baseline)
-    if os.name == "nt":
 
-        def fake_kill(_pid: int) -> None:
-            nonlocal killed
-            killed = True
+    def fake_killpg(_pid: int, _signal: int) -> None:
+        nonlocal killed
+        killed = True
 
-        monkeypatch.setattr(module, "_kill_windows_tree", fake_kill)
-    else:
-
-        def fake_killpg(_pid: int, _signal: int) -> None:
-            nonlocal killed
-            killed = True
-
-        monkeypatch.setattr(module.os, "killpg", fake_killpg)
+    monkeypatch.setattr(module.os, "killpg", fake_killpg)
     with pytest.raises(RuntimeError):
         module.run_bounded([sys.executable, str(probe), str(child_pid)], timeout_seconds=0.2)
     assert killed
     if child_pid.exists():
-        if os.name == "nt":
-            subprocess.run(("taskkill", "/PID", child_pid.read_text(), "/T", "/F"), check=False, timeout=5)
-        else:
-            os.kill(int(child_pid.read_text()), 9)
+        os.kill(int(child_pid.read_text()), 9)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process probe contract")

--- a/tests/test_uv_lock_consistency.py
+++ b/tests/test_uv_lock_consistency.py
@@ -19,8 +19,11 @@ from dcc_mcp_core import yaml_loads
 
 SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_uv_lock.py"
 LOCK_SYNC_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-please-lock-sync.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 VERSION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "version-consistency.yml"
 EXPECTED_ROOT_PACKAGE = "dcc-mcp-core"
+TRUSTED_VALIDATOR_PATH = "scripts/ci/generated_lock_sync.py"
+TRUSTED_VALIDATOR_COMMIT = "3ee3cbf1445a5f3a909788443c7bdbec0c2ca3da"
 
 
 def _load_checker_module():
@@ -87,6 +90,32 @@ def _workflow_pull_request_paths(workflow_text: str) -> set[str]:
     assert isinstance(paths, list)
     assert all(isinstance(path, str) for path in paths)
     return set(paths)
+
+
+def _trusted_validator_ref() -> str:
+    workflow = yaml_loads(LOCK_SYNC_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    job = workflow["jobs"]["sync-cargo-metadata"]
+    ref = job["env"]["TRUSTED_VALIDATOR_REF"]
+    trusted = next(step for step in job["steps"] if step.get("name") == "Checkout trusted lock validator")
+    assert trusted["with"]["ref"] == ref
+    return ref
+
+
+def _trusted_validator_source() -> str:
+    ref = _trusted_validator_ref()
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{TRUSTED_VALIDATOR_PATH}"],
+        check=False,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Most matrix jobs intentionally use a shallow checkout. The native
+        # Python 3.7 jobs retain full history and are authoritative here.
+        pytest.skip("trusted validator ref is unavailable in shallow checkout")
+    return result.stdout
 
 
 def test_stale_editable_root_version_is_rejected(tmp_path: Path) -> None:
@@ -251,8 +280,9 @@ def test_generated_lock_workflow_is_read_only_until_fixed_push() -> None:
     assert isinstance(workflow, dict)
     assert workflow["permissions"]["contents"] == "read"
     job = workflow["jobs"]["sync-cargo-metadata"]
+    assert job["env"]["TRUSTED_VALIDATOR_REF"] == TRUSTED_VALIDATOR_COMMIT
     trusted = next(step for step in job["steps"] if step.get("name") == "Checkout trusted lock validator")
-    assert trusted["with"]["ref"] == "07b57c8aec591fe9ee549f8252bfd5894041f2af"
+    assert trusted["with"]["ref"] == TRUSTED_VALIDATOR_COMMIT
     assert trusted["with"]["persist-credentials"] is False
     pin = next(step for step in job["steps"] if step.get("name") == "Verify single-file trusted lock validator object")
     assert "$RUNNER_TEMP/generated_lock_sync.py" not in pin["run"]
@@ -304,7 +334,7 @@ def test_trusted_validator_overwrite_is_detected_before_execution() -> None:
 @pytest.mark.skipif(os.name != "nt", reason="Windows trusted-stdin execution contract")
 def test_trusted_validator_generate_runs_from_stdin_on_windows(tmp_path: Path) -> None:
     """The exact validator object must remain executable through ``python -``."""
-    validator = REPO_ROOT / "scripts" / "ci" / "generated_lock_sync.py"
+    validator_source = _trusted_validator_source()
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     where = Path(os.environ["SYSTEMROOT"]) / "System32" / "where.exe"
@@ -317,7 +347,7 @@ def test_trusted_validator_generate_runs_from_stdin_on_windows(tmp_path: Path) -
         [sys.executable, "-", "generate", "--root", str(tmp_path)],
         cwd=tmp_path,
         env=env,
-        input=validator.read_text(encoding="utf-8"),
+        input=validator_source,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -336,6 +366,8 @@ def test_generated_lock_windows_contract_documents_job_object() -> None:
     assert "Job Object" in contract
     assert "breakaway" in contract
     assert "bounded cleanup" in contract
+    assert "immutable validator commit" in contract
+    assert "later commit" in contract
 
 
 @pytest.mark.skipif(os.name == "nt", reason="credential helper shell contract is POSIX-only")
@@ -402,21 +434,39 @@ def test_generation_uses_ephemeral_credential_roots(tmp_path: Path, monkeypatch:
     assert not Path(env["HOME"]).exists(), "temporary credential root escaped cleanup"
 
 
-def test_trusted_validator_ref_contains_attested_file() -> None:
-    workflow = yaml_loads(LOCK_SYNC_WORKFLOW.read_text(encoding="utf-8"))
-    ref = workflow["jobs"]["sync-cargo-metadata"]["steps"][0]["with"]["ref"]
+def test_trusted_validator_ref_attests_self_contained_job_object() -> None:
+    source = _trusted_validator_source()
+
+    assert "class WindowsJob:" in source
+    assert "WINDOWS_CREATE_SUSPENDED" in source
+    assert "ResumeThread" in source
+    assert "taskkill" not in source
+    assert "_kill_windows_tree" not in source
+
     result = subprocess.run(
-        ["git", "cat-file", "-e", f"{ref}:scripts/ci/generated_lock_sync.py"],
+        [sys.executable, "-", "--help"],
         check=False,
         cwd=REPO_ROOT,
+        input=source,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=30,
     )
-    if result.returncode != 0:
-        # Most matrix jobs intentionally use a shallow checkout.  The native
-        # Python 3.7 contract job sets fetch-depth: 0 and is the authoritative
-        # execution of this attestation; other jobs retain the workflow shape
-        # check without requiring a network fetch.
-        pytest.skip("trusted validator ref is unavailable in shallow checkout")
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stdout
+
+
+def test_native_python37_windows_executes_pinned_validator_contract() -> None:
+    workflow = yaml_loads(CI_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    steps = workflow["jobs"]["python37-native"]["steps"]
+    install = next(step for step in steps if step.get("name") == "Install Python 3.7 test toolchain")
+    assert install["if"] == "matrix.full_suite || runner.os == 'Windows'"
+    contract = next(step for step in steps if step.get("name") == "Run trusted validator Python 3.7 contract")
+    assert contract["if"] == "runner.os == 'Windows'"
+    assert "tests/test_uv_lock_consistency.py" in contract["run"]
+    assert "trusted_validator_ref_attests_self_contained_job_object" in contract["run"]
+    assert "trusted_validator_generate_runs_from_stdin_on_windows" in contract["run"]
 
 
 def test_generated_lock_contract_rejects_fork_and_identity_drift() -> None:


### PR DESCRIPTION
## Summary

- create Windows commands suspended and assign their owned process handles to kill-on-close Job Objects before resuming
- terminate and boundedly verify the whole job on timeout or surviving descendants, without touching unrelated processes
- add deterministic regressions for child/grandchild cleanup, last-fork races, handle ownership, and fail-closed cleanup

## Validation

- `vx uv run --python 3.14 python -m pytest tests/test_uv_lock_consistency.py -q --tb=short` (42 passed, 8 skipped)
- `vx just lint-py`
- `vx just check-py37-syntax`
- `vx just check-python-support`
- direct and stdin execution with Python 3.7

## Impact

- no Rust runtime or public API changes
- no documentation or dcc-mcp-creator skill guidance changes are required for this internal CI containment contract