### PR TITLE
fix: separate catalog support from live discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ Start a new agent turn after installation.
 
 ```
 Gateway CLI+REST (agent default — use dcc-mcp skill + dcc-mcp-cli):
-Support check (only when unclear): `dcc-mcp-cli dcc-types` lists canonical adapter-backed identifiers from the release catalog without starting a gateway; use `list` for live sessions.
+Support check (only when unclear): `dcc-mcp-cli dcc-types` lists canonical adapter-backed identifiers from the release catalog without starting a gateway. For one target, use `dcc-mcp-cli --output json dcc-types --dcc-type <dcc>` to keep catalog support, local registration, readiness, and later capability evidence separate; `live_instances: 0` means an observed empty local registry while `null` means the observation is unavailable, and neither is proof that the adapter, installation, or project-local host is absent. Use `list` for full live-session inventory.
 1. Discover: `dcc-mcp-cli search --query "keyword" --dcc-type maya` or `POST /v1/search` → get `tool_slug`; names/summaries are tokenized, so underscores are optional (`create_sphere` and `sphere` both work).
 2. Follow `next_step`: a no-schema hit calls directly only when search also carries safety hints; otherwise perform the returned targeted `load_skill` or `describe`. A correlated load may inline `compact_schema` with safety/execution hints and point straight to `call`.
 3. Execute: `dcc-mcp-cli call <slug> --json '{"radius": 2.0}'` or `POST /v1/call`.

--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -200,6 +200,9 @@ coordinates, or stale control ids.
 # 0. Inspect catalog-backed DCC identifiers when support is unclear
 dcc-mcp-cli dcc-types
 
+# Keep catalog and runtime evidence separate for one target
+dcc-mcp-cli --output json dcc-types --dcc-type unreal
+
 # 1. Select a live instance; local list auto-ensures the loopback gateway
 dcc-mcp-cli list
 
@@ -225,7 +228,13 @@ Use the `dcc-mcp` skill to wrap these CLI calls as structured MCP tools in your 
 
 `dcc-types` reads the release catalog without starting a gateway; it reports
 adapter-backed identifiers such as `godot` and `renderdoc`, while `list` reports
-live sessions.
+live sessions. The targeted form returns the versioned
+`dcc-discovery-decision` contract. Treat `live_instances: 0` only as an empty
+local registry result and `live_instances: null` as an unavailable observation:
+package installation, adapter import, project-local bootstrap, and public
+support remain independent evidence gates. Follow its
+read-only `next_action`; do not call a DCC until search returns an
+instance-qualified slug or identity.
 
 On failure, keep the CLI-returned `request_id` and run `doctor` for startup or
 readiness faults, then `stats --status failure --session-id task-42` for the

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Then discover a live capability before calling it:
 
 ~~~bash
 dcc-mcp-cli dcc-types
+dcc-mcp-cli --output json dcc-types --dcc-type unreal
 dcc-mcp-cli list
 dcc-mcp-cli search --query "create sphere" --dcc-type maya --limit 20
 dcc-mcp-cli describe <tool-slug>
@@ -265,7 +266,12 @@ contain the unified search parser also accept unquoted positional words.
 
 `dcc-types` is an offline, catalog-backed capability query. It reports
 canonical adapter identifiers and install-plan availability; `list` remains
-the source of truth for live instances.
+the source of truth for live instances. The targeted `--dcc-type` form emits a
+versioned decision that keeps public catalog support, package/bootstrap state,
+registry registration, readiness, capability discovery, and real-host proof
+separate. In particular, `live_instances: 0` does not mean zero supported or
+installed applications; `live_instances: null` means the local registry
+observation was unavailable.
 
 Replace the placeholder with the slug returned by search. For remote workstations,
 register a gateway profile and select it:

--- a/contracts/dcc-discovery-decision-v1.schema.json
+++ b/contracts/dcc-discovery-decision-v1.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dcc-mcp.dev/contracts/dcc-discovery-decision-v1.schema.json",
+  "title": "DCC discovery decision v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "dcc_type",
+    "live_instances",
+    "public_adapter",
+    "released_catalog",
+    "package_installation",
+    "adapter_import",
+    "project_bootstrap",
+    "registry_registration",
+    "direct_readiness",
+    "gateway_capability_index",
+    "search_hit",
+    "exact_instance_call",
+    "real_host_effect",
+    "uncertainties",
+    "failure_stage",
+    "failure_reason",
+    "next_action"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "dcc_type": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "live_instances": { "type": ["integer", "null"], "minimum": 0 },
+    "public_adapter": { "$ref": "#/$defs/presence" },
+    "released_catalog": {
+      "enum": ["present", "absent", "stale", "unknown"]
+    },
+    "package_installation": {
+      "enum": ["absent", "planned", "installed", "unknown"]
+    },
+    "adapter_import": { "enum": ["pass", "fail", "unknown"] },
+    "project_bootstrap": {
+      "enum": ["not_detected", "bootstrappable", "configured", "failed", "unknown"]
+    },
+    "registry_registration": {
+      "enum": ["present", "absent", "stale", "unknown"]
+    },
+    "direct_readiness": { "enum": ["ready", "not_ready", "unknown"] },
+    "gateway_capability_index": { "$ref": "#/$defs/presence" },
+    "search_hit": { "$ref": "#/$defs/presence" },
+    "exact_instance_call": { "enum": ["pass", "fail", "not_run", "unknown"] },
+    "real_host_effect": {
+      "enum": ["verified", "not_verified", "not_applicable", "unknown"]
+    },
+    "uncertainties": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "enum": ["version", "custom_fork", "real_host"] }
+    },
+    "failure_stage": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9_-]*$"
+    },
+    "failure_reason": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Z][A-Z0-9_]*$"
+    },
+    "next_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "command", "requires_consent"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-z][a-z0-9_]*$"
+        },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+        },
+        "requires_consent": { "type": "boolean" },
+        "instructions_url": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "pattern": "^https://"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "presence": { "enum": ["present", "absent", "unknown"] }
+  }
+}

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -1,23 +1,21 @@
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use dcc_mcp_models::DccName;
-use serde::Serialize;
 use thiserror::Error;
 
 use crate::domain::install::{
-    InstallPlan, InstallPlanError, InstallPlanner, InstallPolicy, InstallRequest,
-    InstallStepAction, normalized_dcc_key,
+    InstallPlan, InstallPlanError, InstallPlanner, InstallPolicy, InstallRequest, InstallStepAction,
 };
 
 const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
 
+mod discovery;
 mod pip;
 mod policy;
 mod report;
 
+pub use discovery::{DccAdapterSummary, DccTypeSummary, DccTypesCatalog};
 use pip::{pip_install_args, pip_show_args, pip_uninstall_args};
 use policy::{AutoInstallPolicy, ask_consent, render_install_policy_prompt};
 pub use report::{
@@ -45,29 +43,6 @@ pub enum InstallError {
     Io(#[from] std::io::Error),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DccTypesCatalog {
-    pub total: usize,
-    pub dcc_types: Vec<DccTypeSummary>,
-    pub custom_types_supported: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DccTypeSummary {
-    pub dcc_type: String,
-    pub adapters: Vec<DccAdapterSummary>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-pub struct DccAdapterSummary {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    pub catalog_install_available: bool,
-}
-
 /// Describes how to undo a completed step.
 #[derive(Debug)]
 enum StepRollback {
@@ -84,7 +59,7 @@ enum StepExecution {
 }
 
 pub struct InstallService {
-    default_catalog_path: PathBuf,
+    default_catalog_path: Option<PathBuf>,
     auto_install_policy: AutoInstallPolicy,
 }
 
@@ -92,7 +67,17 @@ impl InstallService {
     #[must_use]
     pub fn new(default_catalog_path: PathBuf) -> Self {
         Self {
-            default_catalog_path,
+            default_catalog_path: Some(default_catalog_path),
+            auto_install_policy: AutoInstallPolicy::from_env(),
+        }
+    }
+
+    /// Build a service whose implicit catalog is the release catalog embedded
+    /// in this binary. Custom catalogs must be passed explicitly in a request.
+    #[must_use]
+    pub fn bundled() -> Self {
+        Self {
+            default_catalog_path: None,
             auto_install_policy: AutoInstallPolicy::from_env(),
         }
     }
@@ -103,7 +88,7 @@ impl InstallService {
         auto_install_policy: AutoInstallPolicy,
     ) -> Self {
         Self {
-            default_catalog_path,
+            default_catalog_path: Some(default_catalog_path),
             auto_install_policy,
         }
     }
@@ -113,56 +98,6 @@ impl InstallService {
         let entries = self.load_entries(request.catalog_path.as_deref())?;
         let plan = InstallPlanner::plan(&entries, request)?;
         Ok(self.apply_auto_install_policy(plan))
-    }
-
-    /// List adapter-backed DCC types from the same catalog used by `install`.
-    pub fn dcc_types(&self, catalog_path: Option<&Path>) -> Result<DccTypesCatalog, InstallError> {
-        let entries = self.load_entries(catalog_path)?;
-        let mut grouped: BTreeMap<String, BTreeMap<String, DccAdapterSummary>> = BTreeMap::new();
-        let mut canonical_by_normalized: BTreeMap<String, String> = BTreeMap::new();
-
-        for entry in entries.iter().filter(|entry| {
-            entry
-                .tags
-                .iter()
-                .any(|tag| tag.eq_ignore_ascii_case("adapter"))
-        }) {
-            let adapter = DccAdapterSummary {
-                name: entry.name.clone(),
-                version: entry.version.clone(),
-                url: entry.url.clone(),
-                catalog_install_available: entry.install.is_some(),
-            };
-            for dcc_type in &entry.dcc {
-                let parsed = DccName::parse(dcc_type).to_string();
-                let normalized = normalized_dcc_key(&parsed);
-                if normalized.is_empty() {
-                    continue;
-                }
-                let canonical = canonical_by_normalized
-                    .entry(normalized)
-                    .or_insert_with(|| parsed.clone())
-                    .clone();
-                grouped
-                    .entry(canonical)
-                    .or_default()
-                    .insert(adapter.name.clone(), adapter.clone());
-            }
-        }
-
-        let dcc_types = grouped
-            .into_iter()
-            .map(|(dcc_type, adapters)| DccTypeSummary {
-                dcc_type,
-                adapters: adapters.into_values().collect(),
-            })
-            .collect::<Vec<_>>();
-
-        Ok(DccTypesCatalog {
-            total: dcc_types.len(),
-            dcc_types,
-            custom_types_supported: true,
-        })
     }
 
     /// Generate and execute an install plan with user consent.
@@ -195,11 +130,13 @@ impl InstallService {
             return dcc_mcp_catalog::load_from_file(path).map_err(Into::into);
         }
 
-        let entries = dcc_mcp_catalog::load_from_file(Path::new(&self.default_catalog_path))?;
-        if entries.is_empty() {
-            return dcc_mcp_catalog::load_from_str(BUNDLED_CATALOG).map_err(Into::into);
+        if let Some(default_path) = self.default_catalog_path.as_deref() {
+            let entries = dcc_mcp_catalog::load_from_file(Path::new(default_path))?;
+            if !entries.is_empty() {
+                return Ok(entries);
+            }
         }
-        Ok(entries)
+        dcc_mcp_catalog::load_from_str(BUNDLED_CATALOG).map_err(Into::into)
     }
 
     fn apply_auto_install_policy(&self, mut plan: InstallPlan) -> InstallPlan {

--- a/crates/dcc-mcp-cli/src/application/install/discovery.rs
+++ b/crates/dcc-mcp-cli/src/application/install/discovery.rs
@@ -1,0 +1,504 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use dcc_mcp_models::DccName;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::{BUNDLED_CATALOG, InstallError, InstallService};
+use crate::domain::install::normalized_dcc_key;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DccTypesCatalog {
+    pub total: usize,
+    pub dcc_types: Vec<DccTypeSummary>,
+    pub custom_types_supported: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DccTypeSummary {
+    pub dcc_type: String,
+    pub adapters: Vec<DccAdapterSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DccAdapterSummary {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub catalog_install_available: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Presence {
+    Present,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CatalogPresence {
+    Present,
+    Absent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PackageInstallation {
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AdapterImport {
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ProjectBootstrap {
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RegistryRegistration {
+    Present,
+    Absent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DirectReadiness {
+    Ready,
+    NotReady,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ExactInstanceCall {
+    NotRun,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RealHostEffect {
+    NotVerified,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Uncertainty {
+    Version,
+    CustomFork,
+    RealHost,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct DiscoveryNextAction {
+    id: String,
+    command: Vec<String>,
+    requires_consent: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DccDiscoveryDecision {
+    schema_version: u8,
+    dcc_type: String,
+    live_instances: Option<usize>,
+    public_adapter: Presence,
+    released_catalog: CatalogPresence,
+    package_installation: PackageInstallation,
+    adapter_import: AdapterImport,
+    project_bootstrap: ProjectBootstrap,
+    registry_registration: RegistryRegistration,
+    direct_readiness: DirectReadiness,
+    gateway_capability_index: Presence,
+    search_hit: Presence,
+    exact_instance_call: ExactInstanceCall,
+    real_host_effect: RealHostEffect,
+    uncertainties: Vec<Uncertainty>,
+    failure_stage: Option<String>,
+    failure_reason: Option<String>,
+    next_action: DiscoveryNextAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RuntimeObservation {
+    live_instances: usize,
+    registry_registration: RegistryRegistration,
+    direct_readiness: DirectReadiness,
+}
+
+impl InstallService {
+    /// List adapter-backed DCC types from the bundled or explicitly supplied catalog.
+    pub fn dcc_types(&self, catalog_path: Option<&Path>) -> Result<DccTypesCatalog, InstallError> {
+        let entries = if let Some(path) = catalog_path {
+            self.load_entries(Some(path))?
+        } else {
+            dcc_mcp_catalog::load_from_str(BUNDLED_CATALOG)?
+        };
+        let mut grouped: BTreeMap<String, BTreeMap<String, DccAdapterSummary>> = BTreeMap::new();
+        let mut canonical_by_normalized: BTreeMap<String, String> = BTreeMap::new();
+
+        for entry in entries.iter().filter(|entry| {
+            entry
+                .tags
+                .iter()
+                .any(|tag| tag.eq_ignore_ascii_case("adapter"))
+        }) {
+            let adapter = DccAdapterSummary {
+                name: entry.name.clone(),
+                version: entry.version.clone(),
+                url: entry.url.clone(),
+                catalog_install_available: entry.install.is_some(),
+            };
+            for dcc_type in &entry.dcc {
+                let parsed = DccName::parse(dcc_type).to_string();
+                let normalized = normalized_dcc_key(&parsed);
+                if normalized.is_empty() {
+                    continue;
+                }
+                let canonical = canonical_by_normalized
+                    .entry(normalized)
+                    .or_insert_with(|| parsed.clone())
+                    .clone();
+                grouped
+                    .entry(canonical)
+                    .or_default()
+                    .insert(adapter.name.clone(), adapter.clone());
+            }
+        }
+
+        let dcc_types = grouped
+            .into_iter()
+            .map(|(dcc_type, adapters)| DccTypeSummary {
+                dcc_type,
+                adapters: adapters.into_values().collect(),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(DccTypesCatalog {
+            total: dcc_types.len(),
+            dcc_types,
+            custom_types_supported: true,
+        })
+    }
+
+    pub(crate) fn discovery_decision(
+        &self,
+        catalog_path: Option<&std::path::Path>,
+        requested_dcc_type: &str,
+        inventory: Option<&Value>,
+    ) -> DccDiscoveryDecision {
+        let Some(canonical_dcc) = validated_dcc_type(requested_dcc_type) else {
+            return failure_decision(
+                "unknown",
+                Presence::Unknown,
+                CatalogPresence::Unknown,
+                None,
+                "input_validation",
+                "INVALID_DCC_TYPE",
+                inspect_catalog_action(),
+            );
+        };
+        let requested_key = normalized_dcc_key(&canonical_dcc);
+        let runtime = inventory.map(|value| observe_runtime(value, &requested_key));
+
+        let entries = if let Some(path) = catalog_path {
+            self.load_entries(Some(path))
+        } else {
+            dcc_mcp_catalog::load_from_str(BUNDLED_CATALOG).map_err(Into::into)
+        };
+        let entries = match entries {
+            Ok(entries) => entries,
+            Err(_) => {
+                return failure_decision(
+                    &canonical_dcc,
+                    Presence::Unknown,
+                    CatalogPresence::Unknown,
+                    runtime,
+                    "catalog_load",
+                    "CATALOG_LOAD_FAILED",
+                    inspect_catalog_action(),
+                );
+            }
+        };
+        let adapter = entries.iter().find(|entry| {
+            entry
+                .tags
+                .iter()
+                .any(|tag| tag.eq_ignore_ascii_case("adapter"))
+                && entry.dcc.iter().any(|dcc| {
+                    let parsed = DccName::parse(dcc).to_string();
+                    normalized_dcc_key(&parsed) == requested_key
+                })
+        });
+        let public_adapter = if catalog_path.is_none() && adapter.is_some() {
+            Presence::Present
+        } else {
+            Presence::Unknown
+        };
+        let released_catalog = if catalog_path.is_some() {
+            CatalogPresence::Unknown
+        } else if adapter.is_some() {
+            CatalogPresence::Present
+        } else {
+            CatalogPresence::Absent
+        };
+        let Some(runtime) = runtime else {
+            return failure_decision(
+                &canonical_dcc,
+                public_adapter,
+                released_catalog,
+                None,
+                "registry_read",
+                "REGISTRY_READ_FAILED",
+                doctor_action(),
+            );
+        };
+        let live_instances = runtime.live_instances;
+        let direct_readiness = runtime.direct_readiness;
+        let instructions_url = if catalog_path.is_none() {
+            adapter
+                .and_then(|entry| entry.install.as_ref())
+                .and_then(|install| install.instructions_url.clone())
+        } else {
+            None
+        };
+        let next_action = if direct_readiness == DirectReadiness::Ready {
+            search_action(&canonical_dcc)
+        } else if live_instances > 0 {
+            wait_ready_action(&canonical_dcc)
+        } else if catalog_path.is_none()
+            && adapter.and_then(|entry| entry.install.as_ref()).is_some()
+        {
+            install_plan_action(&canonical_dcc, instructions_url)
+        } else {
+            inspect_catalog_action()
+        };
+        let (failure_stage, failure_reason) = if adapter.is_none() {
+            (
+                Some("catalog_lookup".to_string()),
+                Some("CATALOG_ENTRY_NOT_FOUND".to_string()),
+            )
+        } else if direct_readiness == DirectReadiness::NotReady {
+            (
+                Some("direct_readiness".to_string()),
+                Some("INSTANCE_NOT_READY".to_string()),
+            )
+        } else {
+            (None, None)
+        };
+
+        DccDiscoveryDecision {
+            schema_version: 1,
+            dcc_type: canonical_dcc,
+            live_instances: Some(live_instances),
+            public_adapter,
+            released_catalog,
+            package_installation: PackageInstallation::Unknown,
+            adapter_import: AdapterImport::Unknown,
+            project_bootstrap: ProjectBootstrap::Unknown,
+            registry_registration: runtime.registry_registration,
+            direct_readiness,
+            gateway_capability_index: Presence::Unknown,
+            search_hit: Presence::Unknown,
+            exact_instance_call: ExactInstanceCall::NotRun,
+            real_host_effect: RealHostEffect::NotVerified,
+            uncertainties: vec![
+                Uncertainty::Version,
+                Uncertainty::CustomFork,
+                Uncertainty::RealHost,
+            ],
+            failure_stage,
+            failure_reason,
+            next_action,
+        }
+    }
+}
+
+fn validated_dcc_type(requested: &str) -> Option<String> {
+    if requested.trim() != requested
+        || requested.is_empty()
+        || requested.chars().count() > 64
+        || requested
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '/' | '\\' | ':'))
+    {
+        return None;
+    }
+
+    let canonical = DccName::parse(requested).to_string();
+    (!canonical.is_empty() && canonical.chars().count() <= 64).then_some(canonical)
+}
+
+fn observe_runtime(inventory: &Value, requested_key: &str) -> RuntimeObservation {
+    let matching_instances = inventory
+        .get("instances")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|instance| {
+            instance
+                .get("dcc_type")
+                .and_then(Value::as_str)
+                .map(|dcc| {
+                    let parsed = DccName::parse(dcc).to_string();
+                    normalized_dcc_key(&parsed) == requested_key
+                })
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    let live_instances = matching_instances.len();
+    let ready_instances = matching_instances
+        .iter()
+        .filter(|instance| {
+            instance
+                .pointer("/direct_control/ready")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .count();
+
+    RuntimeObservation {
+        live_instances,
+        registry_registration: if live_instances > 0 {
+            RegistryRegistration::Present
+        } else {
+            RegistryRegistration::Absent
+        },
+        direct_readiness: if live_instances == 0 {
+            DirectReadiness::Unknown
+        } else if ready_instances > 0 {
+            DirectReadiness::Ready
+        } else {
+            DirectReadiness::NotReady
+        },
+    }
+}
+
+fn failure_decision(
+    dcc_type: &str,
+    public_adapter: Presence,
+    released_catalog: CatalogPresence,
+    runtime: Option<RuntimeObservation>,
+    failure_stage: &str,
+    failure_reason: &str,
+    next_action: DiscoveryNextAction,
+) -> DccDiscoveryDecision {
+    DccDiscoveryDecision {
+        schema_version: 1,
+        dcc_type: dcc_type.to_string(),
+        live_instances: runtime.map(|observation| observation.live_instances),
+        public_adapter,
+        released_catalog,
+        package_installation: PackageInstallation::Unknown,
+        adapter_import: AdapterImport::Unknown,
+        project_bootstrap: ProjectBootstrap::Unknown,
+        registry_registration: runtime
+            .map(|observation| observation.registry_registration)
+            .unwrap_or(RegistryRegistration::Unknown),
+        direct_readiness: runtime
+            .map(|observation| observation.direct_readiness)
+            .unwrap_or(DirectReadiness::Unknown),
+        gateway_capability_index: Presence::Unknown,
+        search_hit: Presence::Unknown,
+        exact_instance_call: ExactInstanceCall::NotRun,
+        real_host_effect: RealHostEffect::NotVerified,
+        uncertainties: vec![
+            Uncertainty::Version,
+            Uncertainty::CustomFork,
+            Uncertainty::RealHost,
+        ],
+        failure_stage: Some(failure_stage.to_string()),
+        failure_reason: Some(failure_reason.to_string()),
+        next_action,
+    }
+}
+
+fn install_plan_action(dcc_type: &str, instructions_url: Option<String>) -> DiscoveryNextAction {
+    DiscoveryNextAction {
+        id: "plan_install".to_string(),
+        command: vec![
+            "dcc-mcp-cli".to_string(),
+            "--output".to_string(),
+            "json".to_string(),
+            "--non-interactive".to_string(),
+            "install".to_string(),
+            "--dcc-type".to_string(),
+            dcc_type.to_string(),
+        ],
+        requires_consent: false,
+        instructions_url,
+    }
+}
+
+fn search_action(dcc_type: &str) -> DiscoveryNextAction {
+    DiscoveryNextAction {
+        id: "search_capabilities".to_string(),
+        command: vec![
+            "dcc-mcp-cli".to_string(),
+            "--output".to_string(),
+            "json".to_string(),
+            "search".to_string(),
+            "--dcc-type".to_string(),
+            dcc_type.to_string(),
+        ],
+        requires_consent: false,
+        instructions_url: None,
+    }
+}
+
+fn wait_ready_action(dcc_type: &str) -> DiscoveryNextAction {
+    DiscoveryNextAction {
+        id: "wait_ready".to_string(),
+        command: vec![
+            "dcc-mcp-cli".to_string(),
+            "--output".to_string(),
+            "json".to_string(),
+            "wait-ready".to_string(),
+            "--dcc-type".to_string(),
+            dcc_type.to_string(),
+        ],
+        requires_consent: false,
+        instructions_url: None,
+    }
+}
+
+fn inspect_catalog_action() -> DiscoveryNextAction {
+    DiscoveryNextAction {
+        id: "inspect_catalog".to_string(),
+        command: vec![
+            "dcc-mcp-cli".to_string(),
+            "--output".to_string(),
+            "json".to_string(),
+            "--non-interactive".to_string(),
+            "dcc-types".to_string(),
+        ],
+        requires_consent: false,
+        instructions_url: None,
+    }
+}
+
+fn doctor_action() -> DiscoveryNextAction {
+    DiscoveryNextAction {
+        id: "inspect_registry".to_string(),
+        command: vec![
+            "dcc-mcp-cli".to_string(),
+            "--output".to_string(),
+            "json".to_string(),
+            "doctor".to_string(),
+        ],
+        requires_consent: false,
+        instructions_url: None,
+    }
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -27,6 +27,7 @@ use crate::domain::rest::{
 };
 use crate::infra::http::HttpGateway;
 
+mod dcc_types_output;
 mod image_artifacts;
 mod job_progress;
 mod lint;
@@ -166,6 +167,9 @@ enum Command {
         /// Read a custom adapter catalog instead of the release catalog.
         #[arg(long, env = "DCC_MCP_CATALOG_PATH")]
         catalog: Option<PathBuf>,
+        /// Resolve one DCC's catalog and live-instance states independently.
+        #[arg(long)]
+        dcc_type: Option<String>,
     },
     /// Search callable tools, or list the complete loaded inventory when no query is provided.
     Search {
@@ -684,9 +688,8 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             run_doctor(doctor.request(registry_dir, Some(gateway_host), Some(gateway_port))).await?
         }
         Command::List => control.list_instances().await?,
-        Command::DccTypes { catalog } => {
-            let service = InstallService::new(PathBuf::from("dcc-mcp-catalog.yml"));
-            to_json(service.dcc_types(catalog.as_deref())?)?
+        Command::DccTypes { catalog, dcc_type } => {
+            dcc_types_output::run(catalog.as_deref(), dcc_type.as_deref())?
         }
         Command::Search {
             query,
@@ -922,7 +925,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             execute,
             json,
         } => {
-            let service = InstallService::new(PathBuf::from("dcc-mcp-catalog.yml"));
+            let service = InstallService::bundled();
             let req = InstallRequest {
                 dcc_type,
                 version,

--- a/crates/dcc-mcp-cli/src/presentation/cli/dcc_types_output.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/dcc_types_output.rs
@@ -1,0 +1,18 @@
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::to_json;
+use crate::application::gateway_ensure;
+use crate::application::install::InstallService;
+use crate::application::local_registry::list_local_instances;
+
+pub(super) fn run(catalog: Option<&Path>, dcc_type: Option<&str>) -> anyhow::Result<Value> {
+    let service = InstallService::bundled();
+    if let Some(dcc_type) = dcc_type {
+        let inventory = list_local_instances(gateway_ensure::default_registry_dir()).ok();
+        to_json(service.discovery_decision(catalog, dcc_type, inventory.as_ref()))
+    } else {
+        to_json(service.dcc_types(catalog)?)
+    }
+}

--- a/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/tests.rs
@@ -81,13 +81,16 @@ fn dcc_types_contract_accepts_a_custom_catalog() {
         "dcc-types",
         "--catalog",
         "studio-catalog.yml",
+        "--dcc-type",
+        "studio tool",
     ])
     .expect("parse dcc-types command");
 
-    let Command::DccTypes { catalog } = args.command else {
+    let Command::DccTypes { catalog, dcc_type } = args.command else {
         panic!("expected dcc-types command");
     };
     assert_eq!(catalog, Some(PathBuf::from("studio-catalog.yml")));
+    assert_eq!(dcc_type.as_deref(), Some("studio tool"));
 }
 
 #[test]
@@ -908,7 +911,10 @@ fn gateway_endpoint_for_command_ensures_gateway_for_agent_control_commands() {
     assert!(
         gateway_endpoint_for_command(
             DEFAULT_BASE_URL,
-            &Command::DccTypes { catalog: None },
+            &Command::DccTypes {
+                catalog: None,
+                dcc_type: None,
+            },
             &local,
         )
         .is_none()

--- a/crates/dcc-mcp-cli/tests/discovery_cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/discovery_cli_e2e.rs
@@ -1,0 +1,425 @@
+mod support;
+
+use dcc_mcp_transport::discovery::file_registry::FileRegistry;
+use dcc_mcp_transport::discovery::types::{ServiceEntry, ServiceStatus};
+use serde_json::Value;
+use tempfile::{NamedTempFile, TempDir};
+
+use support::*;
+
+const DISCOVERY_DECISION_SCHEMA: &str =
+    include_str!("../../../contracts/dcc-discovery-decision-v1.schema.json");
+
+fn validate_decision(value: &Value) {
+    let schema: Value = serde_json::from_str(DISCOVERY_DECISION_SCHEMA).unwrap();
+    jsonschema::validator_for(&schema)
+        .unwrap()
+        .validate(value)
+        .unwrap();
+}
+
+#[test]
+fn dcc_types_distinguishes_catalog_support_from_zero_live_instances() {
+    let registry = TempDir::new().unwrap();
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let value = run_json_with_env(
+        &["--output", "json", "dcc-types", "--dcc-type", "unreal"],
+        &[("DCC_MCP_REGISTRY_DIR", registry_s.as_str())],
+    );
+
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["dcc_type"], "unreal");
+    assert_eq!(value["live_instances"], 0);
+    assert_eq!(value["public_adapter"], "present");
+    assert_eq!(value["released_catalog"], "present");
+    assert_eq!(value["package_installation"], "unknown");
+    assert_eq!(value["adapter_import"], "unknown");
+    assert_eq!(value["project_bootstrap"], "unknown");
+    assert_eq!(value["registry_registration"], "absent");
+    assert_eq!(value["direct_readiness"], "unknown");
+    assert_eq!(value["gateway_capability_index"], "unknown");
+    assert_eq!(value["search_hit"], "unknown");
+    assert_eq!(value["exact_instance_call"], "not_run");
+    assert_eq!(value["real_host_effect"], "not_verified");
+    assert_eq!(
+        value["uncertainties"],
+        serde_json::json!(["version", "custom_fork", "real_host"])
+    );
+    assert_eq!(value["next_action"]["id"], "plan_install");
+    assert_eq!(value["next_action"]["requires_consent"], false);
+    assert_eq!(
+        value["next_action"]["command"],
+        serde_json::json!([
+            "dcc-mcp-cli",
+            "--output",
+            "json",
+            "--non-interactive",
+            "install",
+            "--dcc-type",
+            "unreal"
+        ])
+    );
+    assert_eq!(
+        value["next_action"]["instructions_url"],
+        "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
+    );
+
+    validate_decision(&value);
+}
+
+#[test]
+fn dcc_types_does_not_treat_a_missing_catalog_row_as_unsupported() {
+    let registry = TempDir::new().unwrap();
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let value = run_json_with_env(
+        &["--output", "json", "dcc-types", "--dcc-type", "studio tool"],
+        &[("DCC_MCP_REGISTRY_DIR", registry_s.as_str())],
+    );
+
+    assert_eq!(value["public_adapter"], "unknown");
+    assert_eq!(value["released_catalog"], "absent");
+    assert_eq!(value["failure_stage"], "catalog_lookup");
+    assert_eq!(value["failure_reason"], "CATALOG_ENTRY_NOT_FOUND");
+    assert_eq!(value["next_action"]["id"], "inspect_catalog");
+    assert!(
+        !value
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("unsupported")
+    );
+
+    validate_decision(&value);
+}
+
+#[test]
+fn targeted_decision_uses_the_bundled_release_catalog_not_cwd() {
+    let cwd = TempDir::new().unwrap();
+    std::fs::write(
+        cwd.path().join("dcc-mcp-catalog.yml"),
+        r#"entries:
+  - name: private-unreal
+    description: Private Unreal adapter
+    dcc: [unreal]
+    tags: [adapter]
+    install:
+      type: pip
+      pip_package: private-unreal
+      instructions_url: https://private.invalid/secret/install
+"#,
+    )
+    .unwrap();
+    let registry = TempDir::new().unwrap();
+    let output = cli_command()
+        .current_dir(cwd.path())
+        .env("DCC_MCP_REGISTRY_DIR", registry.path())
+        .args(["--output", "json", "dcc-types", "--dcc-type", "unreal"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(value["public_adapter"], "present");
+    assert_eq!(value["released_catalog"], "present");
+    assert_eq!(
+        value["next_action"]["instructions_url"],
+        "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
+    );
+    assert!(!value.to_string().contains("private.invalid"));
+    validate_decision(&value);
+}
+
+#[test]
+fn unfiltered_catalog_uses_the_bundled_release_catalog_not_cwd() {
+    let cwd = TempDir::new().unwrap();
+    std::fs::write(
+        cwd.path().join("dcc-mcp-catalog.yml"),
+        r#"entries:
+  - name: private-only-adapter
+    description: Private adapter
+    dcc: [private-host]
+    tags: [adapter]
+    url: https://private.invalid/secret/repository
+"#,
+    )
+    .unwrap();
+    let output = cli_command()
+        .current_dir(cwd.path())
+        .args(["--output", "json", "dcc-types"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let serialized = value.to_string();
+
+    assert_eq!(value["total"], 37);
+    assert!(serialized.contains("dcc-mcp-unreal"));
+    assert!(!serialized.contains("private-only-adapter"));
+    assert!(!serialized.contains("private.invalid"));
+}
+
+#[test]
+fn plan_only_install_uses_the_bundled_release_catalog_not_cwd() {
+    let cwd = TempDir::new().unwrap();
+    std::fs::write(
+        cwd.path().join("dcc-mcp-catalog.yml"),
+        r#"entries:
+  - name: private-unreal
+    description: Private Unreal adapter
+    dcc: [unreal]
+    tags: [adapter]
+    url: https://private.invalid/secret/repository
+    install:
+      type: pip
+      pip_package: private-unreal
+"#,
+    )
+    .unwrap();
+    let output = cli_command()
+        .current_dir(cwd.path())
+        .args([
+            "--output",
+            "json",
+            "--non-interactive",
+            "install",
+            "--dcc-type",
+            "unreal",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let serialized = value.to_string();
+
+    assert_eq!(value["adapter"]["name"], "dcc-mcp-unreal");
+    assert!(!serialized.contains("private-unreal"));
+    assert!(!serialized.contains("private.invalid"));
+}
+
+#[test]
+fn dcc_types_does_not_present_a_custom_catalog_as_the_release_catalog() {
+    let registry = TempDir::new().unwrap();
+    let registry_s = registry.path().to_string_lossy().to_string();
+    let catalog = NamedTempFile::new().unwrap();
+    std::fs::write(
+        catalog.path(),
+        r#"entries:
+  - name: studio-unreal
+    description: Studio Unreal adapter
+    dcc: [unreal]
+    tags: [adapter]
+    install:
+      type: pip
+      pip_package: studio-unreal
+      instructions_url: https://internal.invalid/unreal/install
+"#,
+    )
+    .unwrap();
+    let catalog_s = catalog.path().to_string_lossy().to_string();
+    let value = run_json_with_env(
+        &[
+            "--output",
+            "json",
+            "dcc-types",
+            "--catalog",
+            &catalog_s,
+            "--dcc-type",
+            "unreal",
+        ],
+        &[("DCC_MCP_REGISTRY_DIR", registry_s.as_str())],
+    );
+
+    assert_eq!(value["public_adapter"], "unknown");
+    assert_eq!(value["released_catalog"], "unknown");
+    assert_eq!(value["next_action"]["id"], "inspect_catalog");
+    assert_eq!(value["next_action"]["instructions_url"], Value::Null);
+    assert!(!value["next_action"].to_string().contains(&catalog_s));
+    assert!(!value["next_action"].to_string().contains("install"));
+    assert!(!value.to_string().contains("internal.invalid"));
+}
+
+#[test]
+fn dcc_types_keeps_live_registration_and_readiness_separate_from_catalog_support() {
+    let registry_dir = TempDir::new().unwrap();
+    let registry = FileRegistry::new(registry_dir.path()).unwrap();
+    registry
+        .register(ServiceEntry::new("godot", "127.0.0.1", 18080))
+        .unwrap();
+    let registry_s = registry_dir.path().to_string_lossy().to_string();
+    let value = run_json_with_env(
+        &["--output", "json", "dcc-types", "--dcc-type", "godot"],
+        &[("DCC_MCP_REGISTRY_DIR", registry_s.as_str())],
+    );
+
+    assert_eq!(value["public_adapter"], "present");
+    assert_eq!(value["released_catalog"], "present");
+    assert_eq!(value["live_instances"], 1);
+    assert_eq!(value["registry_registration"], "present");
+    assert_eq!(value["direct_readiness"], "ready");
+    assert_eq!(value["gateway_capability_index"], "unknown");
+    assert_eq!(value["search_hit"], "unknown");
+    assert_eq!(value["exact_instance_call"], "not_run");
+    assert_eq!(value["next_action"]["id"], "search_capabilities");
+}
+
+#[test]
+fn dcc_types_waits_for_a_registered_but_unready_instance_before_searching() {
+    let registry_dir = TempDir::new().unwrap();
+    let registry = FileRegistry::new(registry_dir.path()).unwrap();
+    let mut entry = ServiceEntry::new("unreal", "127.0.0.1", 18080);
+    entry.status = ServiceStatus::Booting;
+    registry.register(entry).unwrap();
+    let registry_s = registry_dir.path().to_string_lossy().to_string();
+    let value = run_json_with_env(
+        &["--output", "json", "dcc-types", "--dcc-type", "unreal"],
+        &[("DCC_MCP_REGISTRY_DIR", registry_s.as_str())],
+    );
+
+    assert_eq!(value["registry_registration"], "present");
+    assert_eq!(value["direct_readiness"], "not_ready");
+    assert_eq!(value["failure_stage"], "direct_readiness");
+    assert_eq!(value["failure_reason"], "INSTANCE_NOT_READY");
+    assert_eq!(value["next_action"]["id"], "wait_ready");
+    assert_eq!(
+        value["next_action"]["command"],
+        serde_json::json!([
+            "dcc-mcp-cli",
+            "--output",
+            "json",
+            "wait-ready",
+            "--dcc-type",
+            "unreal"
+        ])
+    );
+}
+
+#[test]
+fn invalid_dcc_identifiers_return_a_safe_schema_valid_failure() {
+    let registry = TempDir::new().unwrap();
+    let invalid_values = [
+        "".to_string(),
+        "x".repeat(65),
+        "maya\r\nPRIVATE".to_string(),
+        r"C:\private\adapter".to_string(),
+        "/private/adapter".to_string(),
+    ];
+
+    for invalid in invalid_values {
+        let output = cli_command()
+            .env("DCC_MCP_REGISTRY_DIR", registry.path())
+            .args(["--output", "json", "dcc-types", "--dcc-type", &invalid])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert_eq!(value["dcc_type"], "unknown");
+        assert_eq!(value["live_instances"], Value::Null);
+        assert_eq!(value["registry_registration"], "unknown");
+        assert_eq!(value["failure_stage"], "input_validation");
+        assert_eq!(value["failure_reason"], "INVALID_DCC_TYPE");
+        assert_eq!(value["next_action"]["id"], "inspect_catalog");
+        if !invalid.is_empty() {
+            assert!(!combined.contains(&invalid));
+        }
+        validate_decision(&value);
+    }
+}
+
+#[test]
+fn invalid_catalog_returns_a_safe_schema_valid_failure() {
+    let registry_dir = TempDir::new().unwrap();
+    let registry = FileRegistry::new(registry_dir.path()).unwrap();
+    registry
+        .register(ServiceEntry::new("unreal", "127.0.0.1", 18080))
+        .unwrap();
+    let catalog = NamedTempFile::new().unwrap();
+    std::fs::write(catalog.path(), "entries: [private-secret").unwrap();
+    let catalog_s = catalog.path().to_string_lossy().to_string();
+    let registry_s = registry_dir.path().to_string_lossy().to_string();
+    let output = cli_command()
+        .env("DCC_MCP_REGISTRY_DIR", &registry_s)
+        .args([
+            "--output",
+            "json",
+            "dcc-types",
+            "--catalog",
+            &catalog_s,
+            "--dcc-type",
+            "unreal",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(value["failure_stage"], "catalog_load");
+    assert_eq!(value["failure_reason"], "CATALOG_LOAD_FAILED");
+    assert_eq!(value["live_instances"], 1);
+    assert_eq!(value["registry_registration"], "present");
+    assert_eq!(value["direct_readiness"], "ready");
+    assert_eq!(value["next_action"]["id"], "inspect_catalog");
+    assert!(!combined.contains(&catalog_s));
+    validate_decision(&value);
+}
+
+#[test]
+fn unreadable_registry_returns_a_safe_schema_valid_failure() {
+    let registry_file = NamedTempFile::new().unwrap();
+    let registry_s = registry_file.path().to_string_lossy().to_string();
+    let output = cli_command()
+        .env("DCC_MCP_REGISTRY_DIR", &registry_s)
+        .args(["--output", "json", "dcc-types", "--dcc-type", "unreal"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(value["public_adapter"], "present");
+    assert_eq!(value["released_catalog"], "present");
+    assert_eq!(value["live_instances"], Value::Null);
+    assert_eq!(value["registry_registration"], "unknown");
+    assert_eq!(value["failure_stage"], "registry_read");
+    assert_eq!(value["failure_reason"], "REGISTRY_READ_FAILED");
+    assert_eq!(value["next_action"]["id"], "inspect_registry");
+    assert!(!combined.contains(&registry_s));
+    validate_decision(&value);
+}

--- a/crates/dcc-mcp-cli/tests/discovery_decision_contract.rs
+++ b/crates/dcc-mcp-cli/tests/discovery_decision_contract.rs
@@ -1,0 +1,80 @@
+mod support;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use support::run_json_with_env;
+
+const DECISION_SCHEMA: &str =
+    include_str!("../../../contracts/dcc-discovery-decision-v1.schema.json");
+const GAME_ENGINE_FIXTURES: &str =
+    include_str!("../../../tests/fixtures/discovery-decision/game-engines.json");
+
+#[test]
+fn game_engine_decisions_match_v1_schema_and_preserve_unknowns() {
+    let schema: Value = serde_json::from_str(DECISION_SCHEMA).unwrap();
+    let validator = jsonschema::validator_for(&schema).unwrap();
+    let fixtures: Value = serde_json::from_str(GAME_ENGINE_FIXTURES).unwrap();
+    let cases = fixtures["cases"].as_array().unwrap();
+
+    assert_eq!(cases.len(), 4);
+    for case in cases {
+        let registry = TempDir::new().unwrap();
+        let registry_s = registry.path().to_string_lossy().to_string();
+        let dcc_type = case["dcc_type"].as_str().unwrap();
+        let decision = run_json_with_env(
+            &["--output", "json", "dcc-types", "--dcc-type", dcc_type],
+            &[("DCC_MCP_REGISTRY_DIR", registry_s.as_str())],
+        );
+        validator
+            .validate(&decision)
+            .unwrap_or_else(|error| panic!("{}: {error}", case["id"]));
+        assert_eq!(decision["live_instances"], 0);
+        assert_eq!(decision["public_adapter"], "present");
+        assert_eq!(decision["released_catalog"], "present");
+        assert_eq!(decision["package_installation"], "unknown");
+        assert_eq!(decision["project_bootstrap"], "unknown");
+        assert_eq!(decision["registry_registration"], "absent");
+        assert_eq!(decision["exact_instance_call"], "not_run");
+        assert_eq!(decision["real_host_effect"], "not_verified");
+        assert_eq!(
+            decision["next_action"]["instructions_url"],
+            case["expected_instructions_url"]
+        );
+        assert!(
+            decision["uncertainties"]
+                .as_array()
+                .unwrap()
+                .contains(&Value::String("real_host".to_string()))
+        );
+        assert!(
+            !decision
+                .to_string()
+                .to_ascii_lowercase()
+                .contains("unsupported")
+        );
+    }
+
+    let unreal = cases
+        .iter()
+        .find(|case| case["id"] == "unreal-5.6")
+        .unwrap();
+    assert_eq!(unreal["context"]["legacy_remote_execution_required"], false);
+    assert_eq!(
+        unreal["context"]["selected_bootstrap_path"],
+        "engine_bundled_python"
+    );
+    assert_eq!(unreal["context"]["optional_native_bridge_required"], false);
+
+    let tuanjie = cases
+        .iter()
+        .find(|case| case["id"] == "unity-tuanjie")
+        .unwrap();
+    assert_eq!(tuanjie["context"]["reported_version"], "2022.3.48t1");
+
+    let godot = cases
+        .iter()
+        .find(|case| case["id"] == "godot-project")
+        .unwrap();
+    assert_eq!(godot["context"]["machine_wide_host_detected"], false);
+}

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -148,6 +148,7 @@ path/source/version without launching or downloading anything.
 
 ```bash
 dcc-mcp-cli dcc-types
