### PR TITLE
fix(gateway): enforce safe discovery boundaries

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/admin/application/health.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/application/health.rs
@@ -25,18 +25,20 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
     let registry = s.gateway.registry.clone();
     let all = s.gateway.all_instances_async().await;
     let live = s.gateway.live_instances_async().await;
-    let eligible = eligible_health_entries(&s.gateway.policy, live);
-    let ready = eligible.len();
-    let job_persistence = collect_job_persistence_health(&s.gateway, &eligible).await;
+    let live_eligibility = classify_health_entries(&s.gateway.policy, live);
+    let all_eligibility = classify_health_entries(&s.gateway.policy, all);
+    let ready = live_eligibility.eligible.len();
+    let total = all_eligibility.eligible.len();
+    let rejected = all_eligibility.rejected;
+    let job_persistence =
+        collect_job_persistence_health(&s.gateway, &live_eligibility.eligible).await;
     let gateway_sentinels = registry
         .list_instances_async(GATEWAY_SENTINEL_DCC_TYPE.to_string())
         .await
         .unwrap_or_default();
-    let total = eligible_instance_count(&s.gateway.policy, &all);
-
     let uptime_secs = s.started_at.elapsed().unwrap_or_default().as_secs();
 
-    let status = if ready > 0 || total == 0 {
+    let status = if ready > 0 || (total == 0 && rejected == 0) {
         "ok"
     } else {
         "degraded"
@@ -53,6 +55,7 @@ pub async fn handle_admin_health(State(s): State<AdminState>) -> impl IntoRespon
             "status": status,
             "instances_ready": ready,
             "instances_total": total,
+            "instances_rejected": rejected,
             "uptime_secs": uptime_secs,
             "version": s.gateway.server_version,
             "rss_bytes": rss_bytes,
@@ -173,23 +176,28 @@ async fn collect_job_persistence_health(
     })
 }
 
