### PR TITLE
fix(ci): materialize isolated uv config

### DIFF
--- a/scripts/ci/generated_lock_sync.py
+++ b/scripts/ci/generated_lock_sync.py
@@ -398,7 +398,13 @@ def sanitized_environment(source: Mapping[str, str], *, isolated_home: Path) -> 
     env["XDG_CACHE_HOME"] = str(isolated_home / "cache")
     env["CARGO_HOME"] = str(isolated_home / "cargo")
     env["PIP_CONFIG_FILE"] = str(isolated_home / "pip.conf")
-    env["UV_CONFIG_FILE"] = str(isolated_home / "uv.toml")
+    # uv treats UV_CONFIG_FILE as an explicit path and fails closed when the
+    # file is absent.  Materialize the empty isolated config before exposing
+    # the path so lock generation cannot fall back to a user-owned config.
+    isolated_home.mkdir(parents=True, exist_ok=True)
+    uv_config = isolated_home / "uv.toml"
+    uv_config.touch(exist_ok=True)
+    env["UV_CONFIG_FILE"] = str(uv_config)
     return env
 
 

--- a/tests/test_uv_lock_consistency.py
+++ b/tests/test_uv_lock_consistency.py
@@ -545,6 +545,8 @@ def test_generation_environment_cannot_expose_write_credentials(tmp_path: Path) 
     assert "GITHUB_TOKEN" not in env and "GH_TOKEN" not in env and "PERSONAL_ACCESS_TOKEN" not in env
     assert env["GIT_CONFIG_NOSYSTEM"] == "1"
     assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert Path(env["UV_CONFIG_FILE"]).is_file()
+    assert Path(env["UV_CONFIG_FILE"]).parent == tmp_path / "isolated-home"
 
     probe = tmp_path / "hostile_lock_backend_probe.py"
     probe.write_text(


### PR DESCRIPTION
Materialize the isolated uv.toml before setting UV_CONFIG_FILE so generated lock validation cannot fail on a missing explicit config path or fall back to user configuration. Adds a regression assertion for the isolated file and preserves credential-stripping behavior.