+dcc-mcp-cli --output json dcc-types --dcc-type unreal
 dcc-mcp-cli dcc-types --catalog ./studio-catalog.yml
 dcc-mcp-cli list
 dcc-mcp-cli list --gateway pcA
@@ -219,7 +220,7 @@ launching operation.
 
 | Command | REST/API contract | Meaning |
 |---|---|---|
-| `dcc-types [--catalog <path>]` | bundled or supplied adapter catalog | List canonical adapter-backed DCC identifiers without starting a gateway. Each row includes matching adapters, version/source metadata when present, and whether the catalog can produce an install plan. |
+| `dcc-types [--dcc-type <dcc>] [--catalog <path>]` | bundled or supplied adapter catalog + local FileRegistry for the targeted form | Without `--dcc-type`, list canonical adapter-backed identifiers without starting a gateway. With one target, emit the versioned discovery decision that separates catalog, registration, readiness, capability, and real-host evidence. |
 | `health` | `GET /v1/healthz` | Check the configured endpoint. |
 | `stats [--range 1h\|24h\|7d\|all] [--dcc-type <dcc>] [--skill <name>] [--tool <name>] [--status success\|failure] [--instance-id <id>] [--session-id <id>]` | `GET /v1/debug/stats` | Query persisted gateway tool-call counts and return `stats_coverage`, including direct routes excluded from the aggregate. JSON is the default output for agent use. |
 | `feedback --tool-name <name> --intent <text> --blocker <text> [--attempt <text>] [--severity <level>] [--dcc-type <dcc>] [--instance-id <id>] [--request-id <id>] [--job-id <id>]` | `POST /v1/feedback` | File bounded gateway-level feedback even after the referenced DCC exits. The receipt points to `resources://gateway/events`. |
