### PR TITLE
fix: reject nonportable regex boundary semantics

### DIFF
--- a/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
+++ b/python/dcc_mcp_core/_runtime/recipe_schema_patterns.py
@@ -55,9 +55,12 @@ def pattern_is_safe(pattern: str) -> bool:
     while index < len(pattern):
         character = pattern[index]
         if escaped:
-            # ``\N{name}`` requires Python 3.8+ and ``\z`` requires Python
-            # 3.14+, so neither belongs to the Python 3.7-3.14 common subset.
+            # ``\N{name}`` requires Python 3.8+, ``\z`` requires Python 3.14+,
+            # and ``\B`` changed empty-string semantics in Python 3.14.
+            # None belongs to the Python 3.7-3.14 portable common subset.
             if character in {"N", "z"}:
+                return False
+            if character == "B" and not in_character_class:
                 return False
             # Numeric and named backreferences are non-regular and can
             # force unbounded backtracking. Reject all digit escapes to

--- a/skills/dcc-mcp-skills-creator/SKILL.md
+++ b/skills/dcc-mcp-skills-creator/SKILL.md
@@ -176,6 +176,8 @@ Generated `tools.yaml` entries follow the modern contract:
   they preserve the intended matching semantics. Global inline flags such as
   `(?i)` are portable only at the absolute start; use scoped flags such as
   `(?i:...)` when flags must appear after a prefix or inside another group.
+  The `\B` non-boundary assertion is not portable because its empty-string
+  behavior changes in Python 3.14; express the intended boundary explicitly.
 - `execution` is `sync` or `async`; use `async` for deferred/long-running work.
 - `job_strategy` is `monolithic` (default), `chunked`, or `isolated`. Agents
   use it to select a safe execution and recovery workflow.

