### PR TITLE
feat(catalog): enable LiquiGen release install

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -1245,7 +1245,7 @@ entries:
                     .is_some_and(|install| install.install_type == "pip")
             })
             .collect::<Vec<_>>();
-        assert_eq!(pip_entries.len(), 32);
+        assert_eq!(pip_entries.len(), 33);
         assert!(pip_entries.iter().all(|entry| {
             let install = entry.install.as_ref().unwrap();
             install
@@ -1274,6 +1274,11 @@ entries:
                 "dcc_mcp_touchdesigner:TouchDesignerMcpServer",
             ),
             ("dcc-mcp-shogun", "shogun", "dcc_mcp_shogun:ShogunMcpServer"),
+            (
+                "dcc-mcp-liquigen",
+                "liquigen",
+                "dcc_mcp_liquigen.server:main",
+            ),
             ("dcc-mcp-krita", "krita", "dcc_mcp_krita.server:main"),
             ("dcc-mcp-gimp", "gimp", "dcc_mcp_gimp.server:main"),
         ] {

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -157,7 +157,7 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
 
   - name: "dcc-mcp-liquigen"
-    # Automatic install is omitted until the PyPI trusted publisher is configured.
+    # Pin the public GitHub release wheel until the PyPI trusted publisher is configured.
     description: "LiquiGen adapter with typed node-graph inspection, simulation controls, VAT export, and Unreal Engine handoff"
     dcc: ["liquigen"]
     url: "https://github.com/dcc-mcp/dcc-mcp-liquigen"
@@ -166,6 +166,13 @@ entries:
     version: "0.1.0"
     min_core_version: "0.20.22"
     maintainer: "dcc-mcp"
+    install:
+      type: pip
+      pip_package: "dcc-mcp-liquigen"
+      url: "https://github.com/dcc-mcp/dcc-mcp-liquigen/releases/download/v0.1.0/dcc_mcp_liquigen-0.1.0-py3-none-any.whl"
+      sha256: "97f33d45c289c20b67f16b8b356fa83afb9abbd633cd29cdde415aa81af11834"
+      entry_point: "dcc_mcp_liquigen.server:main"
+      instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-liquigen/main/README.md"
 
   - name: "dcc-mcp-zbrush"
     description: "ZBrush adapter for DCC-MCP"

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -62,10 +62,11 @@ submit a PR updating this matrix before the release PR merges.
 | OpenUSD | [dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) | 0.8.1 | >=0.19.45,<1.0.0 | — | Headless USD stage adapter | 2026-07 |
 | Custom Studio Tool | _(your repo here)_ | _your version_ | _your pin_ | _your min_ | _your pattern_ | _date_ |
 
-LiquiGen, Tiled, Material Maker, and Wwise remain discoverable source projects, but the
+Tiled, Material Maker, and Wwise remain discoverable source projects, but the
 bundled catalog omits automatic install metadata until each project publishes a
-wheel (and, for LiquiGen, its PyPI trusted publisher) that can be pinned by URL
-and SHA-256.
+wheel that can be pinned by URL and SHA-256. LiquiGen is currently pinned to its
+immutable GitHub release wheel; its PyPI trusted publisher can replace that
+fallback without changing the adapter identity.
 
 ## Column Reference
 

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -63,7 +63,7 @@ def test_skill_only_packages_are_not_pip_adapters() -> None:
     assert "dcc-mcp-cache-inspector" not in entry_names
 
 
-def test_liquigen_is_discoverable_before_pypi_publisher_activation() -> None:
+def test_liquigen_is_installable_from_pinned_github_release_wheel() -> None:
     entries = {entry["name"]: entry for entry in _entries()}
     liquigen = entries["dcc-mcp-liquigen"]
 
@@ -71,4 +71,14 @@ def test_liquigen_is_discoverable_before_pypi_publisher_activation() -> None:
     assert liquigen["version"] == "0.1.0"
     assert liquigen["min_core_version"] == "0.20.22"
     assert "typed node-graph" in liquigen["description"]
-    assert "install" not in liquigen
+    assert liquigen["install"] == {
+        "type": "pip",
+        "pip_package": "dcc-mcp-liquigen",
+        "url": (
+            "https://github.com/dcc-mcp/dcc-mcp-liquigen/releases/download/v0.1.0/"
+            "dcc_mcp_liquigen-0.1.0-py3-none-any.whl"
+        ),
+        "sha256": "97f33d45c289c20b67f16b8b356fa83afb9abbd633cd29cdde415aa81af11834",
+        "entry_point": "dcc_mcp_liquigen.server:main",
+        "instructions_url": "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-liquigen/main/README.md",
+    }


### PR DESCRIPTION
## Summary
- expose the immutable LiquiGen 0.1.0 GitHub release wheel to the Core install planner
- bind the wheel SHA256, entry point, and README instructions URL
- keep the PyPI trusted publisher as a future replacement without changing adapter identity

## Validation
- vx uv run pytest -q tests/test_public_adapter_catalog.py
- vx cargo test -p dcc-mcp-catalog bundled_pip_adapters_bind_published_wheels_and_entry_points
- vx cargo test -p dcc-mcp-cli dcc_types_lists_release_catalog_without_a_gateway --test cli_e2e -- --exact
- vx just lint
- cold-installed the exact GitHub release wheel with vx uv