@@ -274,6 +275,21 @@ use `list` for live inventory. The core still accepts unknown/custom DCC names,
 so `custom_types_supported` remains true even when a custom identifier has no
 catalog install plan. Alias normalization follows `DccName::parse`, including
 `3ds Max`, `3ds-max`, and `3dsmax` mapping to `3dsmax`.
+
+The targeted form, `dcc-types --dcc-type <dcc>`, follows
+[`dcc-discovery-decision-v1.schema.json`](../../contracts/dcc-discovery-decision-v1.schema.json).
+It is read-only and does not start a gateway. `live_instances: 0` means only
+that no matching live row was found in the local FileRegistry;
+`live_instances: null` means that observation was unavailable or the requested
+identifier was invalid. Neither state proves that a public adapter, package
+installation, project-local plugin, or custom fork is absent. Unobserved gates
+stay `unknown`, and fixture evidence is never real-host proof. When the bundled catalog has an installable adapter, the
+safe next action is the plan-only `install --dcc-type <dcc>` command together
+with the adapter-owned installation URL. A custom catalog is never reported as
+the released public catalog, and the decision does not copy its private URL or
+path into a plan action. Run a separate explicit `install --catalog <path>`
+plan when that local source is intended. Search and calls remain separate: call
+only a slug or exact identity returned by live capability discovery.
 
 For post-task review, route every task call with
 `--require-gateway --agent-session-id task-42`, then query

