### PR TITLE
feat(catalog): register LiquiGen adapter

### DIFF
--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -916,7 +916,7 @@ mod tests {
         let catalog = service.dcc_types(None).unwrap();
 
         assert!(catalog.custom_types_supported);
-        assert_eq!(catalog.dcc_types.len(), 36);
+        assert_eq!(catalog.dcc_types.len(), 37);
         for alias in ["after effects", "after-effects", "comfy-ui"] {
             assert!(
                 catalog
@@ -941,6 +941,7 @@ mod tests {
             ("gimp", "dcc-mcp-gimp"),
             ("godot", "dcc-mcp-godot"),
             ("krita", "dcc-mcp-krita"),
+            ("liquigen", "dcc-mcp-liquigen"),
             ("mari", "dcc-mcp-mari"),
             ("material-maker", "dcc-mcp-material-maker"),
             ("obs", "dcc-mcp-obs"),

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -1873,7 +1873,7 @@ fn dcc_types_lists_release_catalog_without_a_gateway() {
 
     assert_eq!(value["custom_types_supported"], true);
     let types = value["dcc_types"].as_array().unwrap();
-    assert_eq!(types.len(), 36);
+    assert_eq!(types.len(), 37);
     for expected in [
         "aftereffects",
         "c4d",

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -156,6 +156,17 @@ entries:
       sha256: "4df543a902bcd771bc0733c1ba894fd802a64e1e897adb65c29800dcf5cb2ccf"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
 
+  - name: "dcc-mcp-liquigen"
+    # Automatic install is omitted until the PyPI trusted publisher is configured.
+    description: "LiquiGen adapter with typed node-graph inspection, simulation controls, VAT export, and Unreal Engine handoff"
+    dcc: ["liquigen"]
+    url: "https://github.com/dcc-mcp/dcc-mcp-liquigen"
+    issues_url: "https://github.com/dcc-mcp/dcc-mcp-liquigen/issues"
+    tags: ["adapter", "liquigen", "official", "water", "simulation", "vat", "unreal"]
+    version: "0.1.0"
+    min_core_version: "0.20.22"
+    maintainer: "dcc-mcp"
+
   - name: "dcc-mcp-zbrush"
     description: "ZBrush adapter for DCC-MCP"
     dcc: ["zbrush"]

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -38,6 +38,7 @@ submit a PR updating this matrix before the release PR merges.
 | FPT / ShotGrid | [dcc-mcp-fpt](https://github.com/dcc-mcp/dcc-mcp-fpt) | 0.1.8 | >=0.19.45,<1.0.0 | — | REST bridge | 2026-06 |
 | Nuke | [dcc-mcp-nuke](https://github.com/dcc-mcp/dcc-mcp-nuke) | 0.13.1 | >=0.19.45,<1.0.0 | — | Host main-thread dispatcher | — |
 | Unreal | [dcc-mcp-unreal](https://github.com/dcc-mcp/dcc-mcp-unreal) | 0.3.0 | >=0.19.45,<1.0.0 | — | Unreal Python bridge | — |
+| LiquiGen | [dcc-mcp-liquigen](https://github.com/dcc-mcp/dcc-mcp-liquigen) | 0.1.0 | >=0.20.22,<1.0.0 | 1.0.5+ | Standalone native host bridge with typed node-graph, simulation, VAT export, and Unreal handoff tools | 2026-09 |
 | ZBrush | [dcc-mcp-zbrush](https://github.com/dcc-mcp/dcc-mcp-zbrush) | 0.2.18 | >=0.19.45,<1.0.0 | — | Socket bridge + sidecar | — |
 | Photoshop | [dcc-mcp-photoshop](https://github.com/dcc-mcp/dcc-mcp-photoshop) | 0.1.37 | >=0.19.45,<1.0.0 | Photoshop UXP | WebSocket bridge | 2026-06 |
 | Premiere Pro | [dcc-mcp-premiere](https://github.com/dcc-mcp/dcc-mcp-premiere) | 0.5.0 | >=0.19.45,<1.0.0 | 25.6+ | UXP WebSocket bridge | — |
@@ -61,9 +62,10 @@ submit a PR updating this matrix before the release PR merges.
 | OpenUSD | [dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) | 0.8.1 | >=0.19.45,<1.0.0 | — | Headless USD stage adapter | 2026-07 |
 | Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
 
-Tiled, Material Maker, and Wwise remain discoverable source projects, but the
+LiquiGen, Tiled, Material Maker, and Wwise remain discoverable source projects, but the
 bundled catalog omits automatic install metadata until each project publishes a
-wheel that can be pinned by URL and SHA-256.
+wheel (and, for LiquiGen, its PyPI trusted publisher) that can be pinned by URL
+and SHA-256.
 
 ## Column Reference
 

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -61,3 +61,14 @@ def test_skill_only_packages_are_not_pip_adapters() -> None:
     # Cache Inspector is distributed through marketplace.json as a Skill pack.
     # It intentionally has no PyPI project or first-party adapter catalog entry.
     assert "dcc-mcp-cache-inspector" not in entry_names
+
+
+def test_liquigen_is_discoverable_before_pypi_publisher_activation() -> None:
+    entries = {entry["name"]: entry for entry in _entries()}
+    liquigen = entries["dcc-mcp-liquigen"]
+
+    assert liquigen["dcc"] == ["liquigen"]
+    assert liquigen["version"] == "0.1.0"
+    assert liquigen["min_core_version"] == "0.20.22"
+    assert "typed node-graph" in liquigen["description"]
+    assert "install" not in liquigen


### PR DESCRIPTION
## Summary
- register dcc-mcp-liquigen 0.1.0 for CLI discovery under the liquigen DCC type
- document LiquiGen 1.0.5 compatibility and the native bridge workflow
- keep automatic install disabled until the PyPI trusted publisher is configured

## Validation
- vx uv run pytest tests/test_public_adapter_catalog.py -q
- vx cargo test -p dcc-mcp-cli bundled_catalog_lists_adapter_dcc_types_and_collapses_aliases
- vx cargo test -p dcc-mcp-catalog bundled_adapter_catalog_matches_compatibility_matrix
- vx cargo test -p dcc-mcp-catalog bundled_pip_adapters_bind_published_wheels_and_entry_points
- built CLI dcc-types reports liquigen with dcc-mcp-liquigen and catalog_install_available=false