### PR TITLE
fix: enforce portable recipe regex syntax

### DIFF
--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+_INLINE_FLAG_CHARACTERS = "aiLmsux-"
+
+
+def _is_global_inline_flag_group(pattern: str, index: int) -> bool:
+    """Return whether ``index`` starts a syntactic ``(?flags)`` group."""
+    if not pattern.startswith("(?", index):
+        return False
+    cursor = index + 2
+    while cursor < len(pattern) and pattern[cursor] in _INLINE_FLAG_CHARACTERS:
+        cursor += 1
+    return cursor > index + 2 and cursor < len(pattern) and pattern[cursor] == ")"
+
 
 def pattern_is_safe(pattern: str) -> bool:
     """Accept only patterns whose backtracking structure is provably linear.
@@ -43,6 +55,10 @@ def pattern_is_safe(pattern: str) -> bool:
     while index < len(pattern):
         character = pattern[index]
         if escaped:
+            # ``\N{name}`` requires Python 3.8+ and ``\z`` requires Python
+            # 3.14+, so neither belongs to the Python 3.7-3.14 common subset.
+            if character in {"N", "z"}:
+                return False
             # Numeric and named backreferences are non-regular and can
             # force unbounded backtracking. Reject all digit escapes to
             # keep the accepted grammar explicit and conservative.
@@ -90,6 +106,11 @@ def pattern_is_safe(pattern: str) -> bool:
             # regular, but rejecting the whole construct avoids ambiguity
             # in this deliberately small safety grammar.
             if pattern.startswith("(?P=", index):
+                return False
+            # Python 3.7 permits global inline flags after a prefix or inside
+            # another group, while current Python requires absolute position
+            # zero. Scoped ``(?flags:...)`` groups remain portable anywhere.
+            if index != 0 and _is_global_inline_flag_group(pattern, index):
                 return False
             frames.append(frame_has_quantifier)
             frame_has_quantifier = False
@@ -700,7 +721,7 @@ def _group_content_start(
     parent_ignore_case: bool,
 ) -> tuple[int, bool, bool, bool]:
     """Return group content, width, scoped case-fold state, and support."""
-    for prefix in ("?:", "?=", "?!", "?<=", "?<!", "?>"):
+    for prefix in ("?:", "?=", "?!", "?<=", "?<!"):
         if pattern.startswith(prefix, start):
             return (
                 start + len(prefix),
@@ -716,11 +737,13 @@ def _group_content_start(
         comment_end = pattern.find(")", start + 2)
         content_start = comment_end if comment_end >= 0 else start
         return content_start, True, parent_ignore_case, True
-    if pattern.startswith("?(", start):
+    # Atomic groups require Python 3.11+, so they are outside the portable
+    # Python 3.7-3.14 recipe grammar. Conditional groups are also unsupported.
+    if pattern.startswith(("?>", "?("), start):
         return start, False, parent_ignore_case, False
     if start < len(pattern) and pattern[start] == "?":
         cursor = start + 1
-        while cursor < len(pattern) and pattern[cursor] in "aiLmsux-":
+        while cursor < len(pattern) and pattern[cursor] in _INLINE_FLAG_CHARACTERS:
             cursor += 1
         if cursor > start + 1 and cursor < len(pattern) and pattern[cursor] in ":)":
             ignore_case, supported = _apply_inline_case_flag(

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -170,6 +170,12 @@ Generated `tools.yaml` entries follow the modern contract:
   root, and its value must be the absolute canonical Draft 2020-12 URI
   `https://json-schema.org/draft/2020-12/schema`. Null, relative, unsupported,
   and nested dialect declarations fail closed during recipe admission.
+- Recipe `pattern` and `patternProperties` expressions must use syntax shared
+  by Python 3.7-3.14. Version-specific constructs such as atomic groups
+  `(?>...)` fail closed; use portable constructs such as `(?:...)` only when
+  they preserve the intended matching semantics. Global inline flags such as
+  `(?i)` are portable only at the absolute start; use scoped flags such as
+  `(?i:...)` when flags must appear after a prefix or inside another group.
 - `execution` is `sync` or `async`; use `async` for deferred/long-running work.
 - `job_strategy` is `monolithic` (default), `chunked`, or `isolated`. Agents
   use it to select a safe execution and recovery workflow.

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
+from dcc_mcp_core._runtime.recipe_schema_patterns import pattern_is_safe
 from dcc_mcp_core.recipes import _RecipeSchemaValidator
 from dcc_mcp_core.recipes import get_recipe_content
 from dcc_mcp_core.recipes import get_recipes_path
@@ -1360,6 +1361,192 @@ class TestRegisterRecipesTools:
             assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
             assert applied["success"] is False
             assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        ("schema", "inputs"),
+        [
+            ({"type": "string", "pattern": "^(?>ab)+$"}, "abab"),
+            (
+                {
+                    "type": "object",
+                    "patternProperties": {"^(?>ab)+$": {"type": "string"}},
+                },
+                {"abab": "value"},
+            ),
+            ({"type": "string", "pattern": "^ab++$"}, "ab"),
+            ({"type": "string", "pattern": r"^\z$"}, ""),
+            ({"type": "string", "pattern": r"^\N{EM DASH}$"}, "—"),
+        ],
+    )
+    def test_python_version_specific_regex_syntax_fails_closed_during_admission(
+        self,
+        schema: dict[str, object],
+        inputs: object,
+    ) -> None:
+        assert validate_recipe_inputs({"inputs_schema": schema}, inputs) == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [
+            "^a(?i)b$",
+            "^(?:(?i)ab)$",
+        ],
+    )
+    def test_nonleading_global_inline_flags_fail_closed_across_schema_keywords(self, pattern: str) -> None:
+        assert pattern_is_safe(pattern) is False
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, "aB") == [
+            "$: Recipe input schema is invalid"
+        ]
+        assert validate_recipe_inputs(
+            {
+                "inputs_schema": {
+                    "type": "object",
+                    "patternProperties": {pattern: {"type": "string"}},
+                }
+            },
+            {"aB": "value"},
+        ) == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        ("pattern", "value"),
+        [
+            ("(?i)^ab$", "AB"),
+            ("^a(?i:b)$", "aB"),
+            (r"^\(\?i\)$", "(?i)"),
+            (r"^[()?i]+$", "(?i)"),
+        ],
+    )
+    def test_portable_inline_flag_and_literal_controls_remain_supported(self, pattern: str, value: str) -> None:
+        assert pattern_is_safe(pattern) is True
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, value) == []
+        assert (
+            validate_recipe_inputs(
+                {
+                    "inputs_schema": {
+                        "type": "object",
+                        "patternProperties": {pattern: {"type": "string"}},
+                    }
+                },
+                {value: "value"},
+            )
+            == []
+        )
+
+    def test_inline_flag_portability_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        handlers = self._make_recipe_handlers(
+            tmp_path,
+            skill_name="inline-flag-portability-skill",
+            recipes={
+                "prefixed-global-pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": "^a(?i)b$"}},
+                },
+                "nested-global-pattern-properties": {
+                    "type": "object",
+                    "patternProperties": {"^(?:(?i)ab)$": {"type": "string"}},
+                },
+                "leading-global-pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": "(?i)^ab$"}},
+                },
+                "scoped-pattern-properties": {
+                    "type": "object",
+                    "patternProperties": {"^a(?i:b)$": {"type": "string"}},
+                },
+                "escaped-literal-pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": r"^\(\?i\)$"}},
+                },
+                "character-class-pattern-properties": {
+                    "type": "object",
+                    "patternProperties": {r"^[()?i]+$": {"type": "string"}},
+                },
+            },
+        )
+        cases = [
+            ("prefixed-global-pattern", {"value": "aB"}, False),
+            ("nested-global-pattern-properties", {"aB": "value"}, False),
+            ("leading-global-pattern", {"value": "AB"}, True),
+            ("scoped-pattern-properties", {"aB": "value"}, True),
+            ("escaped-literal-pattern", {"value": "(?i)"}, True),
+            ("character-class-pattern-properties", {"(?i)": "value"}, True),
+        ]
+
+        for recipe_name, inputs, expected_valid in cases:
+            params = {"skill": "inline-flag-portability-skill", "recipe": recipe_name, "inputs": inputs}
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            assert validated["context"]["valid"] is expected_valid
+            assert applied["success"] is expected_valid
+            if not expected_valid:
+                assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+                assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        ("schema", "inputs"),
+        [
+            ({"type": "string", "pattern": "^(?:ab)+$"}, "abab"),
+            (
+                {
+                    "type": "object",
+                    "patternProperties": {"^(?:ab)+$": {"type": "string"}},
+                },
+                {"abab": "value"},
+            ),
+            ({"type": "string", "pattern": r"^\Z$"}, ""),
+            ({"type": "string", "pattern": r"^\u2014$"}, "—"),
+        ],
+    )
+    def test_portable_regex_syntax_controls_remain_supported(
+        self,
+        schema: dict[str, object],
+        inputs: object,
+    ) -> None:
+        assert validate_recipe_inputs({"inputs_schema": schema}, inputs) == []
+
+    def test_atomic_group_rejection_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        atomic_pattern = "^(?>ab)+$"
+        portable_pattern = "^(?:ab)+$"
+        handlers = self._make_recipe_handlers(
+            tmp_path,
+            skill_name="portable-regex-skill",
+            recipes={
+                "atomic-pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": atomic_pattern}},
+                },
+                "atomic-pattern-properties": {
+                    "type": "object",
+                    "patternProperties": {atomic_pattern: {"type": "string"}},
+                },
+                "portable-pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": portable_pattern}},
+                },
+            },
+        )
+
+        for recipe_name, inputs in (
+            ("atomic-pattern", {"value": "abab"}),
+            ("atomic-pattern-properties", {"abab": "value"}),
+        ):
+            params = {"skill": "portable-regex-skill", "recipe": recipe_name, "inputs": inputs}
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            assert validated["context"]["valid"] is False
+            assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+            assert applied["success"] is False
+            assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+        portable_params = {
+            "skill": "portable-regex-skill",
+            "recipe": "portable-pattern",
+            "inputs": {"value": "abab"},
+        }
+        portable_validated = handlers["recipes__validate"](json.dumps(portable_params))
+        portable_applied = handlers["recipes__apply"](json.dumps(portable_params))
+        assert portable_validated["context"]["valid"] is True
+        assert portable_applied["success"] is True
 
     def test_contains_annotation_branch_work_is_linear(self, monkeypatch: pytest.MonkeyPatch) -> None:
         original_merge = _RecipeSchemaValidator._merge_annotations


### PR DESCRIPTION
## Summary
- reject recipe regex syntax outside the Python 3.7-3.14 common subset
- cover pattern, patternProperties, validate, and apply admission paths
- document the portable recipe regex contract for skill authors

## Validation
- recipe and Python compatibility tests: 206 passed
- Python lint and format: passed
- Python 3.7 syntax and bounded admission probes: passed
- skill package lint: passed