### PR TITLE
fix: recover gateway from service-dead port holders

### DIFF
--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -1008,7 +1008,14 @@ async fn probe_resident_gateway_health(
             // Pre-readiness gateways only expose /health.
             let health_url = format!("http://{host}:{port}/health");
             match client.get(&health_url).send().await {
-                Ok(resp) if resp.status().is_success() => ResidentGatewayHealth::Healthy,
+                // Keep the legacy fallback as strict as the application
+                // readiness probe: only an explicit 200 response proves the
+                // resident gateway is ready.  Other 2xx responses (for
+                // example 204/206) may be emitted by a proxy or an unrelated
+                // listener and must not suppress challenger recovery.
+                Ok(resp) if resp.status() == reqwest::StatusCode::OK => {
+                    ResidentGatewayHealth::Healthy
+                }
                 Ok(resp) => {
                     tracing::warn!(status = %resp.status(), url = %health_url, "Resident gateway readiness probe failed");
                     ResidentGatewayHealth::Unhealthy
@@ -1205,6 +1212,9 @@ fn cooperative_yield_fallback_detail(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::Router;
+    use axum::http::StatusCode;
+    use axum::routing::get;
 
     #[test]
     fn registration_identity_rejects_external_endpoint_replacement() {
@@ -1292,6 +1302,40 @@ mod tests {
         assert_eq!(observed, ResidentGatewayHealth::Unhealthy);
         assert!(started.elapsed() < Duration::from_secs(1));
         holder.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_health_fallback_requires_http_200() {
+        let app = Router::new()
+            .route("/v1/readyz", get(|| async { StatusCode::NOT_FOUND }))
+            .route("/health", get(|| async { StatusCode::NO_CONTENT }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let observed =
+            probe_resident_gateway_health("127.0.0.1", port, Duration::from_millis(500)).await;
+        assert_eq!(observed, ResidentGatewayHealth::Unhealthy);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_health_fallback_accepts_http_200() {
+        let app = Router::new()
+            .route("/v1/readyz", get(|| async { StatusCode::NOT_FOUND }))
+            .route("/health", get(|| async { StatusCode::OK }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let observed =
+            probe_resident_gateway_health("127.0.0.1", port, Duration::from_millis(500)).await;
+        assert_eq!(observed, ResidentGatewayHealth::Healthy);
+        server.abort();
     }
 
     #[test]

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -972,7 +972,7 @@ fn stamp_gateway_sentinel(
 fn challenger_reason(resident_health: ResidentGatewayHealth) -> Option<&'static str> {
     match resident_health {
         ResidentGatewayHealth::Unhealthy => {
-            Some("Resident gateway failed /health probe — entering challenger mode")
+            Some("Resident gateway failed application readiness probe — entering challenger mode")
         }
         ResidentGatewayHealth::Healthy => None,
     }
@@ -990,7 +990,20 @@ async fn probe_resident_gateway_health(
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
     match client.get(&readiness_url).send().await {
-        Ok(resp) if resp.status().is_success() => ResidentGatewayHealth::Healthy,
+        Ok(resp) if resp.status() == reqwest::StatusCode::OK => {
+            let status = resp.status();
+            match resp.bytes().await {
+                Ok(body) if readyz_body_is_healthy(&body) => ResidentGatewayHealth::Healthy,
+                Ok(_) => {
+                    tracing::warn!(status = %status, url = %readiness_url, "Resident gateway readiness body is not ready");
+                    ResidentGatewayHealth::Unhealthy
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, url = %readiness_url, "Resident gateway readiness body read failed");
+                    ResidentGatewayHealth::Unhealthy
+                }
+            }
+        }
         Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
             // Pre-readiness gateways only expose /health.
             let health_url = format!("http://{host}:{port}/health");
@@ -1015,6 +1028,13 @@ async fn probe_resident_gateway_health(
             ResidentGatewayHealth::Unhealthy
         }
     }
+}
+
+fn readyz_body_is_healthy(body: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|payload| payload.get("ok").and_then(serde_json::Value::as_bool))
+        == Some(true)
 }
 
 struct PromotedGatewayGuard {
@@ -1248,10 +1268,37 @@ mod tests {
     }
 
     #[test]
+    fn readyz_requires_explicit_ok_true() {
+        assert!(readyz_body_is_healthy(br#"{"ok":true}"#));
+        assert!(!readyz_body_is_healthy(br#"{"ok":false}"#));
+        assert!(!readyz_body_is_healthy(br#"{}"#));
+        assert!(!readyz_body_is_healthy(b"not-json"));
+        assert!(!readyz_body_is_healthy(b""));
+    }
+
+    #[tokio::test]
+    async fn hanging_resident_readyz_is_bounded_and_unhealthy() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let holder = tokio::spawn(async move {
+            if let Ok((_stream, _peer)) = listener.accept().await {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        });
+
+        let started = std::time::Instant::now();
+        let observed =
+            probe_resident_gateway_health("127.0.0.1", port, Duration::from_millis(100)).await;
+        assert_eq!(observed, ResidentGatewayHealth::Unhealthy);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        holder.abort();
+    }
+
+    #[test]
     fn unhealthy_resident_enters_challenger_mode_even_without_version_advantage() {
         assert_eq!(
             challenger_reason(ResidentGatewayHealth::Unhealthy),
-            Some("Resident gateway failed /health probe — entering challenger mode")
+            Some("Resident gateway failed application readiness probe — entering challenger mode")
         );
     }
 
@@ -1260,7 +1307,7 @@ mod tests {
         // No sentinel: /health fails (connection refused) → Unhealthy → challenger
         assert_eq!(
             challenger_reason(ResidentGatewayHealth::Unhealthy),
-            Some("Resident gateway failed /health probe — entering challenger mode")
+            Some("Resident gateway failed application readiness probe — entering challenger mode")
         );
     }
 

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -580,18 +580,19 @@ impl GatewayRunner {
                 let gw_adapter_version = resident.as_ref().and_then(|e| e.adapter_version.clone());
                 let gw_adapter_dcc = resident.as_ref().and_then(|e| e.adapter_dcc.clone());
 
-                // Three cases reach this branch (decided by /health, not sentinel
-                // presence alone):
-                //   A. /health passes                         -> plain instance
-                //   B. /health fails with a resident sentinel -> challenger
-                //   C. /health fails with no sentinel         -> challenger
+                // Three cases reach this branch (decided by application
+                // readiness, not sentinel presence alone):
+                //   A. /v1/readyz (or legacy /health) passes -> plain instance
+                //   B. readiness fails with a resident sentinel -> challenger
+                //   C. readiness fails with no sentinel         -> challenger
                 //      (TIME_WAIT / race: bind failed, nothing
                 //      listening yet, registry row may be gone)
                 //
                 // Standalone ``dcc-mcp-server gateway`` daemons often hold the
                 // port without a ``__gateway__`` row in this process's
                 // FileRegistry (separate registry dir or daemon-only deploy).
-                // Case A covers that attach/coexist path: probe /health before
+                // Case A covers that attach/coexist path: probe application
+                // readiness before
                 // assuming (C). Without the probe, adapters entered challenger
                 // mode, published a competing sentinel, and shut down (PIP-2509).
                 //

--- a/crates/dcc-mcp-gateway/src/gateway/runner.rs
+++ b/crates/dcc-mcp-gateway/src/gateway/runner.rs
@@ -983,28 +983,35 @@ async fn probe_resident_gateway_health(
     port: u16,
     timeout: Duration,
 ) -> ResidentGatewayHealth {
-    let url = format!("http://{host}:{port}/health");
+    let readiness_url = format!("http://{host}:{port}/v1/readyz");
     let client = reqwest::Client::builder()
         .connect_timeout(timeout)
         .timeout(timeout)
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
-    match client.get(&url).send().await {
+    match client.get(&readiness_url).send().await {
         Ok(resp) if resp.status().is_success() => ResidentGatewayHealth::Healthy,
+        Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+            // Pre-readiness gateways only expose /health.
+            let health_url = format!("http://{host}:{port}/health");
+            match client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => ResidentGatewayHealth::Healthy,
+                Ok(resp) => {
+                    tracing::warn!(status = %resp.status(), url = %health_url, "Resident gateway readiness probe failed");
+                    ResidentGatewayHealth::Unhealthy
+                }
+                Err(err) => {
+                    tracing::warn!(error = %err, url = %health_url, "Resident gateway readiness probe failed");
+                    ResidentGatewayHealth::Unhealthy
+                }
+            }
+        }
         Ok(resp) => {
-            tracing::warn!(
-                status = %resp.status(),
-                url = %url,
-                "Resident gateway /health probe failed"
-            );
+            tracing::warn!(status = %resp.status(), url = %readiness_url, "Resident gateway readiness probe failed");
             ResidentGatewayHealth::Unhealthy
         }
         Err(err) => {
-            tracing::warn!(
-                error = %err,
-                url = %url,
-                "Resident gateway /health probe failed"
-            );
+            tracing::warn!(error = %err, url = %readiness_url, "Resident gateway readiness probe failed");
             ResidentGatewayHealth::Unhealthy
         }
     }

--- a/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
@@ -8,7 +8,7 @@
 
 use dcc_mcp_gateway::{ElectionOutcome, GatewayConfig, GatewayHandle, GatewayRunner};
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceKey};
+use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -19,6 +19,13 @@ use crate::sidecar::SidecarArgs;
 const DEFAULT_PROBE_INTERVAL_SECS: u64 = 1;
 const DEFAULT_PROBE_FAILURES: u32 = 2;
 const DEFAULT_PROBE_TIMEOUT_SECS: u64 = 2;
+
+#[derive(Debug, Clone, Copy)]
+struct ProbeSettings {
+    interval: Duration,
+    failures: u32,
+    timeout: Duration,
+}
 
 /// Owns the gateway runner, heartbeat, and optional failover probe task.
 pub struct SidecarGatewayControl {
@@ -148,26 +155,46 @@ fn spawn_failover_probe(
     host: String,
     port: u16,
 ) -> AbortHandle {
-    let probe_interval = std::env::var("DCC_MCP_GATEWAY_PROBE_INTERVAL")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_PROBE_INTERVAL_SECS)
-        .max(1);
-    let probe_failures = std::env::var("DCC_MCP_GATEWAY_PROBE_FAILURES")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_PROBE_FAILURES)
-        .max(1);
-    let probe_timeout = std::env::var("DCC_MCP_GATEWAY_PROBE_TIMEOUT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_PROBE_TIMEOUT_SECS)
-        .max(1);
+    let settings = ProbeSettings {
+        interval: Duration::from_secs(
+            std::env::var("DCC_MCP_GATEWAY_PROBE_INTERVAL")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_PROBE_INTERVAL_SECS)
+                .max(1),
+        ),
+        failures: std::env::var("DCC_MCP_GATEWAY_PROBE_FAILURES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_PROBE_FAILURES)
+            .max(1),
+        timeout: Duration::from_secs(
+            std::env::var("DCC_MCP_GATEWAY_PROBE_TIMEOUT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_PROBE_TIMEOUT_SECS)
+                .max(1),
+        ),
+    };
+    spawn_failover_probe_with_settings(runner, registry, failover, host, port, settings)
+}
+
+fn spawn_failover_probe_with_settings(
+    runner: Arc<GatewayRunner>,
+    registry: Arc<FileRegistry>,
+    failover: Arc<RwLock<FailoverHandles>>,
+    host: String,
+    port: u16,
+    settings: ProbeSettings,
+) -> AbortHandle {
+    let probe_interval = settings.interval;
+    let probe_failures = settings.failures;
+    let probe_timeout = settings.timeout;
 
     let handle = tokio::spawn(async move {
         let mut consecutive_failures = 0u32;
         loop {
-            tokio::time::sleep(Duration::from_secs(probe_interval)).await;
+            tokio::time::sleep(probe_interval).await;
 
             let is_gateway = failover.read().await.is_gateway;
             if is_gateway {
@@ -217,8 +244,7 @@ fn spawn_failover_probe(
     handle.abort_handle()
 }
 
-async fn probe_gateway_health(host: &str, port: u16, timeout_secs: u64) -> bool {
-    let timeout = Duration::from_secs(timeout_secs);
+async fn probe_gateway_health(host: &str, port: u16, timeout: Duration) -> bool {
     let client = match reqwest::Client::builder()
         .connect_timeout(timeout)
         .timeout(timeout)
@@ -273,7 +299,7 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        let healthy = probe_gateway_health("127.0.0.1", port, 1).await;
+        let healthy = probe_gateway_health("127.0.0.1", port, Duration::from_secs(1)).await;
         server.abort();
         healthy
     }
@@ -294,7 +320,7 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        assert!(probe_gateway_health("127.0.0.1", port, 1).await);
+        assert!(probe_gateway_health("127.0.0.1", port, Duration::from_secs(1)).await);
         server.abort();
     }
 
@@ -308,7 +334,7 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        assert!(!probe_gateway_health("127.0.0.1", port, 1).await);
+        assert!(!probe_gateway_health("127.0.0.1", port, Duration::from_secs(1)).await);
         server.abort();
     }
 
@@ -322,7 +348,7 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        assert!(probe_gateway_health("127.0.0.1", port, 1).await);
+        assert!(probe_gateway_health("127.0.0.1", port, Duration::from_secs(1)).await);
         server.abort();
     }
 
@@ -336,9 +362,115 @@ mod tests {
             }
         });
         let started = std::time::Instant::now();
-        assert!(!probe_gateway_health("127.0.0.1", port, 1).await);
+        assert!(!probe_gateway_health("127.0.0.1", port, Duration::from_secs(1)).await);
         assert!(started.elapsed() < Duration::from_secs(2));
         holder.abort();
+    }
+
+    #[tokio::test]
+    async fn failover_probe_re_elects_service_dead_gateway_and_converges_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(FileRegistry::new(dir.path()).unwrap());
+        let stale_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = stale_listener.local_addr().unwrap().port();
+        let stale_readyz_seen = Arc::new(tokio::sync::Notify::new());
+        let handler_notify = stale_readyz_seen.clone();
+        let stale_app = Router::new()
+            .route(
+                "/v1/readyz",
+                get(move || {
+                    let notify = handler_notify.clone();
+                    async move {
+                        notify.notify_one();
+                        (StatusCode::OK, r#"{"ok":false}"#)
+                    }
+                }),
+            )
+            .route("/health", get(|| async { StatusCode::OK }));
+        let stale_server = tokio::spawn(async move {
+            axum::serve(stale_listener, stale_app).await.unwrap();
+        });
+
+        let runner = Arc::new(
+            GatewayRunner::new(GatewayConfig {
+                host: "127.0.0.1".to_string(),
+                gateway_port: port,
+                registry_dir: Some(dir.path().to_path_buf()),
+                server_name: "sidecar-failover-test".to_string(),
+                server_version: "2.0.0".to_string(),
+                heartbeat_secs: 0,
+                ..GatewayConfig::default()
+            })
+            .unwrap(),
+        );
+        let failover = Arc::new(RwLock::new(FailoverHandles {
+            is_gateway: false,
+            gateway_abort: None,
+            challenger_abort: None,
+            gateway_supervisor: None,
+            gateway_thread: None,
+            sentinel_key: None,
+        }));
+
+        let probe_abort = spawn_failover_probe_with_settings(
+            runner,
+            registry.clone(),
+            failover.clone(),
+            "127.0.0.1".to_string(),
+            port,
+            ProbeSettings {
+                interval: Duration::from_millis(10),
+                failures: 1,
+                timeout: Duration::from_millis(250),
+            },
+        );
+
+        stale_readyz_seen.notified().await;
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        stale_server.abort();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if failover.read().await.is_gateway {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("failover probe should promote after stale gateway exits");
+
+        let state = failover.read().await;
+        assert!(state.is_gateway, "role should converge to gateway");
+        assert!(
+            state.gateway_abort.is_some(),
+            "gateway tasks should be owned"
+        );
+        let sentinel_key = state
+            .sentinel_key
+            .clone()
+            .expect("promotion should publish a gateway sentinel");
+        drop(state);
+        let sentinels = registry
+            .list_instances_async(GATEWAY_SENTINEL_DCC_TYPE.to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            sentinels.len(),
+            1,
+            "registry should converge to one gateway"
+        );
+        assert_eq!(sentinels[0].key(), sentinel_key);
+        assert_eq!(sentinels[0].port, port);
+
+        probe_abort.abort();
+        let mut state = failover.write().await;
+        let sentinel_key = state.sentinel_key.take();
+        abort_failover_handles(&mut state);
+        drop(state);
+        if let Some(key) = sentinel_key {
+            registry.deregister_async(key).await.unwrap();
+        }
     }
 }
 

--- a/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
@@ -1,10 +1,10 @@
 //! Gateway election + health-probe failover for per-DCC sidecar processes.
 //!
 //! In-process DCC adapters use :class:`dcc_mcp_core.gateway_election.DccGatewayElection`
-//! (Python) to promote when ``GET /health`` on the well-known gateway port fails.
-//! Sidecar mode moves MCP dispatch out-of-process; the sidecar must run the
-//! same probe loop in Rust so a surviving peer can take over when the elected
-//! gateway crashes without restarting Maya.
+//! (Python) to promote when application readiness on the well-known gateway
+//! port fails.  Sidecar mode moves MCP dispatch out-of-process; the sidecar
+//! must run the same probe loop in Rust so a surviving peer can take over when
+//! the elected gateway crashes or becomes service-dead without restarting Maya.
 
 use dcc_mcp_gateway::{ElectionOutcome, GatewayConfig, GatewayHandle, GatewayRunner};
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
@@ -218,17 +218,127 @@ fn spawn_failover_probe(
 }
 
 async fn probe_gateway_health(host: &str, port: u16, timeout_secs: u64) -> bool {
-    let url = format!("http://{host}:{port}/health");
+    let timeout = Duration::from_secs(timeout_secs);
     let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
+        .connect_timeout(timeout)
+        .timeout(timeout)
         .build()
     {
         Ok(c) => c,
         Err(_) => return false,
     };
-    match client.get(&url).send().await {
-        Ok(resp) => resp.status().is_success(),
-        Err(_) => false,
+    let readiness_url = format!("http://{host}:{port}/v1/readyz");
+    match client.get(&readiness_url).send().await {
+        Ok(resp) if resp.status() == reqwest::StatusCode::OK => resp
+            .bytes()
+            .await
+            .is_ok_and(|body| readyz_body_is_healthy(&body)),
+        Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+            // Legacy gateways predating /v1/readyz are accepted only when
+            // their explicit /health probe returns HTTP 200.
+            let health_url = format!("http://{host}:{port}/health");
+            client
+                .get(health_url)
+                .send()
+                .await
+                .is_ok_and(|response| response.status() == reqwest::StatusCode::OK)
+        }
+        Ok(_) | Err(_) => false,
+    }
+}
+
+fn readyz_body_is_healthy(body: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|payload| payload.get("ok").and_then(serde_json::Value::as_bool))
+        == Some(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::http::StatusCode;
+    use axum::routing::get;
+
+    async fn probe_with_routes(health_status: StatusCode) -> bool {
+        let app = Router::new()
+            .route(
+                "/v1/readyz",
+                get(|| async { (StatusCode::OK, r#"{"ok":false}"#) }),
+            )
+            .route("/health", get(move || async move { health_status }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let healthy = probe_gateway_health("127.0.0.1", port, 1).await;
+        server.abort();
+        healthy
+    }
+
+    #[tokio::test]
+    async fn service_dead_readyz_does_not_trust_healthy_health_alias() {
+        assert!(!probe_with_routes(StatusCode::OK).await);
+    }
+
+    #[tokio::test]
+    async fn readiness_requires_explicit_ok_true() {
+        let app = Router::new().route(
+            "/v1/readyz",
+            get(|| async { (StatusCode::OK, r#"{"ok":true}"#) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        assert!(probe_gateway_health("127.0.0.1", port, 1).await);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_404_fallback_requires_http_200_health() {
+        let app = Router::new()
+            .route("/v1/readyz", get(|| async { StatusCode::NOT_FOUND }))
+            .route("/health", get(|| async { StatusCode::NO_CONTENT }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        assert!(!probe_gateway_health("127.0.0.1", port, 1).await);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn legacy_404_fallback_accepts_http_200_health() {
+        let app = Router::new()
+            .route("/v1/readyz", get(|| async { StatusCode::NOT_FOUND }))
+            .route("/health", get(|| async { StatusCode::OK }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        assert!(probe_gateway_health("127.0.0.1", port, 1).await);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn hanging_readyz_is_bounded_and_unhealthy() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let holder = tokio::spawn(async move {
+            if let Ok((_stream, _peer)) = listener.accept().await {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        });
+        let started = std::time::Instant::now();
+        assert!(!probe_gateway_health("127.0.0.1", port, 1).await);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        holder.abort();
     }
 }
 

--- a/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
@@ -8,7 +8,7 @@
 
 use dcc_mcp_gateway::{ElectionOutcome, GatewayConfig, GatewayHandle, GatewayRunner};
 use dcc_mcp_transport::discovery::file_registry::FileRegistry;
-use dcc_mcp_transport::discovery::types::{GATEWAY_SENTINEL_DCC_TYPE, ServiceEntry, ServiceKey};
+use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceKey};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -286,6 +286,7 @@ mod tests {
     use axum::Router;
     use axum::http::StatusCode;
     use axum::routing::get;
+    use dcc_mcp_transport::discovery::types::GATEWAY_SENTINEL_DCC_TYPE;
 
     async fn probe_with_routes(health_status: StatusCode) -> bool {
         let app = Router::new()

--- a/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
@@ -429,8 +429,9 @@ mod tests {
         stale_readyz_seen.notified().await;
         tokio::time::sleep(Duration::from_millis(25)).await;
         stale_server.abort();
+        let _ = stale_server.await;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(15), async {
             loop {
                 if failover.read().await.is_gateway {
                     break;

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -60,6 +60,26 @@ def _is_healthy(host: str, port: int, timeout: float) -> bool:
         return False
 
 
+def _is_application_ready(host: str, port: int, timeout: float) -> bool:
+    """Probe application readiness with a bounded legacy fallback."""
+    url = f"http://{host}:{port}/v1/readyz"
+    try:
+        with urlopen(url, timeout=timeout) as resp:
+            if int(getattr(resp, "status", 0)) != 200:
+                return False
+            reader = getattr(resp, "read", None)
+            if not callable(reader):
+                return True
+            raw = reader()
+            if not raw:
+                return True
+            payload = json.loads(raw.decode("utf-8"))
+            return isinstance(payload, dict) and payload.get("ok") is True
+    except (HTTPError, HTTPException, URLError, OSError, ValueError, TypeError, UnicodeDecodeError, AttributeError):
+        # Pre-readiness gateways expose only /health.
+        return _is_healthy(host, port, timeout)
+
+
 def _read_gateway_version_from_admin_health(
     gateway_host: str,
     gateway_port: int,
@@ -229,7 +249,7 @@ def _remove_stale_launch_lock(path: Path, stale_after_secs: float) -> bool:
 def _wait_gateway_ready(host: str, port: int, *, timeout_secs: float, probe_timeout: float = 0.5) -> bool:
     deadline = time.time() + max(timeout_secs, 0.2)
     while time.time() < deadline:
-        if _is_healthy(host, port, timeout=probe_timeout):
+        if _is_application_ready(host, port, timeout=probe_timeout):
             return True
         time.sleep(0.1)
     return False
@@ -262,7 +282,7 @@ def _wait_managed_gateway_ready(
             minimum_version,
             managed_version,
         )
-        if version_is_acceptable and _is_healthy(host, port, timeout=probe_timeout):
+        if version_is_acceptable and _is_application_ready(host, port, timeout=probe_timeout):
             return True
         time.sleep(0.1)
     return False
@@ -395,7 +415,7 @@ def _try_version_takeover(
     # Wait for the old gateway to yield (up to ~20 s for the 15 s cleanup interval + grace).
     deadline = time.time() + 20.0
     while time.time() < deadline:
-        if not _is_healthy(gateway_host, gateway_port, timeout=0.5):
+        if not _is_application_ready(gateway_host, gateway_port, timeout=0.5):
             logger.info("version takeover: old gateway yielded — spawning new version")
             break
         time.sleep(0.5)
@@ -494,7 +514,7 @@ def ensure_gateway_daemon(
     timeout_secs = _resolve_ensure_timeout(timeout_secs)
     if gateway_port <= 0:
         return {"ok": False, "reason": "gateway_port_not_configured"}
-    if _is_healthy(gateway_host, gateway_port, timeout=0.5):
+    if _is_application_ready(gateway_host, gateway_port, timeout=0.5):
         takeover_result = _try_version_takeover(
             gateway_host=gateway_host,
             gateway_port=gateway_port,
@@ -537,7 +557,7 @@ def ensure_gateway_daemon(
 
     try:
         try:
-            if _is_healthy(gateway_host, gateway_port, timeout=0.5):
+            if _is_application_ready(gateway_host, gateway_port, timeout=0.5):
                 return {"ok": True, "reason": "already_healthy", "registry_dir": str(registry_path)}
             spawn = launch_detached(cmd, env=env, cwd=Path.cwd())
             if not spawn.get("ok"):
@@ -670,7 +690,7 @@ class GatewayDaemonGuardian:
         if self.gateway_port <= 0:
             return self._publish({"ok": False, "reason": "gateway_port_not_configured"})
 
-        if _is_healthy(self.gateway_host, self.gateway_port, timeout=self.probe_timeout_secs):
+        if _is_application_ready(self.gateway_host, self.gateway_port, timeout=self.probe_timeout_secs):
             self._consecutive_failures = 0
             takeover_result = _try_version_takeover(
                 gateway_host=self.gateway_host,
@@ -701,7 +721,7 @@ class GatewayDaemonGuardian:
             jitter = random.uniform(0.0, self.reensure_jitter_max_secs)
             if jitter > 0.0 and self._stop.wait(jitter):
                 return self._publish({"ok": False, "reason": "guardian_stopped"})
-            if _is_healthy(self.gateway_host, self.gateway_port, timeout=self.probe_timeout_secs):
+            if _is_application_ready(self.gateway_host, self.gateway_port, timeout=self.probe_timeout_secs):
                 self._consecutive_failures = 0
                 return self._publish(
                     {

--- a/python/dcc_mcp_core/_server/gateway_guardian.py
+++ b/python/dcc_mcp_core/_server/gateway_guardian.py
@@ -65,19 +65,28 @@ def _is_application_ready(host: str, port: int, timeout: float) -> bool:
     url = f"http://{host}:{port}/v1/readyz"
     try:
         with urlopen(url, timeout=timeout) as resp:
-            if int(getattr(resp, "status", 0)) != 200:
+            status = int(getattr(resp, "status", 0))
+            if status == 404:
+                # Pre-readiness gateways expose only /health.
+                return _is_healthy(host, port, timeout)
+            if status != 200:
                 return False
             reader = getattr(resp, "read", None)
             if not callable(reader):
-                return True
+                return False
             raw = reader()
             if not raw:
-                return True
+                return False
             payload = json.loads(raw.decode("utf-8"))
             return isinstance(payload, dict) and payload.get("ok") is True
-    except (HTTPError, HTTPException, URLError, OSError, ValueError, TypeError, UnicodeDecodeError, AttributeError):
-        # Pre-readiness gateways expose only /health.
-        return _is_healthy(host, port, timeout)
+    except HTTPError as err:
+        if int(getattr(err, "code", 0)) == 404:
+            # Pre-readiness gateways expose only /health.
+            return _is_healthy(host, port, timeout)
+        return False
+    except (HTTPException, URLError, OSError, ValueError, TypeError, UnicodeDecodeError, AttributeError):
+        # A transport or malformed readiness response is not proof of liveness.
+        return False
 
 
 def _read_gateway_version_from_admin_health(

--- a/python/dcc_mcp_core/gateway_election.py
+++ b/python/dcc_mcp_core/gateway_election.py
@@ -34,6 +34,7 @@ Usage example::
 from __future__ import annotations
 
 import contextlib
+import json
 
 # Import built-in modules
 import logging
@@ -240,21 +241,34 @@ class DccGatewayElection:
             self._stop_event.wait(self._probe_interval + jitter_s)
 
     def _probe_gateway(self) -> bool:
-        """HTTP GET /health probe against the gateway endpoint.
+        """Bounded application-level readiness probe against the gateway.
 
         Returns:
-            ``True`` if the gateway responds with HTTP 200.
+            ``True`` if ``/v1/readyz`` reports ``ok=true``.  Legacy gateways
+            without that route are accepted via ``/health``.
 
         """
         try:
             import urllib.request
 
-            url = f"http://{self._gateway_host}:{self._gateway_port}/health"
+            url = f"http://{self._gateway_host}:{self._gateway_port}/v1/readyz"
             req = urllib.request.Request(url, method="GET")
             with urllib.request.urlopen(req, timeout=self._probe_timeout) as resp:
-                return resp.status == 200
+                if resp.status != 200:
+                    return False
+                raw = resp.read()
+                if not raw:
+                    return True
+                payload = json.loads(raw.decode("utf-8"))
+                return isinstance(payload, dict) and payload.get("ok") is True
         except Exception:
-            return False
+            try:
+                url = f"http://{self._gateway_host}:{self._gateway_port}/health"
+                req = urllib.request.Request(url, method="GET")
+                with urllib.request.urlopen(req, timeout=self._probe_timeout) as resp:
+                    return resp.status == 200
+            except Exception:
+                return False
 
     def _attempt_election(self) -> bool:
         """Probe the gateway port and, if free, run the real promotion path.

--- a/python/dcc_mcp_core/gateway_election.py
+++ b/python/dcc_mcp_core/gateway_election.py
@@ -43,6 +43,7 @@ import socket
 import threading
 from typing import Any
 from typing import Callable
+from urllib.error import HTTPError
 
 from dcc_mcp_core.constants import ENV_GATEWAY_PROBE_FAILURES
 from dcc_mcp_core.constants import ENV_GATEWAY_PROBE_INTERVAL
@@ -61,7 +62,8 @@ class DccGatewayElection:
     """Manages automatic gateway election when the current gateway fails.
 
     Runs a background daemon thread that:
-    1. Periodically probes the gateway's ``/health`` HTTP endpoint
+    1. Periodically probes the gateway's ``/v1/readyz`` endpoint (with a bounded
+       ``/health`` fallback for legacy gateways)
     2. Counts consecutive failures
     3. Attempts a first-wins socket bind when failures exceed the threshold
     4. Signals the server to upgrade to gateway mode on success
@@ -258,17 +260,23 @@ class DccGatewayElection:
                     return False
                 raw = resp.read()
                 if not raw:
-                    return True
+                    return False
                 payload = json.loads(raw.decode("utf-8"))
                 return isinstance(payload, dict) and payload.get("ok") is True
-        except Exception:
-            try:
-                url = f"http://{self._gateway_host}:{self._gateway_port}/health"
-                req = urllib.request.Request(url, method="GET")
-                with urllib.request.urlopen(req, timeout=self._probe_timeout) as resp:
-                    return resp.status == 200
-            except Exception:
+        except HTTPError as err:
+            if err.code != 404:
                 return False
+        except Exception:
+            return False
+
+        # Only an explicit 404 means the legacy gateway lacks /v1/readyz.
+        try:
+            url = f"http://{self._gateway_host}:{self._gateway_port}/health"
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=self._probe_timeout) as resp:
+                return resp.status == 200
+        except Exception:
+            return False
 
     def _attempt_election(self) -> bool:
         """Probe the gateway port and, if free, run the real promotion path.

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -42,6 +42,22 @@ class _JsonResp(_Resp):
         return json.dumps(self._payload).encode("utf-8")
 
 
+def test_application_ready_requires_readyz_ok_and_ignores_stale_liveness(monkeypatch):
+    """A listening gateway with a non-ready application must be challenged."""
+    calls = []
+
+    def _urlopen(url, **_kwargs):
+        calls.append(url)
+        if url.endswith("/v1/readyz"):
+            return _JsonResp({"ok": False})
+        return _Resp()
+
+    monkeypatch.setattr(gg, "urlopen", _urlopen)
+
+    assert gg._is_application_ready("127.0.0.1", 9765, timeout=0.1) is False
+    assert calls == ["http://127.0.0.1:9765/v1/readyz"]
+
+
 def test_is_healthy_treats_malformed_http_response_as_unhealthy(monkeypatch):
     def _raise_bad_status_line(*_args, **_kwargs):
         raise BadStatusLine("GET /health HTTP/1.1")

--- a/tests/test_gateway_guardian.py
+++ b/tests/test_gateway_guardian.py
@@ -4,6 +4,7 @@ from http.client import BadStatusLine
 import json
 import os
 from pathlib import Path
+import socket
 import sys
 import threading
 import time
@@ -32,6 +33,14 @@ class _Resp:
     def __exit__(self, *_exc):
         return False
 
+    def read(self):
+        return b'{"ok": true}'
+
+
+class _EmptyResp(_Resp):
+    def read(self):
+        return b""
+
 
 class _JsonResp(_Resp):
     def __init__(self, payload, status: int = 200):
@@ -56,6 +65,78 @@ def test_application_ready_requires_readyz_ok_and_ignores_stale_liveness(monkeyp
 
     assert gg._is_application_ready("127.0.0.1", 9765, timeout=0.1) is False
     assert calls == ["http://127.0.0.1:9765/v1/readyz"]
+
+
+def test_application_ready_uses_health_only_for_explicit_legacy_404(monkeypatch):
+    calls = []
+
+    def _urlopen(url, **_kwargs):
+        calls.append(url)
+        if url.endswith("/v1/readyz"):
+            response = _Resp()
+            response.status = 404
+            return response
+        return _Resp()
+
+    monkeypatch.setattr(gg, "urlopen", _urlopen)
+
+    assert gg._is_application_ready("127.0.0.1", 9765, timeout=0.1) is True
+    assert calls == [
+        "http://127.0.0.1:9765/v1/readyz",
+        "http://127.0.0.1:9765/health",
+    ]
+
+
+def test_application_ready_transport_failure_does_not_fallback_to_health(monkeypatch):
+    calls = []
+
+    def _urlopen(url, **_kwargs):
+        calls.append(url)
+        raise OSError("service-dead")
+
+    monkeypatch.setattr(gg, "urlopen", _urlopen)
+    monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: pytest.fail("transport failure must not use stale health"))
+
+    assert gg._is_application_ready("127.0.0.1", 9765, timeout=0.1) is False
+    assert calls == ["http://127.0.0.1:9765/v1/readyz"]
+
+
+def test_application_ready_rejects_empty_success_body(monkeypatch):
+    monkeypatch.setattr(gg, "urlopen", lambda *_args, **_kwargs: _EmptyResp())
+
+    assert gg._is_application_ready("127.0.0.1", 9765, timeout=0.1) is False
+
+
+def test_application_ready_rejects_live_hanging_port_within_probe_timeout():
+    """A listening but unresponsive holder must not block gateway recovery."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    listener.settimeout(0.05)
+    port = listener.getsockname()[1]
+    stop = threading.Event()
+
+    def _hold_connection():
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+            except socket.timeout:
+                continue
+            with conn:
+                while not stop.wait(0.01):
+                    pass
+
+    thread = threading.Thread(target=_hold_connection, daemon=True)
+    thread.start()
+    started = time.monotonic()
+    try:
+        assert gg._is_application_ready("127.0.0.1", port, timeout=0.1) is False
+    finally:
+        stop.set()
+        listener.close()
+        thread.join(timeout=1.0)
+
+    assert time.monotonic() - started < 1.0
 
 
 def test_is_healthy_treats_malformed_http_response_as_unhealthy(monkeypatch):
@@ -388,7 +469,7 @@ def test_launch_lock_acquire_single_attempt_no_loop(tmp_path, monkeypatch):
 
 
 def test_gateway_daemon_guardian_restarts_after_failure_threshold(monkeypatch):
-    monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: False)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *_a, **_k: False)
     calls = []
 
     def _ensure(**kwargs):
@@ -420,7 +501,7 @@ def test_gateway_daemon_guardian_restarts_after_failure_threshold(monkeypatch):
 
 def test_gateway_daemon_guardian_jitter_skips_when_peer_recovers(monkeypatch):
     checks = iter([False, True])
-    monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: next(checks))
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *_a, **_k: next(checks))
     monkeypatch.setattr(gg.random, "uniform", lambda *_a, **_k: 0.0)
 
     def _ensure(**_kwargs):
@@ -445,7 +526,7 @@ def test_gateway_daemon_guardian_jitter_skips_when_peer_recovers(monkeypatch):
 
 def test_gateway_daemon_guardian_resets_failures_on_health(monkeypatch):
     checks = iter([False, True])
-    monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: next(checks))
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *_a, **_k: next(checks))
     monkeypatch.setattr(gg, "_try_version_takeover", lambda **_kwargs: None)
     guardian = gg.GatewayDaemonGuardian(
         gateway_host="127.0.0.1",
@@ -465,7 +546,7 @@ def test_gateway_daemon_guardian_resets_failures_on_health(monkeypatch):
 
 def test_gateway_daemon_guardian_audits_version_when_endpoint_is_healthy(monkeypatch, tmp_path):
     """A healthy stale gateway must still enter the version takeover path."""
-    monkeypatch.setattr(gg, "_is_healthy", lambda *_a, **_k: True)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *_a, **_k: True)
     calls = []
 
     def _takeover(**kwargs):
@@ -513,7 +594,7 @@ def test_guardian_run_catches_crash_and_increments_crash_count(monkeypatch):
         if status.get("crash_count", 0) >= 1:
             crash_reported.set()
 
-    monkeypatch.setattr(gg, "_is_healthy", _crash_after_one)
+    monkeypatch.setattr(gg, "_is_application_ready", _crash_after_one)
 
     guardian = gg.GatewayDaemonGuardian(
         gateway_host="127.0.0.1",
@@ -561,7 +642,7 @@ def test_guardian_run_continues_after_exception(monkeypatch):
         if status.get("crash_count", 0) >= 1:
             crash_reported.set()
 
-    monkeypatch.setattr(gg, "_is_healthy", _probe)
+    monkeypatch.setattr(gg, "_is_application_ready", _probe)
 
     guardian = gg.GatewayDaemonGuardian(
         gateway_host="127.0.0.1",
@@ -642,6 +723,9 @@ def test_ensure_gateway_daemon_spawn_includes_persist_flags(tmp_path, monkeypatc
         def __exit__(self, *_exc):
             return False
 
+        def read(self):
+            return b'{"ok": true}'
+
     def _urlopen(*_args, **_kwargs):
         state["calls"] += 1
         if state["calls"] < 3:
@@ -715,7 +799,7 @@ def _make_runtime_controller(monkeypatch, **owner_attrs):
 
 def test_start_guardian_replaces_dead_guardian(monkeypatch):
     """P1: start_gateway_guardian_if_needed replaces a dead guardian."""
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: False)
     monkeypatch.setattr(gg, "ensure_gateway_daemon", lambda **kw: {"ok": True, "reason": "spawned"})
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
 
@@ -742,7 +826,7 @@ def test_start_guardian_replaces_dead_guardian(monkeypatch):
 
 def test_guardian_watchdog_detects_dead_guardian(monkeypatch):
     """P1: Watchdog loop detects dead guardian and triggers restart."""
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: False)
     monkeypatch.setattr(gg, "ensure_gateway_daemon", lambda **kw: {"ok": True, "reason": "spawned"})
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
 
@@ -1083,7 +1167,7 @@ def test_read_gateway_version_missing_registry():
 
 def test_wait_managed_gateway_ready_rejects_health_only_challenger(monkeypatch, tmp_path):
     """A temporary challenger sentinel cannot prove gateway ownership."""
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: True)
     gg._write_sentinel_entry(
         str(tmp_path),
         gateway_host="127.0.0.1",
@@ -1102,7 +1186,7 @@ def test_wait_managed_gateway_ready_rejects_health_only_challenger(monkeypatch, 
 
 def test_wait_managed_gateway_ready_accepts_owned_same_version(monkeypatch, tmp_path):
     """A healthy process-owned sentinel satisfies the takeover contract."""
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: True)
     services = [
         {
             "dcc_type": "__gateway__",
@@ -1153,7 +1237,7 @@ def test_try_version_takeover_returns_none_when_dev_version(monkeypatch, tmp_pat
     # _get_core_version should return this in test environment.
     monkeypatch.setattr(gg, "_get_core_version", lambda: "0.0.0-dev")
     monkeypatch.setattr(gg, "_read_gateway_version_from_registry", lambda *a, **k: "0.18.0")
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: True)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: True)
 
     result = gg._try_version_takeover(
         gateway_host="127.0.0.1",
@@ -1182,7 +1266,7 @@ def test_try_version_takeover_uses_admin_health_and_cooperative_yield(monkeypatc
         "_write_sentinel_entry",
         lambda *a, **k: pytest.fail("cooperative yield must not rewrite FileRegistry"),
     )
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: False)
     monkeypatch.setattr(gg, "_wait_managed_gateway_ready", lambda *a, **k: True)
 
     def _launch_detached(cmd, **kwargs):
@@ -1252,7 +1336,7 @@ def test_watchdog_interval_env_invalid_falls_back(monkeypatch):
 
 def test_watchdog_immediate_retry_on_guardian_death(monkeypatch):
     """PIP-1416: watchdog immediately probes the new guardian after restart."""
-    monkeypatch.setattr(gg, "_is_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(gg, "_is_application_ready", lambda *a, **k: False)
     monkeypatch.setattr(gg, "ensure_gateway_daemon", lambda **kw: {"ok": True, "reason": "spawned"})
     monkeypatch.setattr(gg, "_resolve_server_bin", lambda: "dcc-mcp-server")
 


### PR DESCRIPTION
## Summary
- probe gateway application readiness via /v1/readyz with bounded legacy /health fallback
- route Python guardian/election and Rust challenger checks through readiness
- add regression coverage for stale liveness responses

## Validation
- x cargo fmt --all -- --check
- python -m compileall -q python/dcc_mcp_core tests/test_gateway_guardian.py

Refs #2405

Core-only change; licensed DCC acceptance remains adapter-owned.