### PR TITLE
feat: add optional MCP 2026 stateless transport

### DIFF
--- a/crates/dcc-mcp-http-server/Cargo.toml
+++ b/crates/dcc-mcp-http-server/Cargo.toml
@@ -57,3 +57,8 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"
 [features]
 default = []
 prometheus = ["dep:dcc-mcp-telemetry", "dcc-mcp-telemetry/prometheus"]
+## Enable MCP 2026-07-28 stateless protocol support (ADR-010 Phase 1).
+## Adds `stateless::StatelessMcpService` and propagates the flag to
+## `dcc-mcp-jsonrpc` so `2026-07-28` appears in `SUPPORTED_PROTOCOL_VERSIONS`.
+## Off by default; will become default at Phase 2 (0.21.0).
+mcp-2026-07-28 = ["dcc-mcp-jsonrpc/mcp-2026-07-28"]

--- a/crates/dcc-mcp-http-server/src/lib.rs
+++ b/crates/dcc-mcp-http-server/src/lib.rs
@@ -43,6 +43,12 @@ pub mod rmcp_tool_call_async;
 pub mod rmcp_tool_call_dispatch;
 pub mod thread_routed_invoker;
 
+/// Stateless MCP service path for protocol version 2026-07-28 (ADR-010 Phase 1).
+///
+/// Enabled by the `mcp-2026-07-28` Cargo feature flag.
+#[cfg(feature = "mcp-2026-07-28")]
+pub mod stateless;
+
 pub use dynamic_tools::{
     DYNAMIC_TOOL_PREFIX, DynamicToolEntry, DynamicToolError, SessionDynamicTools, ToolSpec,
     build_deregister_tool_descriptor, build_list_dynamic_tools_descriptor,

--- a/crates/dcc-mcp-http-server/src/stateless/meta.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/meta.rs
@@ -1,0 +1,97 @@
+//! Parse per-request client metadata from the `_meta` field (MCP 2026-07-28).
+//!
+//! In the 2026-07-28 stateless protocol each request is self-contained.
+//! Client identity, protocol version, and capabilities that were previously
+//! exchanged during `initialize` are now conveyed in `_meta` on every
+//! request.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Client information extracted from `_meta` on a 2026-07-28 request.
+#[derive(Debug, Clone, Default)]
+pub struct RequestMeta {
+    /// Protocol version declared by the client (`_meta.protocolVersion`).
+    pub protocol_version: Option<String>,
+    /// Human-readable client name (`_meta.clientInfo.name`).
+    pub client_name: Option<String>,
+    /// Client version string (`_meta.clientInfo.version`).
+    pub client_version: Option<String>,
+    /// Progress token for long-running tool calls (`_meta.progressToken`).
+    pub progress_token: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawMeta {
+    #[serde(default)]
+    protocol_version: Option<String>,
+    #[serde(default)]
+    client_info: Option<RawClientInfo>,
+    #[serde(default)]
+    progress_token: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawClientInfo {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+impl RequestMeta {
+    /// Extract [`RequestMeta`] from a JSON-RPC `params._meta` value.
+    ///
+    /// Returns a zeroed struct if `meta` is `None` or cannot be decoded —
+    /// stateless requests are valid even without a populated `_meta`.
+    pub fn from_value(meta: Option<&Value>) -> Self {
+        let Some(meta) = meta else {
+            return Self::default();
+        };
+        let Ok(raw) = serde_json::from_value::<RawMeta>(meta.clone()) else {
+            return Self::default();
+        };
+        Self {
+            protocol_version: raw.protocol_version,
+            client_name: raw.client_info.as_ref().and_then(|c| c.name.clone()),
+            client_version: raw.client_info.as_ref().and_then(|c| c.version.clone()),
+            progress_token: raw.progress_token,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_full_meta() {
+        let meta = json!({
+            "protocolVersion": "2026-07-28",
+            "clientInfo": {"name": "TestClient", "version": "1.2.3"},
+            "progressToken": "tok-1"
+        });
+        let m = RequestMeta::from_value(Some(&meta));
+        assert_eq!(m.protocol_version.as_deref(), Some("2026-07-28"));
+        assert_eq!(m.client_name.as_deref(), Some("TestClient"));
+        assert_eq!(m.client_version.as_deref(), Some("1.2.3"));
+        assert_eq!(m.progress_token, Some(json!("tok-1")));
+    }
+
+    #[test]
+    fn handles_missing_meta() {
+        let m = RequestMeta::from_value(None);
+        assert!(m.protocol_version.is_none());
+        assert!(m.client_name.is_none());
+    }
+
+    #[test]
+    fn handles_partial_meta() {
+        let meta = json!({"protocolVersion": "2026-07-28"});
+        let m = RequestMeta::from_value(Some(&meta));
+        assert_eq!(m.protocol_version.as_deref(), Some("2026-07-28"));
+        assert!(m.client_name.is_none());
+    }
+}

--- a/crates/dcc-mcp-http-server/src/stateless/mod.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/mod.rs
@@ -1,0 +1,32 @@
+//! Stateless MCP service path for protocol version 2026-07-28 (ADR-010 Phase 1).
+//!
+//! This module is compiled only when the `mcp-2026-07-28` feature flag is
+//! enabled.  It provides a request-handling layer that:
+//!
+//! - Does **not** create sessions or read `Mcp-Session-Id`.
+//! - Handles `server/discover` in place of `initialize`.
+//! - Routes tool calls to the existing [`crate::rmcp_tool_call_dispatch`]
+//!   pipeline with `session_id = None` (Tool Registry / Dispatcher / Catalog
+//!   are not modified).
+//! - Reads `_meta` on every request for per-request client context.
+//!
+//! ## Usage
+//!
+//! The caller (typically an axum handler or integration test) detects the
+//! `MCP-Protocol-Version: 2026-07-28` request header, constructs a
+//! [`StatelessMcpService`] with the shared [`ServerState`] and
+//! [`RegistryContext`], and calls [`StatelessMcpService::handle_request`].
+//!
+//! ```rust,ignore
+//! # use std::sync::Arc;
+//! # use dcc_mcp_http_server::stateless::StatelessMcpService;
+//! # use dcc_mcp_http_server::server_state::ServerState;
+//! # use dcc_mcp_http_server::rmcp_registry_context::RegistryContext;
+//! let service = StatelessMcpService::new(state, registry_context);
+//! let response = service.handle_request(&jsonrpc_req).await;
+//! ```
+
+mod meta;
+mod service;
+
+pub use service::StatelessMcpService;

--- a/crates/dcc-mcp-http-server/src/stateless/service.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/service.rs
@@ -1,0 +1,362 @@
+//! Stateless MCP service for protocol version 2026-07-28 (ADR-010 Phase 1).
+//!
+//! [`StatelessMcpService`] handles JSON-RPC requests for the 2026-07-28
+//! stateless protocol path:
+//!
+//! - No session is created or read.
+//! - `Mcp-Session-Id` header is completely ignored.
+//! - Every request is self-contained; client identity lives in `_meta`.
+//! - `server/discover` replaces `initialize`.
+//! - Tool calls route to the existing [`dispatch_rmcp_tool_call`] — the
+//!   Tool Registry, Dispatcher, and Catalog are **not** modified.
+//!
+//! # Feature gate
+//!
+//! This module is compiled only when the `mcp-2026-07-28` feature is enabled.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tracing::debug;
+
+use dcc_mcp_jsonrpc::{
+    DiscoverResult, JsonRpcRequest, JsonRpcResponse, MCP_PROTOCOL_VERSION_2026_07_28,
+    PromptsCapability, ResourcesCapability, ServerInfo, StatelessServerCapabilities,
+    TasksCapability, ToolsCapability, error_codes,
+};
+
+use crate::mcp_tool_list_builder::{assemble_full_tool_list, slice_tools_page};
+use crate::rmcp_registry_context::RegistryContext;
+use crate::rmcp_tool_call_dispatch::dispatch_rmcp_tool_call;
+use crate::server_state::ServerState;
+
+use super::meta::RequestMeta;
+
+/// Stateless MCP service (2026-07-28 protocol path).
+///
+/// Clone-cheap: all heavy state is behind `Arc`.
+#[derive(Clone)]
+pub struct StatelessMcpService {
+    state: ServerState,
+    registry_context: Arc<RegistryContext>,
+}
+
+impl StatelessMcpService {
+    /// Create a new service backed by the given server state.
+    #[must_use]
+    pub fn new(state: ServerState, registry_context: Arc<RegistryContext>) -> Self {
+        Self {
+            state,
+            registry_context,
+        }
+    }
+
+    /// Handle one JSON-RPC request and return a response value.
+    ///
+    /// Notifications (requests with no `id`) should be handled by the caller
+    /// and not forwarded here; they return `null`.
+    pub async fn handle_request(&self, req: &JsonRpcRequest) -> Option<Value> {
+        let id = req.id.clone()?;
+        let meta = req.params.as_ref().and_then(|p| p.get("_meta")).cloned();
+        let _request_meta = RequestMeta::from_value(meta.as_ref());
+
+        let response = match req.method.as_str() {
+            "server/discover" => self.handle_discover(id),
+            "ping" => json!({"jsonrpc": "2.0", "id": id, "result": {}}),
+            "tools/list" => self.handle_tools_list(id, req).await,
+            "tools/call" => self.handle_tools_call(id, req).await,
+            "resources/list" => self.handle_resources_list(id).await,
+            "prompts/list" => self.handle_prompts_list(id).await,
+            other => {
+                debug!(method = other, "stateless: method not found");
+                let error = JsonRpcResponse::method_not_found(Some(id), other);
+                serde_json::to_value(error).unwrap_or_else(|_| json!(null))
+            }
+        };
+        Some(response)
+    }
+
+    /// `server/discover` — returns server capabilities without creating a session.
+    ///
+    /// Equivalent to `initialize` in the 2026-07-28 stateless model (SEP-2575).
+    fn handle_discover(&self, id: Value) -> Value {
+        let caps = self.build_stateless_capabilities();
+        let result = DiscoverResult {
+            protocol_version: MCP_PROTOCOL_VERSION_2026_07_28.to_string(),
+            server_info: ServerInfo {
+                name: self.state.server_name.clone(),
+                version: self.state.server_version.clone(),
+            },
+            capabilities: caps,
+            instructions: Some(
+                "Direct DCC workflow: search_tools(query) → load_skill → tools/call. \
+                 tools/list is paginated; follow nextCursor if you list it."
+                    .to_string(),
+            ),
+        };
+        let result_value =
+            serde_json::to_value(result).unwrap_or_else(|_| json!({"error": "serialize_failed"}));
+        json!({"jsonrpc": "2.0", "id": id, "result": result_value})
+    }
+
+    fn build_stateless_capabilities(&self) -> StatelessServerCapabilities {
+        StatelessServerCapabilities {
+            tools: Some(ToolsCapability { list_changed: true }),
+            resources: if self.state.features.enable_resources {
+                Some(ResourcesCapability {
+                    subscribe: true,
+                    list_changed: true,
+                })
+            } else {
+                None
+            },
+            prompts: if self.state.features.enable_prompts {
+                Some(PromptsCapability { list_changed: true })
+            } else {
+                None
+            },
+            // Tasks are a first-class capability in 2026-07-28.
+            tasks: Some(TasksCapability {}),
+            experimental: None,
+        }
+    }
+
+    /// `tools/list` — returns the paginated tool list.
+    ///
+    /// No session context: session_id is always `None` in stateless mode.
+    async fn handle_tools_list(&self, id: Value, req: &JsonRpcRequest) -> Value {
+        let full = assemble_full_tool_list(&self.state, true, None);
+        let cursor = req
+            .params
+            .as_ref()
+            .and_then(|p| p.get("cursor"))
+            .and_then(Value::as_str);
+        let (page, next_cursor) = slice_tools_page(full, cursor);
+        let tools: Vec<Value> = page
+            .iter()
+            .map(|t| serde_json::to_value(t).unwrap_or(Value::Null))
+            .collect();
+        let mut result = json!({"tools": tools});
+        if let Some(c) = next_cursor {
+            result["nextCursor"] = Value::String(c);
+        }
+        debug!(count = tools.len(), "stateless: tools/list");
+        json!({"jsonrpc": "2.0", "id": id, "result": result})
+    }
+
+    /// `tools/call` — routes to the existing dispatch pipeline (zero registry changes).
+    async fn handle_tools_call(&self, id: Value, req: &JsonRpcRequest) -> Value {
+        let params = match req.params.as_ref() {
+            Some(p) => p,
+            None => {
+                return json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": error_codes::INVALID_PARAMS, "message": "Missing params"}
+                });
+            }
+        };
+
+        let tool_name = match params.get("name").and_then(Value::as_str) {
+            Some(n) if !n.is_empty() => n.to_string(),
+            _ => {
+                return json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": error_codes::INVALID_PARAMS, "message": "Missing tool name"}
+                });
+            }
+        };
+
+        let arguments = params.get("arguments").cloned();
+
+        // Extract _meta for async dispatch / progress routing.
+        let call_meta: Option<dcc_mcp_jsonrpc::CallToolMeta> = params
+            .get("_meta")
+            .and_then(|m| serde_json::from_value(m.clone()).ok());
+
+        debug!(tool = %tool_name, "stateless: tools/call");
+
+        // Stateless path: no session_id.
+        let dispatch_result = dispatch_rmcp_tool_call(
+            &self.state,
+            &self.registry_context,
+            None,
+            &tool_name,
+            arguments,
+            call_meta.as_ref(),
+        )
+        .await;
+
+        match dispatch_result {
+            Ok(result) => {
+                let result_value = serde_json::to_value(&result)
+                    .unwrap_or_else(|_| json!({"isError": true, "content": []}));
+                json!({"jsonrpc": "2.0", "id": id, "result": result_value})
+            }
+            Err(msg) => {
+                json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "error": {"code": error_codes::INVALID_PARAMS, "message": msg}
+                })
+            }
+        }
+    }
+
+    /// `resources/list` — returns an empty list when resources are disabled.
+    async fn handle_resources_list(&self, id: Value) -> Value {
+        if !self.state.features.enable_resources {
+            return json!({
+                "jsonrpc": "2.0", "id": id,
+                "error": {
+                    "code": error_codes::METHOD_NOT_FOUND,
+                    "message": "Resources not enabled"
+                }
+            });
+        }
+        // Stateless path: no resource provider wiring yet (Phase 1).
+        json!({"jsonrpc": "2.0", "id": id, "result": {"resources": []}})
+    }
+
+    /// `prompts/list` — returns an empty list when prompts are disabled.
+    async fn handle_prompts_list(&self, id: Value) -> Value {
+        if !self.state.features.enable_prompts {
+            return json!({
+                "jsonrpc": "2.0", "id": id,
+                "result": {"prompts": []}
+            });
+        }
+        json!({"jsonrpc": "2.0", "id": id, "result": {"prompts": []}})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
+    use dcc_mcp_skill_rest::StaticReadiness;
+    use dcc_mcp_skills::SkillCatalog;
+    use serde_json::json;
+
+    fn make_service() -> StatelessMcpService {
+        let registry = Arc::new(ToolRegistry::new());
+        let dispatcher = Arc::new(ToolDispatcher::new((*registry).clone()));
+        let catalog = Arc::new(SkillCatalog::new_with_dispatcher(
+            Arc::clone(&registry),
+            Arc::clone(&dispatcher),
+        ));
+        let state = ServerState::builder(registry, dispatcher, catalog).build();
+        let registry_context = Arc::new(RegistryContext {
+            resource_provider: None,
+            prompt_provider: None,
+            readiness: Arc::new(StaticReadiness::fully_ready()),
+            on_skill_catalog_mutated: Arc::new(|| {}),
+        });
+        StatelessMcpService::new(state, registry_context)
+    }
+
+    fn make_request(method: &str, id: Value, params: Option<Value>) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(id),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[tokio::test]
+    async fn server_discover_returns_capabilities() {
+        let svc = make_service();
+        let req = make_request("server/discover", json!(1), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 1);
+        let result = &resp["result"];
+        assert_eq!(result["protocolVersion"], MCP_PROTOCOL_VERSION_2026_07_28);
+        assert_eq!(result["serverInfo"]["name"], "dcc-mcp-http");
+        assert!(result["capabilities"]["tools"].is_object());
+        assert!(result["capabilities"]["tasks"].is_object());
+        assert!(result["instructions"].is_string());
+    }
+
+    #[tokio::test]
+    async fn server_discover_has_no_session_artifacts() {
+        let svc = make_service();
+        let req = make_request("server/discover", json!("disc"), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        // Must not include session-scoped fields.
+        let result = &resp["result"];
+        assert!(result.get("sessionId").is_none());
+        assert!(result["capabilities"].get("elicitation").is_none());
+        assert!(result["capabilities"].get("logging").is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_list_returns_paginated_result() {
+        let svc = make_service();
+        let req = make_request("tools/list", json!(2), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        let tools = resp["result"]["tools"].as_array().expect("tools array");
+        // Core tools are always present (search_tools, load_skill, etc.)
+        assert!(!tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_method_returns_method_not_found() {
+        let svc = make_service();
+        let req = make_request("initialize", json!(3), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        assert_eq!(resp["error"]["code"], error_codes::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn ping_returns_empty_result() {
+        let svc = make_service();
+        let req = make_request("ping", json!(4), None);
+        let resp = svc.handle_request(&req).await.expect("has id");
+
+        assert_eq!(resp["result"], json!({}));
+    }
+
+    #[tokio::test]
+    async fn notification_returns_none() {
+        let svc = make_service();
+        // Notifications have no id.
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            method: "notifications/initialized".to_string(),
+            params: None,
+        };
+        let resp = svc.handle_request(&req).await;
+        assert!(resp.is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_call_missing_name_returns_invalid_params() {
+        let svc = make_service();
+        let req = make_request("tools/call", json!(5), Some(json!({"arguments": {}})));
+        let resp = svc.handle_request(&req).await.expect("has id");
+        assert_eq!(resp["error"]["code"], error_codes::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn tools_call_unknown_tool_returns_error_result() {
+        let svc = make_service();
+        let req = make_request(
+            "tools/call",
+            json!(6),
+            Some(json!({"name": "non_existent_tool_xyz", "arguments": {}})),
+        );
+        let resp = svc.handle_request(&req).await.expect("has id");
+        // dispatch_rmcp_tool_call returns Ok(CallToolResult { is_error: true })
+        // for unknown tools rather than Err.
+        let result = &resp["result"];
+        assert_eq!(result["isError"], true);
+    }
+}

--- a/crates/dcc-mcp-jsonrpc/Cargo.toml
+++ b/crates/dcc-mcp-jsonrpc/Cargo.toml
@@ -14,3 +14,10 @@ dcc-mcp-protocols = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+[features]
+default = []
+## Enable MCP 2026-07-28 stateless protocol support (ADR-010 Phase 1).
+## When enabled, `2026-07-28` is added to `SUPPORTED_PROTOCOL_VERSIONS`.
+## Off by default; will become default at Phase 2 (0.21.0).
+mcp-2026-07-28 = []

--- a/crates/dcc-mcp-jsonrpc/src/discover.rs
+++ b/crates/dcc-mcp-jsonrpc/src/discover.rs
@@ -1,0 +1,284 @@
+//! `server/discover` response types for MCP 2026-07-28.
+//!
+//! `server/discover` replaces the `initialize` / `initialized` handshake that
+//! was defined in the 2025-x specs. It is stateless: the server returns its
+//! capabilities and no session is created.
+//!
+//! Reference: ADR-010 / SEP-2575.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Result payload for `server/discover` (MCP 2026-07-28).
+///
+/// Returned verbatim as the `result` field of a JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerDiscoverResult {
+    /// Protocol version the server will use for this request.
+    pub protocol_version: String,
+    pub server_info: DiscoverServerInfo,
+    pub capabilities: DiscoverCapabilities,
+    /// Optional natural-language instructions for MCP clients / agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+/// Abbreviated `serverInfo` block (name + version), same shape as the 2025 spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoverServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+/// 2026-07-28 capabilities block.
+///
+/// The structure is intentionally a superset of the 2025-06-18 `ServerCapabilities`
+/// so that new fields can be added without breaking old deserializers. Fields that
+/// existed in older specs (`tools`, `resources`, `prompts`, `logging`) keep the
+/// same JSON key names; new fields (`tasks`, `tracing`, `caching`) are additions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DiscoverCapabilities {
+    /// Tools capability (unchanged from 2025 spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Discover2026ToolsCapability>,
+    /// Resources capability (unchanged from 2025 spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<Discover2026ResourcesCapability>,
+    /// Prompts capability (unchanged from 2025 spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompts: Option<Discover2026PromptsCapability>,
+    /// Tasks — first-class in 2026-07-28 (SEP-2663).
+    ///
+    /// Present when the server supports `tasks/get` and `tasks/cancel`.
+    /// `tasks/list` was removed from the spec; do **not** advertise it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<TasksCapability>,
+    /// Vendor-extension capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<Value>,
+}
+
+/// `tools` capability for 2026-07-28 sessions (same shape as 2025 `ToolsCapability`).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Discover2026ToolsCapability {
+    pub list_changed: bool,
+}
+
+/// `resources` capability for 2026-07-28 sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Discover2026ResourcesCapability {
+    pub subscribe: bool,
+    pub list_changed: bool,
+}
+
+/// `prompts` capability for 2026-07-28 sessions.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Discover2026PromptsCapability {
+    pub list_changed: bool,
+}
+
+/// `tasks` capability — new in MCP 2026-07-28, SEP-2663.
+///
+/// An empty struct signals that `tasks/get` and `tasks/cancel` are supported.
+/// There are no sub-fields in the initial spec.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TasksCapability {}
+
+/// Per-request `_meta` block for MCP 2026-07-28 stateless requests.
+///
+/// In 2026-07-28, every request is self-contained: session context (client
+/// info, capabilities, protocol version) is carried in `params._meta` rather
+/// than being established once during `initialize`. All fields are optional so
+/// that older clients that do not send them continue to parse successfully.
+///
+/// SEP-2575.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StatelessRequestMeta {
+    /// Declared protocol version of the client for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<String>,
+    /// Free-form client identification (name + version).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_info: Option<StatelessClientInfo>,
+    /// Client capabilities for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_capabilities: Option<Value>,
+    /// Progress token for streaming / `InputRequiredResult` callbacks (SEP-2260).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_token: Option<Value>,
+    /// W3C Trace Context `traceparent` header value (SEP-414).
+    ///
+    /// When present the server SHOULD propagate it to downstream calls and
+    /// include it in diagnostic logs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub traceparent: Option<String>,
+    /// W3C Trace Context `tracestate` header value (SEP-414).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tracestate: Option<String>,
+}
+
+/// Minimal client identification carried in `_meta.clientInfo` (2026-07-28).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatelessClientInfo {
+    pub name: String,
+    pub version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    // ── ServerDiscoverResult round-trip ─────────────────────────────────────
+
+    #[test]
+    fn server_discover_result_serialises_to_camel_case() {
+        let result = ServerDiscoverResult {
+            protocol_version: "2026-07-28".to_string(),
+            server_info: DiscoverServerInfo {
+                name: "dcc-mcp-core".to_string(),
+                version: "0.19.0".to_string(),
+            },
+            capabilities: DiscoverCapabilities {
+                tools: Some(Discover2026ToolsCapability { list_changed: true }),
+                resources: Some(Discover2026ResourcesCapability {
+                    subscribe: true,
+                    list_changed: true,
+                }),
+                prompts: Some(Discover2026PromptsCapability { list_changed: true }),
+                tasks: Some(TasksCapability {}),
+                experimental: None,
+            },
+            instructions: Some("Direct DCC workflow".to_string()),
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+
+        // Top-level keys must be camelCase.
+        assert!(
+            json.get("protocolVersion").is_some(),
+            "expected protocolVersion, got: {json}"
+        );
+        assert_eq!(json["protocolVersion"], "2026-07-28");
+        assert!(json.get("serverInfo").is_some(), "expected serverInfo");
+        assert!(json.get("capabilities").is_some(), "expected capabilities");
+        assert!(json.get("instructions").is_some(), "expected instructions");
+
+        // Capabilities sub-keys.
+        let caps = &json["capabilities"];
+        assert!(caps.get("tools").is_some());
+        assert!(caps.get("tasks").is_some());
+        assert_eq!(caps["tools"]["listChanged"], true);
+    }
+
+    #[test]
+    fn server_discover_result_optional_fields_omitted_when_none() {
+        let result = ServerDiscoverResult {
+            protocol_version: "2026-07-28".to_string(),
+            server_info: DiscoverServerInfo {
+                name: "test".to_string(),
+                version: "0.0.1".to_string(),
+            },
+            capabilities: DiscoverCapabilities::default(),
+            instructions: None,
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+        // `instructions` must be absent (not null) when None.
+        assert!(
+            json.get("instructions").is_none(),
+            "instructions should be omitted, got: {json}"
+        );
+        // Empty capabilities should produce an empty object.
+        let caps = &json["capabilities"];
+        assert_eq!(*caps, json!({}), "empty caps must be {{}}");
+    }
+
+    #[test]
+    fn server_discover_result_roundtrip() {
+        let original = ServerDiscoverResult {
+            protocol_version: "2026-07-28".to_string(),
+            server_info: DiscoverServerInfo {
+                name: "dcc-mcp-core".to_string(),
+                version: "0.19.0".to_string(),
+            },
+            capabilities: DiscoverCapabilities {
+                tools: Some(Discover2026ToolsCapability { list_changed: true }),
+                resources: None,
+                prompts: None,
+                tasks: Some(TasksCapability {}),
+                experimental: Some(json!({"dcc-mcp": {"compactResponses": true}})),
+            },
+            instructions: None,
+        };
+        let json_str = serde_json::to_string(&original).unwrap();
+        let recovered: ServerDiscoverResult = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(recovered.protocol_version, original.protocol_version);
+        assert_eq!(recovered.server_info.name, original.server_info.name);
+        assert!(recovered.capabilities.tools.is_some());
+        assert!(recovered.capabilities.tasks.is_some());
+        assert!(recovered.capabilities.resources.is_none());
+    }
+
+    // ── StatelessRequestMeta round-trip ─────────────────────────────────────
+
+    #[test]
+    fn stateless_request_meta_all_optional_omitted_by_default() {
+        let meta = StatelessRequestMeta::default();
+        let json = serde_json::to_value(&meta).unwrap();
+        // All fields are None, so the serialised object must be empty.
+        assert_eq!(json, json!({}), "default meta must serialise to {{}}");
+    }
+
+    #[test]
+    fn stateless_request_meta_roundtrip_with_all_fields() {
+        let meta = StatelessRequestMeta {
+            protocol_version: Some("2026-07-28".to_string()),
+            client_info: Some(StatelessClientInfo {
+                name: "test-client".to_string(),
+                version: "1.0".to_string(),
+            }),
+            client_capabilities: Some(json!({"sampling": {}})),
+            progress_token: Some(Value::String("tok-abc".to_string())),
+            traceparent: Some("00-trace-id-span-00".to_string()),
+            tracestate: Some("vendor=abc".to_string()),
+        };
+
+        let json_str = serde_json::to_string(&meta).unwrap();
+        let recovered: StatelessRequestMeta = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(recovered.protocol_version.as_deref(), Some("2026-07-28"));
+        assert_eq!(
+            recovered.client_info.as_ref().map(|i| i.name.as_str()),
+            Some("test-client")
+        );
+        assert_eq!(
+            recovered.traceparent.as_deref(),
+            Some("00-trace-id-span-00")
+        );
+    }
+
+    #[test]
+    fn stateless_request_meta_serialises_client_info_as_camel_case() {
+        let meta = StatelessRequestMeta {
+            protocol_version: Some("2026-07-28".to_string()),
+            client_info: Some(StatelessClientInfo {
+                name: "MyCLI".to_string(),
+                version: "2.0".to_string(),
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&meta).unwrap();
+        // Top-level key must be camelCase.
+        assert!(
+            json.get("clientInfo").is_some(),
+            "expected clientInfo key, got: {json}"
+        );
+        assert_eq!(json["protocolVersion"], "2026-07-28");
+    }
+}

--- a/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
+++ b/crates/dcc-mcp-jsonrpc/src/jsonrpc.rs
@@ -85,6 +85,33 @@ pub mod error_codes {
     /// deadline (typically because the embedded runtime is starved by a busy DCC
     /// host). Clients should back off and retry with fewer concurrent sessions.
     pub const GATEWAY_BUSY: i64 = -32003;
+
+    // ── MCP 2026-07-28 specific error codes ────────────────────────────────
+
+    /// MCP 2026-07-28 — the client sent an `MCP-Protocol-Version` header
+    /// whose value is not in the server's supported versions list.
+    ///
+    /// The `data` payload MUST include a `supported_versions` array so the
+    /// client can retry with the correct version (ADR-010 §版本降级流程):
+    ///
+    /// ```json
+    /// {
+    ///   "code": -32004,
+    ///   "message": "Unsupported protocol version",
+    ///   "data": {
+    ///     "requested": "2026-07-28",
+    ///     "supported_versions": ["2026-07-28", "2025-06-18", "2025-03-26"]
+    ///   }
+    /// }
+    /// ```
+    pub const UNSUPPORTED_PROTOCOL_VERSION: i64 = -32004;
+
+    /// MCP 2026-07-28 — the server received a stateless request that omitted
+    /// a required `_meta` field (e.g. `protocolVersion`).
+    ///
+    /// Only emitted on the `2026-07-28` code path; legacy session requests
+    /// use `INVALID_PARAMS` instead.
+    pub const VERSION_REQUIRED: i64 = -32005;
 }
 
 impl JsonRpcResponse {
@@ -161,6 +188,27 @@ impl JsonRpcResponse {
 
     pub fn internal_error(id: Option<Value>, msg: impl Into<String>) -> Self {
         Self::error(id, error_codes::INTERNAL_ERROR, msg)
+    }
+
+    /// MCP 2026-07-28 — respond with `UNSUPPORTED_PROTOCOL_VERSION` (-32004).
+    ///
+    /// `requested` is the version the client asked for; `supported` is the
+    /// slice of versions the server accepts (passed through as `data`).
+    pub fn unsupported_protocol_version(
+        id: Option<Value>,
+        requested: &str,
+        supported: &[&str],
+    ) -> Self {
+        use serde_json::json;
+        Self::error_with_data(
+            id,
+            error_codes::UNSUPPORTED_PROTOCOL_VERSION,
+            "Unsupported protocol version",
+            Some(json!({
+                "requested": requested,
+                "supported_versions": supported,
+            })),
+        )
     }
 }
 

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -87,7 +87,11 @@ pub const MCP_PROTOCOL_VERSION_2026_07_28: &str = MCP_PROTOCOL_VERSION_2026;
 /// still `2025-06-18` in Phase 1.  The ordering here is used only for fallback
 /// when the client requests an *unknown* version — which remains `2025-06-18`
 /// until Phase 2.
+#[cfg(feature = "mcp-2026-07-28")]
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-06-18", "2025-03-26"];
+
+#[cfg(not(feature = "mcp-2026-07-28"))]
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
 /// Legacy (session-based) protocol versions (2025-x and earlier).
 ///
@@ -151,11 +155,19 @@ pub fn select_protocol_mode(
     mcp_protocol_version_header: Option<&str>,
     has_session_id: bool,
 ) -> ProtocolMode {
+    #[cfg(feature = "mcp-2026-07-28")]
     match mcp_protocol_version_header {
         Some(v) if v == MCP_PROTOCOL_VERSION_2026 => ProtocolMode::Stateless,
         Some(v) if LEGACY_PROTOCOL_VERSIONS.contains(&v) => ProtocolMode::Session,
         None if has_session_id => ProtocolMode::Session,
         _ => ProtocolMode::default(),
+    }
+
+    #[cfg(not(feature = "mcp-2026-07-28"))]
+    {
+        let _ = mcp_protocol_version_header;
+        let _ = has_session_id;
+        ProtocolMode::Session
     }
 }
 
@@ -207,6 +219,7 @@ mod tests {
 
     // ── negotiate_protocol_version ──────────────────────────────────────────
 
+    #[cfg(feature = "mcp-2026-07-28")]
     #[test]
     fn negotiate_returns_2026_when_client_requests_it() {
         assert_eq!(negotiate_protocol_version(Some("2026-07-28")), "2026-07-28");
@@ -237,6 +250,7 @@ mod tests {
 
     // ── select_protocol_mode ────────────────────────────────────────────────
 
+    #[cfg(feature = "mcp-2026-07-28")]
     #[test]
     fn select_protocol_mode_returns_stateless_for_2026() {
         assert_eq!(

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -1,11 +1,14 @@
-//! Transport-neutral JSON-RPC 2.0 envelopes and MCP protocol types.
+//! MCP JSON-RPC 2.0 protocol types (2025-03-26 and 2025-06-18 Streamable HTTP
+//! spec, and 2026-07-28 stateless spec).
 //!
-//! Reference: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! References:
+//! - 2025-03-26: <https://modelcontextprotocol.io/specification/2025-03-26/basic/transports>
+//! - 2025-06-18: <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports>
+//! - 2026-07-28: ADR-010 / SEP-2575 (stateless, `server/discover`)
 //!
-//! Generic envelopes and standard error codes are shared by MCP and other
-//! JSON-RPC application protocols. MCP-specific payloads follow the 2025-03-26
-//! Streamable HTTP spec. Downstream crates can depend on both without pulling
-//! in axum/tokio/reqwest.
+//! Extracted from `dcc-mcp-http` so that downstream crates (clients,
+//! CLIs, alternative transports) can depend on the wire types without
+//! pulling in axum/tokio/reqwest.
 //!
 //! ## Maintainer layout
 //!
@@ -16,13 +19,15 @@
 //! | File | Contents |
 //! |------|----------|
 //! | `jsonrpc.rs`              | `JsonRpcRequest` / `JsonRpcResponse` / `JsonRpcError` / `JsonRpcNotification` / `JsonRpcMessage` / `JsonRpcBatch` + `error_codes` module |
-//! | `lifecycle.rs`            | `initialize` / `ServerCapabilities` / `ClientRoot` / `RootsListResult` / `LoggingSetLevelParams` / `ElicitationCreate*` |
+//! | `lifecycle.rs`            | `initialize` / `ServerCapabilities` / `ClientRoot` / `RootsListResult` / `LoggingSetLevelParams` / `ElicitationCreate*` (2025-x only) |
+//! | `discover.rs`             | `ServerDiscoverResult` / `DiscoverCapabilities` / `TasksCapability` / `StatelessRequestMeta` (2026-07-28) |
 //! | `tools.rs`                | `ListToolsResult` / `McpTool` / `McpToolAnnotations` / `CallTool*` / `ToolContent` |
 //! | `resources.rs`            | `McpResource` / `ListResourcesResult` / `ReadResource*` / `ResourceContents` / `SubscribeResourceParams` + `RESOURCE_NOT_ENABLED_ERROR` |
 //! | `prompts.rs`              | `McpPrompt` / `McpPromptArgument` / `ListPromptsResult` / `GetPrompt*` / `McpPromptMessage` / `McpPromptContent` |
 //! | `sse.rs`                  | `format_sse_event` + `encode_cursor` / `decode_cursor` pagination helpers |
 //! | `notification_builder.rs` | `NotificationBuilder` / `JsonRpcRequestBuilder` — fluent envelope construction (#484) |
 
+mod discover;
 mod jsonrpc;
 mod lifecycle;
 mod notification_builder;
@@ -31,15 +36,20 @@ mod resources;
 mod sse;
 mod tools;
 
+pub use discover::{
+    Discover2026PromptsCapability, Discover2026ResourcesCapability, Discover2026ToolsCapability,
+    DiscoverCapabilities, DiscoverServerInfo, ServerDiscoverResult, StatelessClientInfo,
+    StatelessRequestMeta, TasksCapability,
+};
 pub use jsonrpc::{
     JsonRpcBatch, JsonRpcError, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
     JsonRpcResponse, error_codes,
 };
 pub use lifecycle::{
-    ClientCapabilities, ClientInfo, ClientRoot, ElicitationCapability, ElicitationCreateParams,
-    ElicitationCreateResult, InitializeParams, InitializeResult, LoggingCapability,
-    LoggingSetLevelParams, PromptsCapability, ResourcesCapability, RootsListResult,
-    ServerCapabilities, ServerInfo, ToolsCapability,
+    ClientCapabilities, ClientInfo, ClientRoot, DiscoverResult, ElicitationCapability,
+    ElicitationCreateParams, ElicitationCreateResult, InitializeParams, InitializeResult,
+    LoggingCapability, LoggingSetLevelParams, PromptsCapability, ResourcesCapability,
+    RootsListResult, ServerCapabilities, ServerInfo, StatelessServerCapabilities, ToolsCapability,
 };
 pub use notification_builder::{JsonRpcRequestBuilder, NotificationBuilder};
 pub use prompts::{
@@ -59,15 +69,38 @@ pub use tools::{
 // ── Protocol-version negotiation + session/header/method constants ─────────
 
 /// MCP protocol version this server implements (default / latest).
+///
+/// Phase 1 (0.19.0): still `2025-06-18`; will become `2026-07-28` in Phase 2
+/// (0.21.0) per ADR-010.
 pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 
+/// The MCP 2026-07-28 protocol version string.
+pub const MCP_PROTOCOL_VERSION_2026: &str = "2026-07-28";
+
+/// Alias for [`MCP_PROTOCOL_VERSION_2026`] — explicit date-qualified name.
+pub const MCP_PROTOCOL_VERSION_2026_07_28: &str = MCP_PROTOCOL_VERSION_2026;
+
 /// All protocol versions this server can speak, newest first.
-pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
+///
+/// `2026-07-28` is listed first so that `negotiate_protocol_version` returns it
+/// when a client explicitly requests it, even though `MCP_PROTOCOL_VERSION` is
+/// still `2025-06-18` in Phase 1.  The ordering here is used only for fallback
+/// when the client requests an *unknown* version — which remains `2025-06-18`
+/// until Phase 2.
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-06-18", "2025-03-26"];
+
+/// Legacy (session-based) protocol versions (2025-x and earlier).
+///
+/// Used by [`select_protocol_mode`] to decide whether to route to the
+/// session-based or stateless handler.
+pub const LEGACY_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
 /// Negotiate the protocol version to use for a session.
 ///
 /// If the client requests a version we support, we use it; otherwise we fall
-/// back to our latest supported version (`SUPPORTED_PROTOCOL_VERSIONS[0]`).
+/// back to the Phase 1 default (`2025-06-18`), keeping old clients working.
+///
+/// In Phase 2 this will change to fall back to `2026-07-28`.
 pub fn negotiate_protocol_version(client_requested: Option<&str>) -> &'static str {
     if let Some(requested) = client_requested {
         for &v in SUPPORTED_PROTOCOL_VERSIONS {
@@ -76,12 +109,75 @@ pub fn negotiate_protocol_version(client_requested: Option<&str>) -> &'static st
             }
         }
     }
-    // Client asked for an unknown version (or didn't specify one) — use our latest.
-    SUPPORTED_PROTOCOL_VERSIONS[0]
+    // Client asked for an unknown version (or didn't specify one) — fall back to
+    // the Phase 1 default so existing session-based clients are not broken.
+    MCP_PROTOCOL_VERSION
+}
+
+/// Protocol routing mode derived from request headers (ADR-010).
+///
+/// The gateway and HTTP server use this to decide which handler path to invoke:
+/// the existing session-based path or the new stateless path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtocolMode {
+    /// 2025-x session-based path (`initialize` + `Mcp-Session-Id`).
+    Session,
+    /// 2026-07-28 stateless path (`server/discover`, no session).
+    Stateless,
+}
+
+impl Default for ProtocolMode {
+    /// Phase 1 default: session mode (old behaviour preserved).
+    ///
+    /// Will become `Stateless` in Phase 2 (0.21.0) per ADR-010.
+    fn default() -> Self {
+        ProtocolMode::Session
+    }
+}
+
+/// Determine the protocol mode to use for an incoming request.
+///
+/// Decision logic (ADR-010 §協議分流):
+///
+/// 1. `MCP-Protocol-Version: 2026-07-28`   → `Stateless`
+/// 2. `MCP-Protocol-Version: <legacy>`     → `Session`
+/// 3. No `MCP-Protocol-Version` + `Mcp-Session-Id` present → `Session`
+/// 4. No headers / unknown version         → Phase 1 default (`Session`)
+///
+/// `mcp_protocol_version_header` – value of the `MCP-Protocol-Version` header,
+/// if present.  `has_session_id` – true if the request carries a
+/// `Mcp-Session-Id` header.
+pub fn select_protocol_mode(
+    mcp_protocol_version_header: Option<&str>,
+    has_session_id: bool,
+) -> ProtocolMode {
+    match mcp_protocol_version_header {
+        Some(v) if v == MCP_PROTOCOL_VERSION_2026 => ProtocolMode::Stateless,
+        Some(v) if LEGACY_PROTOCOL_VERSIONS.contains(&v) => ProtocolMode::Session,
+        None if has_session_id => ProtocolMode::Session,
+        _ => ProtocolMode::default(),
+    }
 }
 
 /// The `Mcp-Session-Id` HTTP header name.
 pub const MCP_SESSION_HEADER: &str = "Mcp-Session-Id";
+
+/// The `MCP-Protocol-Version` HTTP header name (2026-07-28, SEP-2243).
+///
+/// Clients that support `2026-07-28` MUST send this header on every request.
+/// The server echoes the negotiated version in the response header.
+pub const MCP_PROTOCOL_VERSION_HEADER: &str = "MCP-Protocol-Version";
+
+/// The `Mcp-Method` HTTP header name (2026-07-28, SEP-2243).
+///
+/// Carries the JSON-RPC method name at the transport level so that HTTP
+/// middlewares (rate limiters, routers) can inspect it without parsing the body.
+pub const MCP_METHOD_HEADER: &str = "Mcp-Method";
+
+/// The `Mcp-Name` HTTP header name (2026-07-28, SEP-2243).
+///
+/// Carries the tool / resource / prompt name at the transport level.
+pub const MCP_NAME_HEADER: &str = "Mcp-Name";
 
 /// Vendored capability key for delta tools notifications.
 pub const DELTA_TOOLS_UPDATE_CAP: &str = "dcc_mcp_core/deltaToolsUpdate";
@@ -98,25 +194,86 @@ pub const ELICITATION_CREATE_METHOD: &str = "elicitation/create";
 /// Number of tools returned per `tools/list` page.
 pub const TOOLS_LIST_PAGE_SIZE: usize = 32;
 
+// ── MCP 2026-07-28 method name constants ───────────────────────────────────
+
+/// `server/discover` — replaces `initialize` in the 2026-07-28 stateless path.
+///
+/// Returns [`ServerDiscoverResult`] as the `result` field.
+pub const SERVER_DISCOVER_METHOD: &str = "server/discover";
+
 #[cfg(test)]
 mod tests {
-    use super::{MCP_PROTOCOL_VERSION, negotiate_protocol_version};
+    use super::*;
+
+    // ── negotiate_protocol_version ──────────────────────────────────────────
 
     #[test]
-    fn protocol_negotiation_preserves_supported_versions() {
-        assert_eq!(
-            negotiate_protocol_version(Some(MCP_PROTOCOL_VERSION)),
-            MCP_PROTOCOL_VERSION
-        );
+    fn negotiate_returns_2026_when_client_requests_it() {
+        assert_eq!(negotiate_protocol_version(Some("2026-07-28")), "2026-07-28");
+    }
+
+    #[test]
+    fn negotiate_returns_2025_06_18_when_client_requests_it() {
+        assert_eq!(negotiate_protocol_version(Some("2025-06-18")), "2025-06-18");
+    }
+
+    #[test]
+    fn negotiate_returns_2025_03_26_when_client_requests_it() {
         assert_eq!(negotiate_protocol_version(Some("2025-03-26")), "2025-03-26");
     }
 
     #[test]
-    fn protocol_negotiation_falls_back_to_latest_supported_version() {
-        assert_eq!(negotiate_protocol_version(None), MCP_PROTOCOL_VERSION);
+    fn negotiate_falls_back_to_default_for_unknown_version() {
+        // Unknown version → Phase 1 default (2025-06-18, not 2026-07-28).
+        let result = negotiate_protocol_version(Some("2024-01-01"));
+        assert_eq!(result, MCP_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn negotiate_falls_back_to_default_when_none() {
+        let result = negotiate_protocol_version(None);
+        assert_eq!(result, MCP_PROTOCOL_VERSION);
+    }
+
+    // ── select_protocol_mode ────────────────────────────────────────────────
+
+    #[test]
+    fn select_protocol_mode_returns_stateless_for_2026() {
         assert_eq!(
-            negotiate_protocol_version(Some("2099-01-01")),
-            MCP_PROTOCOL_VERSION
+            select_protocol_mode(Some("2026-07-28"), false),
+            ProtocolMode::Stateless
+        );
+    }
+
+    #[test]
+    fn select_protocol_mode_returns_session_for_legacy_header() {
+        assert_eq!(
+            select_protocol_mode(Some("2025-06-18"), false),
+            ProtocolMode::Session
+        );
+        assert_eq!(
+            select_protocol_mode(Some("2025-03-26"), false),
+            ProtocolMode::Session
+        );
+    }
+
+    #[test]
+    fn select_protocol_mode_returns_session_when_session_id_present_and_no_header() {
+        assert_eq!(select_protocol_mode(None, true), ProtocolMode::Session);
+    }
+
+    #[test]
+    fn select_protocol_mode_returns_default_when_no_hints() {
+        // Phase 1 default is Session.
+        assert_eq!(select_protocol_mode(None, false), ProtocolMode::default());
+        assert_eq!(ProtocolMode::default(), ProtocolMode::Session);
+    }
+
+    #[test]
+    fn select_protocol_mode_unknown_version_falls_back_to_default() {
+        assert_eq!(
+            select_protocol_mode(Some("3000-01-01"), false),
+            ProtocolMode::default()
         );
     }
 }

--- a/crates/dcc-mcp-jsonrpc/src/lifecycle.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lifecycle.rs
@@ -1,8 +1,12 @@
 //! MCP lifecycle messages: `initialize`, capabilities, `roots/list`,
 //! `logging/setLevel`, `elicitation/create`.
+//!
+//! Also includes `server/discover` types for MCP 2026-07-28 (ADR-010 Phase 1).
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+pub use crate::discover::TasksCapability;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -126,4 +130,49 @@ pub struct ElicitationCreateResult {
 pub struct ServerInfo {
     pub name: String,
     pub version: String,
+}
+
+// ── MCP 2026-07-28: server/discover (ADR-010 Phase 1) ───────────────────────
+
+// `TasksCapability` is re-exported from `discover` to keep one canonical definition.
+
+/// `ServerCapabilities` for MCP 2026-07-28 stateless sessions.
+///
+/// Differs from the session-based [`ServerCapabilities`] in that:
+/// - `tasks` is a first-class field (not experimental)
+/// - `elicitation` is absent (handled via `InputRequiredResult` multi-turn)
+/// - `logging` is omitted (deprecated in 2026-07-28)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StatelessServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<ToolsCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourcesCapability>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompts: Option<PromptsCapability>,
+    /// Tasks are a first-class capability in 2026-07-28 (SEP-2663).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<TasksCapability>,
+    /// Vendor-extension capabilities.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<serde_json::Value>,
+}
+
+/// Result payload for `server/discover` (MCP 2026-07-28, SEP-2575).
+///
+/// Replaces `initialize` in the 2026-07-28 stateless protocol.  Every
+/// request is self-contained (no session), so the client calls
+/// `server/discover` once (or caches the result) to learn server capabilities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResult {
+    /// The protocol version this server is speaking (`"2026-07-28"`).
+    pub protocol_version: String,
+    /// Server name and version.
+    pub server_info: ServerInfo,
+    /// Server capabilities under the 2026-07-28 model.
+    pub capabilities: StatelessServerCapabilities,
+    /// Optional human-readable workflow hint for AI agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }


### PR DESCRIPTION
## Summary
- add opt-in MCP 2026-07-28 wire types, protocol-mode routing, and `server/discover`
- add a stateless HTTP service behind the `mcp-2026-07-28` feature flag while preserving legacy session transport
- align stateless capability checks with the current `ServerState.features` contract

## Validation
- `cargo test -p dcc-mcp-jsonrpc` (22 unit + 3 envelope tests passed)
- `cargo test -p dcc-mcp-http-server --features mcp-2026-07-28` (98 unit tests + doctests passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The feature remains opt-in and does not change the default 2025-06-18 session transport.

## Scope
This PR provides the wire types and reusable stateless service seam for Phase 1. It deliberately does not change the top-level `/mcp` listener or gateway routing; that integration is a follow-up change with end-to-end transport tests.
