### PR TITLE
fix: stabilize discovery and preserve CLI errors

### DIFF
--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -30,13 +30,15 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
     )?;
     let gateway = HttpGateway::default();
     let mut hits = Vec::new();
-    let limit = request.limit.unwrap_or(25).clamp(1, 100);
+    let mut total_matches = 0_usize;
+    let mut truncated = false;
     let query = request
         .query
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string);
+    let limit = effective_search_limit(query.as_deref(), request.limit);
 
     for entry in &entries {
         let discovery_mcp_url = local_instance::discovery_mcp_url(entry);
@@ -74,21 +76,61 @@ pub async fn search_local(registry_dir: PathBuf, request: SearchRequest) -> anyh
                 })?;
             json!({ "tools": tools })
         };
+        let previous = hits.len();
         extend_tool_hits(&mut hits, entry, &payload);
         extend_skill_hits(&mut hits, entry, &payload);
-        if hits.len() >= limit {
-            hits.truncate(limit);
-            break;
-        }
+        let payload_returned = hits.len() - previous;
+        let payload_matches = payload
+            .get("total_matches")
+            .or_else(|| payload.get("total"))
+            .and_then(Value::as_u64)
+            .map(|value| value as usize)
+            .unwrap_or(payload_returned)
+            .max(payload_returned);
+        total_matches += payload_matches;
+        truncated |= payload.get("truncated").and_then(Value::as_bool) == Some(true)
+            || payload_returned < payload_matches;
     }
 
+    hits.sort_by(|left, right| {
+        let left_key = left
+            .get("slug")
+            .and_then(Value::as_str)
+            .or_else(|| left.get("skill_name").and_then(Value::as_str));
+        let right_key = right
+            .get("slug")
+            .and_then(Value::as_str)
+            .or_else(|| right.get("skill_name").and_then(Value::as_str));
+        left_key.cmp(&right_key).then_with(|| {
+            left.get("instance_id")
+                .and_then(Value::as_str)
+                .cmp(&right.get("instance_id").and_then(Value::as_str))
+        })
+    });
+    if hits.len() > limit {
+        hits.truncate(limit);
+        truncated = true;
+    }
+    let returned = hits.len();
+
     Ok(json!({
-        "total": hits.len(),
+        "total": returned,
+        "total_matches": total_matches,
+        "returned": returned,
+        "truncated": truncated || returned < total_matches,
         "hits": hits,
         "source": "local_mcp",
         "registry_dir": registry_dir,
         "query": request.query,
     }))