--- a/tests/test_recipe_regex_portability_routes.py
+++ b/tests/test_recipe_regex_portability_routes.py
@@ -1,0 +1,158 @@
+"""Real MCP and REST regressions for portable recipe regex admission."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+import urllib.error
+import urllib.request
+
+import pytest
+
+from conftest import McpClient
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+from dcc_mcp_core.recipes import register_recipes_tools
+
+
+def _post_json(url: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8"))
+
+
+def _mcp_output(body: dict[str, Any]) -> dict[str, Any]:
+    result = body["result"]
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        return structured
+    return json.loads(result["content"][0]["text"])
+
+
+def _rest_slug(base_url: str, action: str) -> str:
+    status, body = _post_json(
+        f"{base_url}/v1/search",
+        {"query": action, "dcc_type": "python", "loaded_only": True},
+    )
+    assert status == 200
+    matches = [hit["slug"] for hit in body["hits"] if hit.get("action") == action]
+    assert len(matches) == 1, body
+    return matches[0]
+
+
+def _recipe_metadata(skill_dir: Path, recipe_path: Path) -> MagicMock:
+    metadata = MagicMock()
+    metadata.name = "regex-portability-route-skill"
+    metadata.skill_path = str(skill_dir)
+    metadata.metadata = {"dcc-mcp": {"recipes": str(recipe_path)}}
+    return metadata
+
+
+@pytest.mark.parametrize("transport", ["mcp", "rest"])
+def test_non_boundary_assertion_is_rejected_through_real_routes(tmp_path: Path, transport: str) -> None:
+    recipe_path = tmp_path / "recipes.yaml"
+    recipe_path.write_text(
+        json.dumps(
+            {
+                "recipes": [
+                    {
+                        "name": "pattern",
+                        "inputs_schema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string", "pattern": r"\B"}},
+                        },
+                        "steps": [],
+                    },
+                    {
+                        "name": "pattern-properties",
+                        "inputs_schema": {
+                            "type": "object",
+                            "patternProperties": {r"\B": {"type": "string"}},
+                        },
+                        "steps": [],
+                    },
+                    {
+                        "name": "literal-control",
+                        "inputs_schema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string", "pattern": r"^\\B$"}},
+                        },
+                        "steps": [],
+                    },
+                    {
+                        "name": "character-class-control",
+                        "inputs_schema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string", "pattern": r"^[\\]B$"}},
+                        },
+                        "steps": [],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    skill_dir = tmp_path / "regex-portability-route-skill"
+    skill_dir.mkdir()
+    metadata = _recipe_metadata(skill_dir, recipe_path)
+    server = McpHttpServer(ToolRegistry(), McpHttpConfig(port=0, server_name="recipe-regex-portability"))
+    register_recipes_tools(server, skills=[metadata], dcc_name="python")
+    handle = server.start()
+    try:
+        mcp_url = handle.mcp_url()
+        cases = (
+            ("pattern", {"value": ""}, False),
+            ("pattern-properties", {"": "value"}, False),
+            ("literal-control", {"value": r"\B"}, True),
+            ("character-class-control", {"value": r"\B"}, True),
+        )
+        for recipe_name, inputs, expected_valid in cases:
+            arguments = {
+                "skill": "regex-portability-route-skill",
+                "recipe": recipe_name,
+                "inputs": inputs,
+            }
+            for action in ("recipes__validate", "recipes__apply"):
+                if transport == "mcp":
+                    status, body = McpClient(mcp_url).post(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": f"{action}:{recipe_name}",
+                            "method": "tools/call",
+                            "params": {"name": action, "arguments": arguments},
+                        }
+                    )
+                    assert status == 200
+                    output = _mcp_output(body)
+                else:
+                    base_url = mcp_url.rsplit("/mcp", 1)[0]
+                    status, body = _post_json(
+                        f"{base_url}/v1/call",
+                        {
+                            "tool_slug": _rest_slug(base_url, action),
+                            "arguments": arguments,
+                        },
+                    )
+                    assert status == 200
+                    output = body["output"]
+
+                if action == "recipes__validate":
+                    assert output["success"] is True
+                    assert output["context"]["valid"] is expected_valid
+                else:
+                    assert output["success"] is expected_valid
+                if not expected_valid:
+                    assert output["context"]["errors"] == ["$: Recipe input schema is invalid"]
+    finally:
+        handle.shutdown()

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1386,6 +1386,83 @@ class TestRegisterRecipesTools:
         assert validate_recipe_inputs({"inputs_schema": schema}, inputs) == ["$: Recipe input schema is invalid"]
 
     @pytest.mark.parametrize(
+        ("schema", "inputs"),
+        [
+            ({"type": "string", "pattern": r"\B"}, ""),
+            (
+                {
+                    "type": "object",
+                    "patternProperties": {r"\B": {"type": "string"}},
+                },
+                {"": "value"},
+            ),
+        ],
+    )
+    def test_version_drifting_non_boundary_assertion_fails_closed_during_admission(
+        self,
+        schema: dict[str, object],
+        inputs: object,
+    ) -> None:
+        assert pattern_is_safe(r"\B") is False
+        assert validate_recipe_inputs({"inputs_schema": schema}, inputs) == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
+        ("pattern", "value"),
+        [
+            (r"^\\B$", r"\B"),
+            (r"^[\\]B$", r"\B"),
+            (r"^[B]+$", "BB"),
+        ],
+    )
+    def test_non_boundary_literal_and_character_class_controls_remain_supported(
+        self,
+        pattern: str,
+        value: str,
+    ) -> None:
+        assert pattern_is_safe(pattern) is True
+        assert validate_recipe_inputs({"inputs_schema": {"type": "string", "pattern": pattern}}, value) == []
+
+    def test_non_boundary_portability_has_validate_apply_parity(self, tmp_path: Path) -> None:
+        handlers = self._make_recipe_handlers(
+            tmp_path,
+            skill_name="non-boundary-portability-skill",
+            recipes={
+                "pattern": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": r"\B"}},
+                },
+                "pattern-properties": {
+                    "type": "object",
+                    "patternProperties": {r"\B": {"type": "string"}},
+                },
+                "literal-control": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": r"^\\B$"}},
+                },
+                "character-class-control": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "pattern": r"^[\\]B$"}},
+                },
+            },
+        )
+        cases = [
+            ("pattern", {"value": ""}, False),
+            ("pattern-properties", {"": "value"}, False),
+            ("literal-control", {"value": r"\B"}, True),
+            ("character-class-control", {"value": r"\B"}, True),
+        ]
+
+        for recipe_name, inputs, expected_valid in cases:
+            params = {"skill": "non-boundary-portability-skill", "recipe": recipe_name, "inputs": inputs}
+            validated = handlers["recipes__validate"](json.dumps(params))
+            applied = handlers["recipes__apply"](json.dumps(params))
+            assert validated["context"]["valid"] is expected_valid
+            assert applied["success"] is expected_valid
+            if not expected_valid:
+                assert validated["context"]["errors"] == ["$: Recipe input schema is invalid"]
+                assert applied["context"]["errors"] == ["$: Recipe input schema is invalid"]
+
+    @pytest.mark.parametrize(
         "pattern",
         [
             "^a(?i)b$",


### PR DESCRIPTION
## Summary
- reject recipe `\B` assertions whose empty-string semantics differ across supported Python versions
- preserve escaped literal backslash-B and character-class controls
- document the Python 3.7-3.14 portable recipe-regex subset

## Validation
- 188 recipe and exact-source MCP/REST tests passed
- installed-wheel MCP/REST route tests passed
- Python 3.7.9 and 3.14.5 admission probes passed
- Ruff, formatting, Python support contract, and skill lint passed
- full Python suite: 10,933 passed; four unrelated local-environment failures remain in installed CLI, Windows process cleanup, and optional semantic-backend isolation

`dcc-mcp-skills-creator` guidance is updated. `dcc-mcp-creator` is unchanged because adapter and runtime wiring are unaffected.