### PR TITLE
fix: preserve trusted UI scope with process names

### DIFF
--- a/AI_AGENT_GUIDE.md
+++ b/AI_AGENT_GUIDE.md
@@ -118,6 +118,9 @@ signals:
    `DCC_MCP_UI_CONTROL_PROCESS_ID` or `DCC_MCP_UI_CONTROL_WINDOW_HANDLE`.
    A request may select that exact PID/HWND or narrow it further, but cannot
    replace the trusted runtime scope with another application.
+   A redundant `process_name` may accompany the trusted binding as metadata or
+   an additional constraint, but a process name or title alone never grants
+   native control and a conflicting trusted name fails closed.
    Raw pointer and keyboard input are enabled by default only inside that exact
    bound scope. Operators can disable them with
    `DCC_MCP_CUA_ALLOW_RAW_INPUT=false`.

--- a/docs/guide/adapter-runtime-contracts.md
+++ b/docs/guide/adapter-runtime-contracts.md
@@ -160,3 +160,9 @@ title constraint is forwarded to the Host to resolve one window inside a
 multi-window process before an exact capability is minted. The Host owns
 platform accessibility, capture, visible control markers, input serialization,
 and Escape interruption.
+
+A request may also repeat `process_name` beside the trusted PID/HWND as
+metadata or an additional constraint. That redundant field preserves the
+trusted native scope when it is consistent with
+`DCC_MCP_UI_CONTROL_PROCESS_NAME`; a conflict fails with `invalid_target`.
+Process names and titles alone never establish the native capability boundary.

--- a/python/dcc_mcp_core/skills/ui-control/SKILL.md
+++ b/python/dcc_mcp_core/skills/ui-control/SKILL.md
@@ -71,6 +71,11 @@ that narrows the trusted PID to one window. The Host resolves that title once,
 then returns and enforces an exact window capability; use an explicit handle if
 the title still matches more than one window.
 
+A redundant `process_name` may accompany a trusted PID or HWND as metadata or
+an additional constraint. It never replaces the exact native binding: a
+process name or title by itself cannot mint a capability, and a process name
+that conflicts with an operator-trusted name fails with `invalid_target`.
+
 Multiple agents may control different applications concurrently. Each logical
 session has its own grant, window capability, observation fences, and bridge.
 The shared Host isolates session state, serializes raw input, and broadcasts

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_backend.py
@@ -175,11 +175,6 @@ def _scope_error(scope: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             ),
             UiErrorCode.PERMISSION_DENIED,
         )
-    if scope.get("process_names"):
-        return skill_error(
-            "Process-name and title-only scopes cannot mint native UI Control capabilities.",
-            UiErrorCode.INVALID_TARGET,
-        )
     return None
 
 

--- a/python/dcc_mcp_core/skills/ui-control/scripts/_cua_support.py
+++ b/python/dcc_mcp_core/skills/ui-control/scripts/_cua_support.py
@@ -236,7 +236,6 @@ def _scope_is_trusted_native_target(scope: Dict[str, Any]) -> bool:
     return bool(
         not scope.get("invalid_reason")
         and scope.get("native_scope_trusted")
-        and not scope.get("process_names")
         and (len(scope.get("process_ids") or []) == 1 or len(scope.get("window_handles") or []) == 1)
     )
 

--- a/tests/test_ui_control_skill.py
+++ b/tests/test_ui_control_skill.py
@@ -1048,6 +1048,82 @@ def test_ui_control_cua_host_uses_adapter_scope_and_title_to_select_one_window(m
     assert _FakeHostClient.instances[0].kwargs["window_title"] == "Substance Designer - Graph"
 
 
+def test_ui_control_cua_host_accepts_redundant_process_name_with_trusted_adapter_scope(monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _FakeHostClient.instances.clear()
+    monkeypatch.setattr(backend, "_HostClient", _FakeHostClient)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_DCC_TYPE", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_NAME", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_HANDLE", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_TITLE", raising=False)
+
+    result = backend.snapshot_tool(
+        {
+            "session_id": "obs-studio",
+            "process_name": "obs64.exe",
+            "trusted_adapter_scope": {
+                "dcc_type": "obs",
+                "process_id": None,
+                "window_handle": 9001,
+                "window_title": "OBS Studio",
+            },
+        }
+    )
+
+    assert result["success"] is True
+    scope = result["context"]["snapshot"]["metadata"]["ui_control"]["scope"]
+    assert scope["native_scope_trusted"] is True
+    assert scope.get("process_ids", []) == []
+    assert scope["window_handles"] == [9001]
+    assert scope["process_names"] == ["obs64.exe"]
+    assert _FakeHostClient.instances[0].kwargs["dcc_type"] == "obs"
+    assert _FakeHostClient.instances[0].kwargs["process_id"] is None
+    assert _FakeHostClient.instances[0].kwargs["window_handle"] == 9001
+
+
+def test_ui_control_cua_host_rejects_process_name_conflicting_with_trusted_identity(monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _FakeHostClient.instances.clear()
+    monkeypatch.setattr(backend, "_HostClient", _FakeHostClient)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
+    monkeypatch.setenv("DCC_MCP_UI_CONTROL_PROCESS_NAME", "renderhost.exe")
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_HANDLE", raising=False)
+
+    result = backend.snapshot_tool(
+        {
+            "session_id": "custom-renderer",
+            "process_name": "otherhost.exe",
+            "trusted_adapter_scope": {
+                "dcc_type": "custom-renderer",
+                "process_id": 8100,
+                "window_handle": 9100,
+                "window_title": "Custom Renderer",
+            },
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "invalid_target"
+    assert "process name is outside the runtime DCC scope" in result["message"]
+    assert not _FakeHostClient.instances
+
+
+def test_ui_control_cua_host_process_name_alone_does_not_mint_native_scope(monkeypatch: Any) -> None:
+    backend = _load_cua_module()
+    _FakeHostClient.instances.clear()
+    monkeypatch.setattr(backend, "_HostClient", _FakeHostClient)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_ID", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_PROCESS_NAME", raising=False)
+    monkeypatch.delenv("DCC_MCP_UI_CONTROL_WINDOW_HANDLE", raising=False)
+
+    result = backend.snapshot_tool({"session_id": "name-only", "process_name": "obs64.exe"})
+
+    assert result["success"] is False
+    assert result["error"] == "permission_denied"
+    assert not _FakeHostClient.instances
+
+
 def test_ui_control_cua_host_controls_trajectory_recording(tmp_path: Path, monkeypatch: Any) -> None:
     backend = _load_cua_module()
     _configure_fake_host(backend, monkeypatch)


### PR DESCRIPTION
## Summary
- preserve trusted native scope when a redundant process name accompanies an operator- or adapter-bound PID/HWND
- keep conflicting trusted names fail-closed and prevent name/title-only capability minting
- add host-neutral regression coverage and update UI-control guidance

## Validation
- `vx just lint`
- `vx just preflight` (3831 workspace tests and 54 SQLite job tests passed)
- focused Python scope/Host tests: 123 passed
- full local Python suite: 10935 passed, 140 skipped, 3 xfailed; 6 environment-dependent failures outside this diff (desktop capture unavailable, installed CLI catalog drift, Rez fixture, sidecar PID timing)
- independent review: APPROVED; P0/P1/P2 = 0/0/0
- creator guidance: no repository package is present and the adapter injection contract is unchanged; bundled UI-control and runtime guidance were updated

Closes #2421