-fn eligible_health_entries(
-    policy: &GatewayPolicy,
-    entries: Vec<ServiceEntry>,
-) -> Vec<ServiceEntry> {
-    entries
-        .into_iter()
-        .filter(|entry| policy.allows_dcc(&entry.dcc_type))
-        .filter(|entry| entry.port != 0)
-        .filter(safe_discovery_target)
-        .collect()
+struct HealthEligibility {
+    eligible: Vec<ServiceEntry>,
+    rejected: usize,
 }
 
-fn eligible_instance_count(policy: &GatewayPolicy, entries: &[ServiceEntry]) -> usize {
-    entries
-        .iter()
+fn classify_health_entries(
+    policy: &GatewayPolicy,
+    entries: Vec<ServiceEntry>,
+) -> HealthEligibility {
+    let mut eligible = Vec::new();
+    let mut rejected = 0;
+    for entry in entries
+        .into_iter()
         .filter(|entry| policy.allows_dcc(&entry.dcc_type) && entry.port != 0)
-        .count()
+    {
+        if safe_discovery_target(&entry) {
+            eligible.push(entry);
+        } else {
+            rejected += 1;
+        }
+    }
+    HealthEligibility { eligible, rejected }
 }
 
 /// Construct a safe health target from the registry identity.
@@ -260,9 +268,8 @@ fn is_known_error_kind(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        eligible_health_entries, eligible_instance_count, health_probe_url,
-        health_url_from_mcp_url, is_known_error_kind, is_known_persistence_state,
-        normalize_error_kind,
+        classify_health_entries, health_probe_url, health_url_from_mcp_url, is_known_error_kind,
+        is_known_persistence_state, normalize_error_kind,
     };
     use dcc_mcp_gateway_core::policy::GatewayPolicy;
     use dcc_mcp_transport::discovery::types::ServiceEntry;
@@ -302,9 +309,9 @@ mod tests {
             ServiceEntry::new("maya", "127.0.0.1", 8765),
             ServiceEntry::new("blender", "127.0.0.1", 8766),
         ];
-        let eligible = eligible_health_entries(&policy, entries);
-        assert_eq!(eligible.len(), 1);
-        assert_eq!(eligible[0].dcc_type, "maya");
+        let eligibility = classify_health_entries(&policy, entries);
+        assert_eq!(eligibility.eligible.len(), 1);
+        assert_eq!(eligibility.eligible[0].dcc_type, "maya");
         assert_eq!(
             health_url_from_mcp_url("https://127.0.0.1:8765/mcp"),
             "https://127.0.0.1:8765/health"
@@ -322,7 +329,9 @@ mod tests {
             ServiceEntry::new("maya", "127.0.0.1", 0),
             ServiceEntry::new("blender", "127.0.0.1", 8766),
         ];
-        assert_eq!(eligible_instance_count(&policy, &entries), 1);
+        let eligibility = classify_health_entries(&policy, entries);
+        assert_eq!(eligibility.eligible.len(), 1);
+        assert_eq!(eligibility.rejected, 0);
     }
 
     #[test]
@@ -433,15 +442,18 @@ pub async fn handle_admin_reliability(State(s): State<AdminState>) -> impl IntoR
     let registry = s.gateway.registry.clone();
     let all = s.gateway.all_instances_async().await;
     let live = s.gateway.live_instances_async().await;
-    let ready = eligible_health_entries(&s.gateway.policy, live).len();
-    let total = eligible_instance_count(&s.gateway.policy, &all);
+    let live_eligibility = classify_health_entries(&s.gateway.policy, live);
+    let all_eligibility = classify_health_entries(&s.gateway.policy, all);
+    let ready = live_eligibility.eligible.len();
+    let total = all_eligibility.eligible.len();
+    let rejected = all_eligibility.rejected;
     let gateway_sentinels = registry
         .list_instances_async(GATEWAY_SENTINEL_DCC_TYPE.to_string())
         .await
         .unwrap_or_default();
 
     let uptime_secs = s.started_at.elapsed().unwrap_or_default().as_secs();
-    let status = if ready > 0 || total == 0 {
+    let status = if ready > 0 || (total == 0 && rejected == 0) {
         "ok"
     } else {
         "degraded"
@@ -535,6 +547,7 @@ pub async fn handle_admin_reliability(State(s): State<AdminState>) -> impl IntoR
             "capability_funnel": {
                 "instances_ready": ready,
                 "instances_total": total,
+                "instances_rejected": rejected,
                 "skills_loaded": 0,
                 "skills_total": 0,
                 "tools_registered": 0,

--- a/crates/dcc-mcp-gateway/src/gateway/admin/basic_endpoint_tests.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/admin/basic_endpoint_tests.rs
@@ -309,7 +309,8 @@ mod endpoint_contracts {
 
         let (_, health) = body_json(app.clone(), "/admin/api/health").await;
         assert_eq!(health["instances_ready"], 0, "{health}");
-        assert_eq!(health["instances_total"], 1, "{health}");
+        assert_eq!(health["instances_total"], 0, "{health}");
+        assert_eq!(health["instances_rejected"], 1, "{health}");
         assert_eq!(health["status"], "degraded", "{health}");
 
         let (_, reliability) = body_json(app.clone(), "/admin/api/reliability").await;
@@ -318,7 +319,11 @@ mod endpoint_contracts {
             "{reliability}"
         );
         assert_eq!(
-            reliability["capability_funnel"]["instances_total"], 1,
+            reliability["capability_funnel"]["instances_total"], 0,
+            "{reliability}"
+        );
+        assert_eq!(
+            reliability["capability_funnel"]["instances_rejected"], 1,
             "{reliability}"
         );
         assert_eq!(reliability["status"], "degraded", "{reliability}");
@@ -376,7 +381,8 @@ mod endpoint_contracts {
 
         let (_, health) = body_json(app.clone(), "/admin/api/health").await;
         assert_eq!(health["instances_ready"], 1, "{health}");
-        assert_eq!(health["instances_total"], 2, "{health}");
+        assert_eq!(health["instances_total"], 1, "{health}");
+        assert_eq!(health["instances_rejected"], 1, "{health}");
         assert_eq!(health["status"], "ok", "{health}");
 
         let (_, reliability) = body_json(app, "/admin/api/reliability").await;
@@ -385,10 +391,72 @@ mod endpoint_contracts {
             "{reliability}"
         );
         assert_eq!(
-            reliability["capability_funnel"]["instances_total"], 2,
+            reliability["capability_funnel"]["instances_total"], 1,
+            "{reliability}"
+        );
+        assert_eq!(
+            reliability["capability_funnel"]["instances_rejected"], 1,
             "{reliability}"
         );
         assert_eq!(reliability["status"], "ok", "{reliability}");
+    }
+
+    #[tokio::test]
+    async fn proxy_ignores_unsafe_available_registration_before_selecting_safe_busy_backend() {
+        let backend_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_port = backend_listener.local_addr().unwrap().port();
+        let backend = Router::new().route(
+            "/mcp",
+            axum::routing::post(|| async { axum::Json(json!({"routed": "safe"})) }),
+        );
+        let backend_task = tokio::spawn(async move {
+            axum::serve(backend_listener, backend).await.unwrap();
+        });
+
+        let gateway = make_gateway_state();
+        let mut safe = dcc_mcp_transport::discovery::types::ServiceEntry::new(
+            "maya",
+            "127.0.0.1",
+            backend_port,
+        );
+        safe.instance_id = uuid::Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap();
+        safe.status = dcc_mcp_transport::discovery::types::ServiceStatus::Busy;
+        gateway.registry.register(safe).unwrap();
+
+        let app = gateway_router_with_admin(gateway);
+        let (register_status, _) = request_json(
+            app.clone(),
+            "POST",
+            "/v1/instances/register",
+            json!({
+                "instance_id": "33333333-3333-4333-8333-333333333333",
+                "dcc_type": "maya",
+                "mcp_url": "http://127.0.0.1:9/mcp"
+            }),
+        )
+        .await;
+        assert_eq!(register_status, StatusCode::OK);
+
+        let (status, payload) = request_json(
+            app,
+            "POST",
+            "/mcp/dcc/maya",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "safe-candidate-test", "version": "1.0"}
+                }
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{payload}");
+        assert_eq!(payload["routed"], "safe", "{payload}");
+
+        backend_task.abort();
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/capability_service.rs
@@ -1133,27 +1133,53 @@ pub(crate) fn is_public_ip(ip: std::net::IpAddr) -> bool {
             if let Some(mapped) = ip.to_ipv4() {
                 return is_public_ip(std::net::IpAddr::V4(mapped));
             }
-            let segments = ip.segments();
+            if ipv6_matches_prefix(ip, [0x0064, 0xff9b, 0, 0, 0, 0, 0, 0], 96) {
+                let octets = ip.octets();
+                let translated =
+                    std::net::Ipv4Addr::new(octets[12], octets[13], octets[14], octets[15]);
+                return is_public_ip(std::net::IpAddr::V4(translated));
+            }
             !(ip.is_loopback()
                 || ip.is_unspecified()
                 || ip.is_unique_local()
                 || ip.is_unicast_link_local()
                 || ip.is_multicast()
-                || (segments[0] & 0xffc0 == 0xfec0) // deprecated site-local
-                || (segments[0] == 0x0064
-                    && segments[1] == 0xff9b
-                    && segments[2] == 0x0001) // local-use NAT64
-                || (segments[0] == 0x0100
-                    && segments[1] == 0
-                    && segments[2] == 0
-                    && segments[3] == 0) // discard-only
-                || (segments[0] == 0x2001 && segments[1] & 0xfff0 == 0x0020) // ORCHIDv2
-                || (segments[0] == 0x2001 && segments[1] == 0x0db8) // documentation
-                || (segments[0] == 0x2001 && segments[1] == 0x0002) // benchmarking
-                || (segments[0] == 0x2001 && (0x0010..=0x001f).contains(&segments[1]))
-                || (0x3fff..=0x3fff).contains(&segments[0]))
+                || NON_GLOBAL_IPV6_PREFIXES
+                    .iter()
+                    .any(|(prefix, prefix_len)| ipv6_matches_prefix(ip, *prefix, *prefix_len)))
         }
     }
+}
+
+/// IANA special-purpose IPv6 blocks that are not globally reachable and are
+/// not already covered by stable `Ipv6Addr` predicates. Prefix matching keeps
+/// the policy auditable when the registry adds a whole block rather than one
+/// exemplar address.
+const NON_GLOBAL_IPV6_PREFIXES: &[([u16; 8], u8)] = &[
+    ([0x0064, 0xff9b, 0x0001, 0, 0, 0, 0, 0], 48), // local-use NAT64
+    ([0x0100, 0, 0, 0, 0, 0, 0, 0], 64),           // discard-only
+    ([0x0100, 0, 0, 0x0001, 0, 0, 0, 0], 64),      // dummy IPv6 prefix
+    ([0x2001, 0, 0, 0, 0, 0, 0, 0], 32),           // Teredo
+    ([0x2001, 0x0002, 0, 0, 0, 0, 0, 0], 48),      // benchmarking
+    ([0x2001, 0x0010, 0, 0, 0, 0, 0, 0], 28),      // deprecated ORCHID
+    ([0x2001, 0x0020, 0, 0, 0, 0, 0, 0], 28),      // ORCHIDv2
+    ([0x2001, 0x0db8, 0, 0, 0, 0, 0, 0], 32),      // documentation
+    ([0x2002, 0, 0, 0, 0, 0, 0, 0], 16),           // 6to4
+    ([0x3fff, 0, 0, 0, 0, 0, 0, 0], 16),           // documentation/reserved
+    ([0x5f00, 0, 0, 0, 0, 0, 0, 0], 16),           // SRv6 SID
+    ([0xfec0, 0, 0, 0, 0, 0, 0, 0], 10),           // deprecated site-local
+];
+
+fn ipv6_matches_prefix(ip: std::net::Ipv6Addr, prefix: [u16; 8], prefix_len: u8) -> bool {
+    debug_assert!(prefix_len <= 128);
+    let address = u128::from_be_bytes(ip.octets());
+    let prefix = u128::from_be_bytes(std::net::Ipv6Addr::from(prefix).octets());
+    let mask = if prefix_len == 0 {
+        0
+    } else {
+        u128::MAX << (128 - u32::from(prefix_len))
+    };
+    address & mask == prefix & mask
 }
 
 #[derive(Clone, Copy)]
@@ -1707,6 +1733,14 @@ mod unit_tests {
         );
         assert!(safe_discovery_target(&entry));
 
+        for host in ["64:ff9b::808:808", "64:ff9b::101:101"] {
+            entry.host = host.to_string();
+            entry
+                .metadata
+                .insert("mcp_url".to_string(), format!("https://[{host}]:8765/mcp"));
+            assert!(safe_discovery_target(&entry), "{host} must remain public");
+        }
+
         for host in [
             "::",
             "::1",
@@ -1715,8 +1749,12 @@ mod unit_tests {
             "ff02::1",
             "fec0::1",
             "64:ff9b:1::1",
+            "64:ff9b::7f00:1",
+            "64:ff9b::c0a8:101",
             "100::1",
             "2001:20::1",
+            "100:0:0:1::1",
+            "5f00::1",
         ] {
             entry.host = host.to_string();
             entry

--- a/crates/dcc-mcp-gateway/src/gateway/handlers/proxy_impl.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/handlers/proxy_impl.rs
@@ -41,14 +41,14 @@ pub async fn handle_proxy_dcc(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Response {
-    let mut candidates = gs
+    let matching = gs
         .live_instances_async()
         .await
         .into_iter()
         .filter(|entry| entry.dcc_type == dcc_type)
         .collect::<Vec<_>>();
 
-    if candidates.is_empty() {
+    if matching.is_empty() {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({"error": format!("No live '{}' instances", dcc_type)})),
@@ -56,11 +56,16 @@ pub async fn handle_proxy_dcc(
             .into_response();
     }
 
-    candidates.sort_by_key(|entry| matches!(entry.status, ServiceStatus::Busy) as u8);
-    let entry = &candidates[0];
-    if !safe_discovery_target(entry) {
-        return unsafe_backend_target_response(entry);
+    let mut candidates = matching
+        .iter()
+        .filter(|entry| safe_discovery_target(entry))
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return unsafe_backend_target_response(&matching[0]);
     }
+
+    candidates.sort_by_key(|entry| matches!(entry.status, ServiceStatus::Busy) as u8);
+    let entry = candidates[0];
     if let Err(error) = crate::gateway::lease_guard::check_raw_mcp_call_owner(entry, &body) {
         return lease_rejection_response(entry, error, &body);
     }

--- a/docs/guide/admin-ui.md
+++ b/docs/guide/admin-ui.md
@@ -557,6 +557,7 @@ Admin token fields intentionally separate two accounting models:
   "uptime_secs": 3600,
   "instances_total": 3,
   "instances_ready": 2,
+  "instances_rejected": 1,
   "response_format": {
     "default": "toon",
     "legacy_mime": "application/json",
@@ -1041,6 +1042,11 @@ Admin token fields intentionally separate two accounting models:
   ]
 }
 ```
+
+`instances_total` and `instances_ready` use the same policy-allowed, safe,
+dispatchable registration set as gateway routing. `instances_rejected` counts
+otherwise eligible registrations that failed the canonical target-safety
+predicate; rejected rows do not inflate capacity or shadow a safe backend.
 
 ## Connecting AuditMiddleware
 

--- a/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/error_report.py
+++ b/python/dcc_mcp_core/skills/dcc-diagnostics/scripts/error_report.py
@@ -2,9 +2,9 @@
 
 Aggregates the most useful signals for diagnosing tool failures:
 
-1. **Recent log lines** — tail the rolling log file written by
-   ``DccServerBase`` (``dcc-mcp-<dcc>.*.log``).  Includes ERROR and WARNING
-   lines plus the last N lines of context.
+1. **Recent log lines** — tail only the current process's rolling log file
+   written by ``DccServerBase`` (``dcc-mcp-<dcc>.<pid>.*.log``).  Includes
+   ERROR and WARNING lines plus the last N lines of context.
 2. **Failed / interrupted jobs** — query the SQLite job-persistence database
    (``dcc-mcp-<dcc>-<instance>-jobs.db``) for recent non-successful jobs.
 3. **Process status** — current PID liveness, platform, Python version.
@@ -41,14 +41,13 @@ def _tail_lines(path: str, n: int) -> list[str]:
         return []
 
 
-def _find_log_files(log_dir: str, dcc_name: str | None) -> list[str]:
-    """Return all matching log files sorted newest-first."""
+def _find_log_files(log_dir: str, dcc_name: str | None, pid: int) -> list[str]:
+    """Return only log files owned by the exact current DCC process."""
+    if not dcc_name or pid <= 0:
+        return []
     base = Path(log_dir)
-    pattern = f"dcc-mcp-{dcc_name}-*.log" if dcc_name else "dcc-mcp-*.log"
+    pattern = f"dcc-mcp-{dcc_name}.{pid}.*.log"
     files = list(base.glob(pattern))
-    if not files:
-        pattern2 = f"dcc-mcp-{dcc_name}*.log" if dcc_name else "dcc-mcp*.log"
-        files = list(base.glob(pattern2))
     return sorted((str(f) for f in files), key=os.path.getmtime, reverse=True)
 
 
@@ -62,7 +61,7 @@ def _extract_errors(lines: list[str], include_warnings: bool = True) -> list[str
     return out
 
 
-def _collect_log_section(log_dir: str, dcc_name: str | None, tail_lines: int) -> dict:
+def _collect_log_section(log_dir: str, dcc_name: str | None, tail_lines: int, pid: int) -> dict:
     """Read recent log lines and extract errors/warnings."""
     if not log_dir or not Path(log_dir).is_dir():
         return {
@@ -72,7 +71,7 @@ def _collect_log_section(log_dir: str, dcc_name: str | None, tail_lines: int) ->
             "and DccServerBase(opts).",
         }
 
-    files = _find_log_files(log_dir, dcc_name)
+    files = _find_log_files(log_dir, dcc_name, pid)
     if not files:
         return {
             "available": False,
@@ -238,7 +237,7 @@ def main(**kwargs) -> None:
         if exact.exists():
             db_path = str(exact)
 
-    log_section = _collect_log_section(log_dir, dcc_name, tail_lines)
+    log_section = _collect_log_section(log_dir, dcc_name, tail_lines, os.getpid())
     job_section = _collect_job_section(db_path, job_limit)
     process_section = _collect_process_section()
 

--- a/skills/dcc-mcp-creator/SKILL.md
+++ b/skills/dcc-mcp-creator/SKILL.md
@@ -255,7 +255,10 @@ the server from its exact target environment. Gateway Admin is check-only.
     only use policy-allowed, identity-matching HTTP(S) endpoints with no
     query credentials or URL userinfo; redirects are not followed, and
     private/link-local targets (including IPv4-mapped IPv6 literals) and DNS
-    names are rejected for periodic outbound probes. Public literal IPv6
+    names are rejected for periodic outbound probes. Gateway health and
+    reliability totals count only registrations accepted by that same dispatch
+    predicate; rejected registrations are reported separately and cannot
+    shadow a safe backend during DCC-type routing. Public literal IPv6
     registrations keep an unbracketed canonical host identity; brackets belong
     only to serialized URLs. Adapters must not copy a bracketed URL host into
     `ServiceEntry.host` or compare raw URL text across discovery and dispatch.
@@ -402,6 +405,9 @@ review any `?mode=raw` export locally before sharing it.
 The bundled error report binds persisted-job diagnostics to the exact current
 instance key. If that database is absent, report persistence as unavailable;
 never glob a sibling instance or fall back to another process's database.
+It likewise binds rolling-log diagnostics to the current DCC process PID; if
+that exact log is absent, report logging as unavailable instead of selecting a
+same-DCC sibling log.
 
 Report adapter-owned dispatch, host-thread, readiness, packaging, or install
 bugs in the adapter repository. Escalate shared CLI, gateway, protocol, or core

--- a/tests/test_error_report_instance_isolation.py
+++ b/tests/test_error_report_instance_isolation.py
@@ -65,3 +65,38 @@ def test_error_report_reads_only_the_exact_current_instance_database(tmp_path, m
     assert "foreign.tool" not in serialized
     assert "foreign-error" not in serialized
     assert report["context"]["jobs"]["db_path"].endswith("dcc-mcp-maya-current-instance-jobs.db")
+
+
+def test_error_report_does_not_read_a_sibling_instance_log(tmp_path, monkeypatch, capsys):
+    sibling = tmp_path / "dcc-mcp-maya.999999.20260901.log"
+    sibling.write_text(r"ERROR sibling-instance-secret C:\Users\foreign\scene.ma", encoding="utf-8")
+    monkeypatch.setenv("DCC_MCP_JOB_INSTANCE_KEY", "current-instance")
+
+    module = _load_error_report_module()
+    module.main(dcc_name="maya", log_dir=str(tmp_path), tail=10, job_limit=10)
+    report = json.loads(capsys.readouterr().out)
+
+    assert not report["context"]["log"]["available"]
+    serialized = json.dumps(report)
+    assert "sibling-instance-secret" not in serialized
+    assert "999999" not in serialized
+    assert "foreign\\scene.ma" not in serialized
+
+
+def test_error_report_reads_only_the_exact_current_process_log(tmp_path, monkeypatch, capsys):
+    pid = 424242
+    current = tmp_path / f"dcc-mcp-maya.{pid}.20260901.log"
+    sibling = tmp_path / "dcc-mcp-maya.999999.20260901.log"
+    current.write_text("ERROR current-instance-error", encoding="utf-8")
+    sibling.write_text("ERROR sibling-instance-secret", encoding="utf-8")
+    monkeypatch.setattr("os.getpid", lambda: pid)
+
+    module = _load_error_report_module()
+    module.main(dcc_name="maya", log_dir=str(tmp_path), tail=10, job_limit=10)
+    report = json.loads(capsys.readouterr().out)
+
+    serialized = json.dumps(report)
+    assert report["context"]["log"]["available"]
+    assert "current-instance-error" in serialized
+    assert "sibling-instance-secret" not in serialized
+    assert report["context"]["log"]["log_file"].endswith(current.name)


### PR DESCRIPTION
Follow-up hardening for the gateway safety boundaries identified after #2393 merged.

- align admin readiness and reliability with dispatch-safe targets
- skip unsafe registrations before proxy selection
- reject non-global IPv6 discovery targets
- isolate diagnostics log fallback by exact instance identity

Validation: gateway admin tests, full workspace lint/format, and instance-isolation regression tests pass.