### PR TITLE
fix: share MCP protocol version with CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "dcc-mcp-catalog",
  "dcc-mcp-gateway-ensure",
  "dcc-mcp-http",
+ "dcc-mcp-jsonrpc",
  "dcc-mcp-marketplace",
  "dcc-mcp-models",
  "dcc-mcp-sidecar",

--- a/crates/dcc-mcp-cli/Cargo.toml
+++ b/crates/dcc-mcp-cli/Cargo.toml
@@ -18,6 +18,7 @@ base64.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 dcc-mcp-catalog.workspace = true
 dcc-mcp-gateway-ensure.workspace = true
+dcc-mcp-jsonrpc = { path = "../dcc-mcp-jsonrpc" }
 dcc-mcp-sidecar = { path = "../dcc-mcp-sidecar", default-features = false, features = ["gateway-daemon", "admin"] }
 dcc-mcp-transport.workspace = true
 dcc-mcp-updater.workspace = true

--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -1,3 +1,4 @@
+use dcc_mcp_jsonrpc::MCP_PROTOCOL_VERSION;
 use serde_json::{Value, json};
 use thiserror::Error;
 use tokio::time::{Instant, sleep};
@@ -10,7 +11,6 @@ use crate::domain::rest::{
 use crate::infra::http::{HttpError, HttpGateway};
 
 const MCP_STREAMABLE_HTTP_ACCEPT: &str = "application/json, text/event-stream";
-const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 
 #[derive(Debug, Error)]
 pub enum ClientError {

--- a/crates/dcc-mcp-cli/src/application/local_control.rs
+++ b/crates/dcc-mcp-cli/src/application/local_control.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
+use dcc_mcp_jsonrpc::MCP_PROTOCOL_VERSION;
 use dcc_mcp_transport::discovery::types::ServiceEntry;
 use serde_json::{Map, Value, json};
 
@@ -17,7 +18,6 @@ use crate::domain::rest::{
 };
 use crate::infra::http::HttpGateway;
 
-const MCP_PROTOCOL_VERSION: &str = "2025-03-26";
 const MCP_ACCEPT: &str = "application/json, text/event-stream";
 const DEFAULT_REQUIRED_READINESS_FIELDS: &[&str] =
     &["process", "dcc", "skill_catalog", "dispatcher"];


### PR DESCRIPTION
## Summary\n- reuse dcc-mcp-jsonrpc::MCP_PROTOCOL_VERSION in gateway and local CLI control paths\n- remove duplicate 2025-03-26 literals so CLI follows core negotiation updates\n\n## Validation\n- cargo fmt --all -- --check\n- cargo test -p dcc-mcp-cli --bin dcc-mcp-cli\n- cargo test -p dcc-mcp-cli --test cli_e2e (25 passed)