--- a/tests/fixtures/discovery-decision/game-engines.json
+++ b/tests/fixtures/discovery-decision/game-engines.json
@@ -1,0 +1,48 @@
+{
+  "cases": [
+    {
+      "id": "unreal-5.6",
+      "dcc_type": "unreal",
+      "context": {
+        "reported_version": "5.6.1",
+        "project_local": true,
+        "selected_bootstrap_path": "engine_bundled_python",
+        "legacy_remote_execution_required": false,
+        "optional_native_bridge_required": false,
+        "evidence_scope": "catalog_and_adapter_contract_only"
+      },
+      "expected_instructions_url": "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unreal/main/README.md"
+    },
+    {
+      "id": "unity-standard",
+      "dcc_type": "unity",
+      "context": {
+        "reported_version": "2022.3.62f1",
+        "project_local": true,
+        "evidence_scope": "catalog_and_adapter_contract_only"
+      },
+      "expected_instructions_url": "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unity/main/install.md"
+    },
+    {
+      "id": "unity-tuanjie",
+      "dcc_type": "unity",
+      "context": {
+        "reported_version": "2022.3.48t1",
+        "project_local": true,
+        "evidence_scope": "catalog_and_adapter_contract_only"
+      },
+      "expected_instructions_url": "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-unity/main/install.md"
+    },
+    {
+      "id": "godot-project",
+      "dcc_type": "godot",
+      "context": {
+        "reported_version": "4.4",
+        "project_local_addon_present": true,
+        "machine_wide_host_detected": false,
+        "evidence_scope": "catalog_and_adapter_contract_only"
+      },
+      "expected_instructions_url": "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-godot/main/README.md"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a versioned discovery decision contract and targeted `dcc-types` query
- keep catalog, registration, readiness, capability, and real-host evidence independent
- represent unavailable registry observation as `live_instances: null`, never as a confirmed zero
- bind default filtered and unfiltered catalog queries to the bundled release catalog
- add game-engine production-path, schema, privacy, failure, and cwd-catalog regressions
- document the read-only zero-instance workflow

## Validation
- `vx cargo test -p dcc-mcp-cli`
- `vx cargo clippy -p dcc-mcp-cli --all-targets -- -D warnings`
- `vx cargo fmt --all -- --check`
- `python scripts/ci/check_rust_test_file_lines.py --exempt-file scripts/ci/rust-test-file-exemptions.txt`
- `vx npm --prefix docs run docs:build`
- `vx npx markdownlint-cli2 "docs/**/*.md" "README.md" "README_zh.md" "!docs/node_modules"`

## Coordination
Refs #2383.

Public `dcc-mcp` guidance is owned by `dcc-mcp-agent-plugins`; companion PR dcc-mcp/dcc-mcp-agent-plugins#12 carries the workflow and tests. The creator Skills do not need changes because this does not alter adapter or Skill authoring contracts.