+}
+
+fn effective_search_limit(query: Option<&str>, requested: Option<usize>) -> usize {
+    match requested {
+        Some(limit) => limit.clamp(1, 100),
+        None if query.is_none() => usize::MAX,
+        None => 25,
+    }
 }
 
 pub async fn describe_local(registry_dir: PathBuf, tool_slug: String) -> anyhow::Result<Value> {

--- a/crates/dcc-mcp-cli/src/application/local_control_tests.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control_tests.rs
@@ -1,6 +1,13 @@
 use super::*;
 
 #[test]
+fn empty_query_without_limit_requests_the_complete_inventory() {
+    assert_eq!(effective_search_limit(None, None), usize::MAX);
+    assert_eq!(effective_search_limit(Some("spawn"), None), 25);
+    assert_eq!(effective_search_limit(None, Some(7)), 7);
+}
+
+#[test]
 fn local_tool_slug_round_trips() {
     let entry = ServiceEntry::new("maya", "127.0.0.1", 18080);
     let slug = local_instance::local_tool_slug(&entry, "maya_scene__get_session_info");

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -6,9 +6,7 @@ use anyhow::{Context, anyhow};
 use clap::{Parser, Subcommand};
 use serde_json::{Map, Value};
 
-use super::output::{
-    ErrorEnvelope, ExitCode, OutputFormat, OutputWriter, exit_code_to_error_code, to_json,
-};
+use super::output::{ExitCode, OutputFormat, OutputWriter, failure_envelope, to_json};
 
 use crate::application::call_attribution::{
     attach_agent_session_id, attach_batch_agent_session_id,
@@ -169,7 +167,7 @@ enum Command {
         #[arg(long, env = "DCC_MCP_CATALOG_PATH")]
         catalog: Option<PathBuf>,
     },
-    /// Search callable tools through local MCP or the selected gateway profile.
+    /// Search callable tools, or list the complete loaded inventory when no query is provided.
     Search {
         /// Query text. Positional words are also accepted, for example `search create sphere`.
         #[arg(short, long, conflicts_with = "query_terms")]
@@ -1161,11 +1159,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         std::process::exit(code);
     }
     if failed {
-        let envelope = ErrorEnvelope::new(
-            exit_code_to_error_code(exit_code),
-            format!("command failed with exit code {}", exit_code.as_i32()),
-            exit_code,
-        );
+        let envelope = failure_envelope(&value, exit_code);
         writer.write_error(&envelope)?;
         std::process::exit(exit_code.as_i32());
     }

--- a/crates/dcc-mcp-cli/src/presentation/output.rs
+++ b/crates/dcc-mcp-cli/src/presentation/output.rs
@@ -11,7 +11,7 @@ use std::io::{IsTerminal, Write};
 
 use anyhow::Context;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 pub(crate) fn to_json(value: impl Serialize) -> anyhow::Result<Value> {
     serde_json::to_value(value).context("failed to serialize command output")
@@ -168,6 +168,60 @@ impl ErrorEnvelope {
         self.error.details = Some(details);
         self
     }
+}
+
+pub(crate) fn failure_envelope(value: &Value, exit_code: ExitCode) -> ErrorEnvelope {
+    let payload = [
+        value.pointer("/result/structuredContent"),
+        value.get("output"),
+        value.get("structuredContent"),
+        value.get("result"),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|candidate| candidate.is_object())
+    .unwrap_or(value);
+
+    let text = |pointers: &[&str]| {
+        pointers
+            .iter()
+            .find_map(|pointer| payload.pointer(pointer).and_then(Value::as_str))
+            .filter(|text| !text.trim().is_empty())
+    };
+    let message = text(&["/message", "/error/message", "/_meta/dcc.error/message"])
+        .unwrap_or("command failed")
+        .to_string();
+    let reason = text(&["/context/reason", "/reason", "/error/reason"])
+        .unwrap_or("command_failed")
+        .to_string();
+
+    let mut details = Map::new();
+    details.insert("reason".to_string(), Value::String(reason));
+    for (name, pointers) in [
+        (
+            "error_type",
+            &[
+                "/context/error_type",
+                "/_meta/dcc.error/type",
+                "/error_type",
+            ][..],
+        ),
+        (
+            "message",
+            &["/_meta/dcc.error/message", "/context/error_message"][..],
+        ),
+        (
+            "traceback",
+            &["/context/traceback", "/_meta/dcc.error/traceback"][..],
+        ),
+    ] {
+        if let Some(value) = text(pointers) {
+            details.insert(name.to_string(), Value::String(value.to_string()));
+        }
+    }
+
+    ErrorEnvelope::new(exit_code_to_error_code(exit_code), message, exit_code)
+        .with_details(Value::Object(details))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dcc-mcp-cli/src/presentation/output/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/output/tests.rs
@@ -1,4 +1,44 @@
 use super::*;
+
+#[test]
+fn failed_call_envelope_preserves_structured_tool_diagnostics() {
+    let value = serde_json::json!({
+        "success": false,
+        "result": {
+            "isError": true,
+            "structuredContent": {
+                "success": false,
+                "message": "Failed to inspect Blueprint 'BP_ShooterEnemyAI'",
+                "error": "RuntimeError",
+                "context": {
+                    "reason": "internal_error",
+                    "error_type": "RuntimeError",
+                    "traceback": "RuntimeError: large graph reflection failed"
+                },
+                "_meta": {
+                    "dcc.error": {
+                        "type": "RuntimeError",
+                        "message": "large graph reflection failed"
+                    }
+                }
+            }
+        }
+    });
+
+    let envelope = failure_envelope(&value, ExitCode::GeneralError);
+
+    assert_eq!(
+        envelope.error.message,
+        "Failed to inspect Blueprint 'BP_ShooterEnemyAI'"
+    );
+    let details = envelope.error.details.expect("structured failure details");
+    assert_eq!(details["reason"], "internal_error");
+    assert_eq!(details["error_type"], "RuntimeError");
+    assert_eq!(
+        details["traceback"],
+        "RuntimeError: large graph reflection failed"
+    );
+}
 use serde_json::json;
 
 #[test]

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -521,6 +521,9 @@ fn local_profile_controls_registered_instance_through_direct_mcp() {
     let search = run_json_with_env(&["search", "--query", "scene", "--dcc-type", "maya"], &envs);
     assert_eq!(search["source"], "local_mcp");
     assert_eq!(search["total"], 2);
+    assert_eq!(search["total_matches"], 2);
+    assert_eq!(search["returned"], 2);
+    assert_eq!(search["truncated"], false);
     assert_eq!(
         search["hits"][0]["backend_tool"],
         "maya_scene__get_session_info"

--- a/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/discovery.rs
+++ b/crates/dcc-mcp-http-server/src/rmcp_tool_call_dispatch/handlers/discovery.rs
@@ -165,12 +165,9 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
             }
         });
         tool_hits.push(hit);
-        if tool_hits.len() >= limit {
-            break;
-        }
     }
 
-    if include_stubs && tool_hits.len() < limit {
+    if include_stubs {
         for summary in state.catalog.list_skills(Some("unloaded")) {
             if let Some(filter) = dcc
                 && !summary.dcc.eq_ignore_ascii_case(filter)
@@ -202,50 +199,50 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
                 "dcc": summary.dcc,
                 "skill_name": summary.name,
             }));
-            if tool_hits.len() >= limit {
-                break;
-            }
         }
 
-        if tool_hits.len() < limit {
-            let mut seen_groups: std::collections::HashSet<(String, String)> =
-                std::collections::HashSet::new();
-            for (skill, group, active) in state.catalog.list_groups() {
-                if active {
-                    continue;
-                }
-                if !seen_groups.insert((skill.clone(), group.clone())) {
-                    continue;
-                }
-                let stub_name = group_stub_name(Some(&skill), &group);
-                let haystack = format!("{stub_name} {group} {skill}").to_lowercase();
-                if !matches_phrase(&haystack, &query, &query_words) {
-                    continue;
-                }
-                tool_hits.push(json!({
-                    "kind": "tool",
-                    "name": stub_name,
-                    "description": format!(
-                        "[stub] inactive tool group `{group}` in skill `{skill}` — call activate_tool_group(group_name=\"{group}\", skill_name=\"{skill}\") to expose its members",
-                    ),
-                    "category": "stub",
-                    "group": group,
-                    "enabled": false,
-                    "dcc": "",
-                    "skill_name": skill,
-                }));
-                if tool_hits.len() >= limit {
-                    break;
-                }
+        let mut seen_groups: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        for (skill, group, active) in state.catalog.list_groups() {
+            if active {
+                continue;
             }
+            if !seen_groups.insert((skill.clone(), group.clone())) {
+                continue;
+            }
+            let stub_name = group_stub_name(Some(&skill), &group);
+            let haystack = format!("{stub_name} {group} {skill}").to_lowercase();
+            if !matches_phrase(&haystack, &query, &query_words) {
+                continue;
+            }
+            tool_hits.push(json!({
+                "kind": "tool",
+                "name": stub_name,
+                "description": format!(
+                    "[stub] inactive tool group `{group}` in skill `{skill}` — call activate_tool_group(group_name=\"{group}\", skill_name=\"{skill}\") to expose its members",
+                ),
+                "category": "stub",
+                "group": group,
+                "enabled": false,
+                "dcc": "",
+                "skill_name": skill,
+            }));
         }
     }
+
+    tool_hits.sort_by(|left, right| {
+        left.get("name")
+            .and_then(Value::as_str)
+            .cmp(&right.get("name").and_then(Value::as_str))
+    });
+    let total_tool_matches = tool_hits.len();
+    tool_hits.truncate(limit);
 
     let mut skill_candidates: Vec<Value> = Vec::new();
     if include_unloaded_skills {
         let candidates = state
             .catalog
-            .search_skills(Some(query_raw), &[], dcc, None, Some(limit));
+            .search_skills(Some(query_raw), &[], dcc, None, None);
         for summary in candidates {
             if summary.loaded {
                 continue;
@@ -299,9 +296,21 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
         }
     }
 
-    let total = tool_hits.len() + skill_candidates.len();
+    skill_candidates.sort_by(|left, right| {
+        left.get("skill_name")
+            .and_then(Value::as_str)
+            .cmp(&right.get("skill_name").and_then(Value::as_str))
+    });
+    let total_skill_matches = skill_candidates.len();
+    skill_candidates.truncate(limit);
+
+    let returned = tool_hits.len() + skill_candidates.len();
+    let total_matches = total_tool_matches + total_skill_matches;
     let result = json!({
-        "total": total,
+        "total": returned,
+        "total_matches": total_matches,
+        "returned": returned,
+        "truncated": returned < total_matches,
         "query": query,
         "tools": tool_hits,
         "skill_candidates": skill_candidates,
@@ -312,6 +321,62 @@ pub(in crate::rmcp_tool_call_dispatch) fn handle_search_tools(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::sync::Arc;
+
+    use dcc_mcp_actions::ToolDispatcher;
+    use dcc_mcp_actions::registry::{ToolMeta, ToolRegistry};
+    use dcc_mcp_jsonrpc::ToolContent;
+    use dcc_mcp_skills::SkillCatalog;
+
+    fn result_text_json(result: &CallToolResult) -> Value {
+        let Some(ToolContent::Text { text }) = result.content.first() else {
+            panic!("expected text content, got {result:?}");
+        };
+        serde_json::from_str(text).expect("handler text should be JSON")
+    }
+
+    #[test]
+    fn search_tools_is_stable_and_reports_truncation() {
+        let registry = Arc::new(ToolRegistry::new());
+        for name in ["unreal_zeta", "unreal_alpha", "unreal_middle"] {
+            registry.register_action(ToolMeta {
+                name: name.to_string(),
+                description: "Unreal deterministic discovery".to_string(),
+                dcc: "unreal".to_string(),
+                ..Default::default()
+            });
+        }
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+        let arguments = json!({
+            "query": "unreal",
+            "dcc": "unreal",
+            "limit": 2,
+            "include_unloaded_skills": false,
+        });
+
+        let first = result_text_json(&handle_search_tools(&state, &arguments));
+        let second = result_text_json(&handle_search_tools(&state, &arguments));
+
+        assert_eq!(first["tools"], second["tools"]);
+        assert_eq!(
+            first["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|tool| tool["name"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["unreal_alpha", "unreal_middle"]
+        );
+        assert_eq!(first["total_matches"], 3);
+        assert_eq!(first["returned"], 2);
+        assert_eq!(first["truncated"], true);
+    }
 
     #[test]
     fn matches_phrase_single_word_substring() {


### PR DESCRIPTION
## Summary
- make tool discovery deterministic before truncation
- report total_matches, returned, and truncated; list the complete loaded inventory when no query or limit is supplied
- preserve structured adapter error reasons and diagnostics in CLI failure envelopes

## Validation
- cargo fmt --all -- --check
- cargo test -p dcc-mcp-http-server
- cargo test -p dcc-mcp-cli
- cargo clippy -p dcc-mcp-http-server -p dcc-mcp-cli --all-targets -- -D warnings

Fixes dcc-mcp/dcc-mcp-unreal#197
Refs dcc-mcp/dcc-mcp-unreal#195