### PR TITLE
feat: add deterministic capture response contract

### DIFF
--- a/docs/guide/cross-dcc-verification.md
+++ b/docs/guide/cross-dcc-verification.md
@@ -67,6 +67,35 @@ Extra fields beyond the three core ones belong in `extra`. The
 comparator does not read `extra`, which keeps DCC-specific telemetry
 from ever breaking a round-trip assertion.
 
+## Deterministic capture responses
+
+Capture implementations can use `dcc_mcp_core.runtime.capture_contract` to
+publish one bounded response shape:
+
+```python
+from dcc_mcp_core import CaptureTargetSpec, build_capture_response
+
+response = build_capture_response(
+    frame.data,
+    width=frame.width,
+    height=frame.height,
+    format="png",
+    backend="mock",
+    target=CaptureTargetSpec.active_viewport(),
+    return_mode="artifact_only",  # image or both are explicit opt-ins
+    unchanged_if_hash=previous_sha256,
+)
+```
+
+`artifact_only` is the compatibility-safe default and returns an
+`artefact://sha256/...` reference plus bounded metadata (`dimensions`,
+`bytes`, `sha256`, `format`, `backend`, and `target`) without inline pixels.
+`image` adds one base64 image payload; `both` adds that payload alongside the
+artifact reference. A matching `unchanged_if_hash` suppresses image data and
+marks the response `unchanged: true`. Targets are explicit (`dcc_window`,
+`active_viewport`, `scene_viewer`, or a positive bounded `crop`); hidden or
+unknown targets fail closed.
+
 ## Writing a verifier skill
 
 Scaffold a skill with `dcc-mcp-skills-creator`, then wire it to

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -660,6 +660,11 @@ _ALL_LAZY: dict[str, str] = {
     "SpatialConvention": "dcc_mcp_core.spatial",
     "plan_spatial_conversion": "dcc_mcp_core.spatial",
     "SceneStats": "dcc_mcp_core.verifier",
+    # Deterministic capture response contract (PIP-2261)
+    "CaptureReturnMode": "dcc_mcp_core.runtime.capture_contract",
+    "CaptureTargetSpec": "dcc_mcp_core.runtime.capture_contract",
+    "build_capture_response": "dcc_mcp_core.runtime.capture_contract",
+    "capture_response": "dcc_mcp_core.runtime.capture_contract",
     "UnitHint": "dcc_mcp_core.asset_import",
     "WorkflowTask": "dcc_mcp_core.workflow_yaml",
     "WorkflowYaml": "dcc_mcp_core.workflow_yaml",

--- a/python/dcc_mcp_core/runtime/__init__.py
+++ b/python/dcc_mcp_core/runtime/__init__.py
@@ -11,6 +11,10 @@ from dcc_mcp_core._lite_fallback import is_gui_executable
 from dcc_mcp_core._lite_fallback import parse_skill_md
 from dcc_mcp_core._lite_fallback import scan_and_load_strict
 from dcc_mcp_core._runtime.config_bridge import resolve_mcp_http_config_class
+from dcc_mcp_core.runtime.capture_contract import CaptureReturnMode
+from dcc_mcp_core.runtime.capture_contract import CaptureTargetSpec
+from dcc_mcp_core.runtime.capture_contract import build_capture_response
+from dcc_mcp_core.runtime.capture_contract import capture_response
 from dcc_mcp_core.runtime.scene_digest import SCENE_DIGEST_SCHEMA_VERSION
 from dcc_mcp_core.runtime.scene_digest import SceneDigestError
 from dcc_mcp_core.runtime.scene_digest import SceneDigestExecution
@@ -22,6 +26,8 @@ McpHttpConfig = resolve_mcp_http_config_class()
 
 __all__ = [
     "SCENE_DIGEST_SCHEMA_VERSION",
+    "CaptureReturnMode",
+    "CaptureTargetSpec",
     "DccCapabilities",
     "GuiExecutableHint",
     "McpHttpConfig",
@@ -32,6 +38,8 @@ __all__ = [
     "SceneDigestExecutionError",
     "SceneDigestSnapshot",
     "StateDigestProvider",
+    "build_capture_response",
+    "capture_response",
     "correct_python_executable",
     "is_gui_executable",
     "parse_skill_md",

--- a/python/dcc_mcp_core/runtime/capture_contract.py
+++ b/python/dcc_mcp_core/runtime/capture_contract.py
@@ -1,0 +1,182 @@
+# ruff: noqa: UP006, UP007, UP045
+
+"""Deterministic, payload-bounded capture response contract.
+
+Capture implementations remain DCC-owned.  This module only turns encoded
+frame bytes into a stable response shape that every adapter can use.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import re
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+__all__ = [
+    "CaptureReturnMode",
+    "CaptureTargetSpec",
+    "build_capture_response",
+    "capture_response",
+]
+
+_SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
+_TARGETS = frozenset(("dcc_window", "active_viewport", "scene_viewer", "crop"))
+
+
+class CaptureReturnMode(str, Enum):
+    """Allowed capture payload modes."""
+
+    ARTIFACT_ONLY = "artifact_only"
+    IMAGE = "image"
+    BOTH = "both"
+
+    @classmethod
+    def parse(cls, value: Union[str, CaptureReturnMode]) -> CaptureReturnMode:
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value).strip().lower())
+        except ValueError as exc:
+            raise ValueError("return_mode must be artifact_only, image, or both") from exc
+
+
+@dataclass(frozen=True)
+class CaptureTargetSpec:
+    """Explicit capture target, optionally narrowed to a pixel crop."""
+
+    kind: str
+    crop_rect: Optional[Tuple[int, int, int, int]] = None
+    visible: bool = True
+
+    def __post_init__(self) -> None:
+        kind = str(self.kind).strip().lower()
+        if kind not in _TARGETS:
+            raise ValueError("target must be dcc_window, active_viewport, scene_viewer, or crop")
+        object.__setattr__(self, "kind", kind)
+        if not self.visible:
+            raise ValueError("target is hidden or blocked")
+        if kind == "crop" and self.crop_rect is None:
+            raise ValueError("crop target requires x, y, width, and height")
+        if kind != "crop" and self.crop_rect is not None:
+            raise ValueError("crop is only valid for a crop target")
+        if self.crop_rect is not None:
+            values = tuple(self.crop_rect)
+            if len(values) != 4 or any(not isinstance(value, int) for value in values):
+                raise ValueError("crop must contain four integer values")
+            if values[2] <= 0 or values[3] <= 0:
+                raise ValueError("crop width and height must be positive")
+            object.__setattr__(self, "crop_rect", values)
+
+    @classmethod
+    def dcc_window(cls) -> CaptureTargetSpec:
+        return cls("dcc_window")
+
+    @classmethod
+    def active_viewport(cls) -> CaptureTargetSpec:
+        return cls("active_viewport")
+
+    @classmethod
+    def scene_viewer(cls) -> CaptureTargetSpec:
+        return cls("scene_viewer")
+
+    @classmethod
+    def crop(cls, x: int, y: int, width: int, height: int) -> CaptureTargetSpec:
+        return cls("crop", (x, y, width, height))
+
+
+def _target_spec(value: Union[str, CaptureTargetSpec]) -> CaptureTargetSpec:
+    if isinstance(value, CaptureTargetSpec):
+        return value
+    return CaptureTargetSpec(str(value))
+
+
+def _digest(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _normalise_hash(value: str) -> str:
+    candidate = str(value).strip().lower()
+    if not _SHA256_RE.fullmatch(candidate):
+        raise ValueError("unchanged_if_hash must be a 64-character SHA-256 digest")
+    return candidate[7:] if candidate.startswith("sha256:") else candidate
+
+
+def build_capture_response(
+    data: bytes,
+    *,
+    width: int,
+    height: int,
+    format: str,
+    backend: str,
+    target: Union[str, CaptureTargetSpec] = "active_viewport",
+    return_mode: Union[str, CaptureReturnMode] = CaptureReturnMode.ARTIFACT_ONLY,
+    unchanged_if_hash: Optional[str] = None,
+    artifact_uri: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a deterministic capture response without duplicating pixels.
+
+    ``artifact_only`` is the compatibility-safe default.  Inline image data
+    is base64 encoded only for ``image``/``both`` and is omitted when
+    ``unchanged_if_hash`` matches the computed digest.
+    """
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise TypeError("capture data must be bytes-like")
+    if int(width) <= 0 or int(height) <= 0:
+        raise ValueError("width and height must be positive")
+    normalized_format = str(format).strip().lower().lstrip(".")
+    if not normalized_format:
+        raise ValueError("format must not be empty")
+    normalized_backend = str(backend).strip()
+    if not normalized_backend:
+        raise ValueError("backend must not be empty")
+    mode = CaptureReturnMode.parse(return_mode)
+    target_spec = _target_spec(target)
+    payload = bytes(data)
+    sha256 = _digest(payload)
+    metadata: Dict[str, Any] = {
+        "dimensions": [int(width), int(height)],
+        "bytes": len(payload),
+        "sha256": sha256,
+        "format": normalized_format,
+        "backend": normalized_backend,
+        "target": target_spec.kind,
+    }
+    if target_spec.crop_rect is not None:
+        metadata["crop"] = list(target_spec.crop_rect)
+
+    result: Dict[str, Any] = {"metadata": metadata}
+    if mode in (CaptureReturnMode.ARTIFACT_ONLY, CaptureReturnMode.BOTH):
+        uri = artifact_uri or f"artefact://sha256/{sha256}"
+        if not isinstance(uri, str) or not uri.strip():
+            raise ValueError("artifact_uri must be a non-empty URI")
+        if not uri.startswith("artefact://"):
+            raise ValueError("artifact_uri must use the artefact:// scheme")
+        result["artifact"] = {"uri": uri, "digest": f"sha256:{sha256}"}
+
+    unchanged = False
+    if unchanged_if_hash is not None:
+        unchanged = _normalise_hash(unchanged_if_hash) == sha256
+    if unchanged:
+        result["unchanged"] = True
+    elif mode in (CaptureReturnMode.IMAGE, CaptureReturnMode.BOTH):
+        result["image"] = base64.b64encode(payload).decode("ascii")
+    return result
+
+
+def capture_response(frame: Any, **kwargs: Any) -> Dict[str, Any]:
+    """Adapt a ``CaptureFrame``-like object to :func:`build_capture_response`."""
+    return build_capture_response(
+        frame.data,
+        width=frame.width,
+        height=frame.height,
+        format=frame.format,
+        backend=kwargs.pop("backend", "unknown"),
+        **kwargs,
+    )

--- a/tests/test_capture_contract.py
+++ b/tests/test_capture_contract.py
@@ -1,0 +1,120 @@
+"""Deterministic capture response contract tests (issue #2261)."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from dcc_mcp_core import CaptureReturnMode
+from dcc_mcp_core import CaptureTargetSpec
+from dcc_mcp_core import build_capture_response
+
+FRAME = b"deterministic-pixels"
+
+
+def test_artifact_only_returns_bounded_metadata_without_pixels() -> None:
+    result = build_capture_response(
+        FRAME,
+        width=16,
+        height=9,
+        format="png",
+        backend="mock",
+        target=CaptureTargetSpec.active_viewport(),
+        return_mode=CaptureReturnMode.ARTIFACT_ONLY,
+    )
+
+    assert set(result) == {"artifact", "metadata"}
+    assert "image" not in result
+    assert "data" not in result
+    assert result["metadata"] == {
+        "dimensions": [16, 9],
+        "bytes": len(FRAME),
+        "sha256": "0ef02515ac75c95c2a3b82754173d5874c16fd75db3d6d04dc6fef3ea3cb8742",
+        "format": "png",
+        "backend": "mock",
+        "target": "active_viewport",
+    }
+    assert result["artifact"]["uri"].startswith("artefact://sha256/")
+
+
+def test_image_and_both_modes_have_expected_inline_payload() -> None:
+    image = build_capture_response(
+        FRAME,
+        width=1,
+        height=1,
+        format="png",
+        backend="mock",
+        target="dcc_window",
+        return_mode="image",
+    )
+    assert set(image) == {"image", "metadata"}
+    assert base64.b64decode(image["image"]) == FRAME
+
+    both = build_capture_response(
+        FRAME,
+        width=1,
+        height=1,
+        format="png",
+        backend="mock",
+        target="dcc_window",
+        return_mode="both",
+    )
+    assert set(both) == {"artifact", "image", "metadata"}
+
+
+def test_unchanged_hash_suppresses_pixels_deterministically() -> None:
+    initial = build_capture_response(
+        FRAME,
+        width=1,
+        height=1,
+        format="png",
+        backend="mock",
+        target="scene_viewer",
+        return_mode="both",
+    )
+    repeated = build_capture_response(
+        FRAME,
+        width=1,
+        height=1,
+        format="png",
+        backend="mock",
+        target="scene_viewer",
+        return_mode="both",
+        unchanged_if_hash=initial["metadata"]["sha256"],
+    )
+    assert set(repeated) == {"artifact", "metadata", "unchanged"}
+    assert repeated["unchanged"] is True
+    assert "image" not in repeated
+    assert repeated["metadata"] == initial["metadata"]
+
+
+def test_target_crop_and_invalid_values_are_explicit() -> None:
+    target = CaptureTargetSpec.crop(1, 2, 30, 40)
+    result = build_capture_response(
+        FRAME,
+        width=30,
+        height=40,
+        format="jpeg",
+        backend="mock",
+        target=target,
+        return_mode="artifact_only",
+    )
+    assert result["metadata"]["target"] == "crop"
+    assert result["metadata"]["crop"] == [1, 2, 30, 40]
+
+    with pytest.raises(ValueError, match="target"):
+        build_capture_response(FRAME, width=1, height=1, format="png", backend="mock", target="modal")
+    with pytest.raises(ValueError, match="hidden"):
+        CaptureTargetSpec("dcc_window", visible=False)
+    with pytest.raises(ValueError, match="return_mode"):
+        build_capture_response(FRAME, width=1, height=1, format="png", backend="mock", return_mode="pixels")
+    with pytest.raises(ValueError, match="unchanged_if_hash"):
+        build_capture_response(
+            FRAME,
+            width=1,
+            height=1,
+            format="png",
+            backend="mock",
+            unchanged_if_hash="not-a-sha256",
+        )


### PR DESCRIPTION
## Summary\n- add bounded artifact_only, image, and both capture response modes\n- enforce explicit visible targets and deterministic crop metadata\n- suppress inline pixels when unchanged_if_hash matches\n\n## Validation\n- 62 focused contract/import tests passed\n- ruff check and format passed\n- cargo fmt --check passed