### PR TITLE
fix(catalog): pin LiquiGen PyPI wheel

### DIFF
--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -157,7 +157,7 @@ entries:
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
 
   - name: "dcc-mcp-liquigen"
-    # Pin the public GitHub release wheel until the PyPI trusted publisher is configured.
+    # Pin the immutable PyPI wheel published through the repository's trusted publisher.
     description: "LiquiGen adapter with typed node-graph inspection, simulation controls, VAT export, and Unreal Engine handoff"
     dcc: ["liquigen"]
     url: "https://github.com/dcc-mcp/dcc-mcp-liquigen"
@@ -169,8 +169,8 @@ entries:
     install:
       type: pip
       pip_package: "dcc-mcp-liquigen"
-      url: "https://github.com/dcc-mcp/dcc-mcp-liquigen/releases/download/v0.1.0/dcc_mcp_liquigen-0.1.0-py3-none-any.whl"
-      sha256: "97f33d45c289c20b67f16b8b356fa83afb9abbd633cd29cdde415aa81af11834"
+      url: "https://files.pythonhosted.org/packages/57/04/09ef0e03c75d0aa2694338a4bb5d3e19d1b5c3d996dac3e635dab2ad450c/dcc_mcp_liquigen-0.1.0-py3-none-any.whl"
+      sha256: "130caacfb16b99b9365db071f145a7613f20b45d9b11a7397934c918b7691d0b"
       entry_point: "dcc_mcp_liquigen.server:main"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-liquigen/main/README.md"
 

--- a/docs/guide/adapter-compatibility-matrix.md
+++ b/docs/guide/adapter-compatibility-matrix.md
@@ -64,9 +64,9 @@ submit a PR updating this matrix before the release PR merges.
 
 Tiled, Material Maker, and Wwise remain discoverable source projects, but the
 bundled catalog omits automatic install metadata until each project publishes a
-wheel that can be pinned by URL and SHA-256. LiquiGen is currently pinned to its
-immutable GitHub release wheel; its PyPI trusted publisher can replace that
-fallback without changing the adapter identity.
+wheel that can be pinned by URL and SHA-256. LiquiGen is pinned to its immutable
+PyPI wheel published through the repository's GitHub Actions trusted publisher;
+the adapter identity remains stable across future wheel updates.
 
 ## Column Reference
 

--- a/tests/test_public_adapter_catalog.py
+++ b/tests/test_public_adapter_catalog.py
@@ -63,7 +63,7 @@ def test_skill_only_packages_are_not_pip_adapters() -> None:
     assert "dcc-mcp-cache-inspector" not in entry_names
 
 
-def test_liquigen_is_installable_from_pinned_github_release_wheel() -> None:
+def test_liquigen_is_installable_from_pinned_pypi_wheel() -> None:
     entries = {entry["name"]: entry for entry in _entries()}
     liquigen = entries["dcc-mcp-liquigen"]
 
@@ -75,10 +75,10 @@ def test_liquigen_is_installable_from_pinned_github_release_wheel() -> None:
         "type": "pip",
         "pip_package": "dcc-mcp-liquigen",
         "url": (
-            "https://github.com/dcc-mcp/dcc-mcp-liquigen/releases/download/v0.1.0/"
+            "https://files.pythonhosted.org/packages/57/04/09ef0e03c75d0aa2694338a4bb5d3e19d1b5c3d996dac3e635dab2ad450c/"
             "dcc_mcp_liquigen-0.1.0-py3-none-any.whl"
         ),
-        "sha256": "97f33d45c289c20b67f16b8b356fa83afb9abbd633cd29cdde415aa81af11834",
+        "sha256": "130caacfb16b99b9365db071f145a7613f20b45d9b11a7397934c918b7691d0b",
         "entry_point": "dcc_mcp_liquigen.server:main",
         "instructions_url": "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-liquigen/main/README.md",
     }


### PR DESCRIPTION
## Summary\n- switch the LiquiGen catalog install artifact from the temporary GitHub release fallback to the PyPI trusted-publisher wheel\n- update the compatibility guidance and catalog contract test with the published URL and SHA-256\n\n## Validation\n- vx uv run pytest -q tests/test_public_adapter_catalog.py\n- vx cargo test -p dcc-mcp-catalog bundled_pip_adapters_bind_published_wheels_and_entry_points\n- vx cargo test -p dcc-mcp-cli dcc_types_lists_release_catalog_without_a_gateway --test cli_e2e -- --exact\n- vx just lint\n- vx git diff --check\n\nPyPI publication was verified from the successful LiquiGen release workflow.