### PR TITLE
feat: add selectable CLI MCP transport

### DIFF
--- a/crates/dcc-mcp-cli/src/application/client.rs
+++ b/crates/dcc-mcp-cli/src/application/client.rs
@@ -12,6 +12,21 @@ use crate::domain::rest::{
 use crate::infra::http::{HttpError, HttpGateway};
 
 const MCP_STREAMABLE_HTTP_ACCEPT: &str = "application/json, text/event-stream";
+
+/// Wire transport used for model-facing tool calls.
+///
+/// `Auto` preserves the historical CLI behavior: use the gateway REST
+/// control-plane endpoint first and fall back to MCP when the REST catalog
+/// does not know the tool.  `Mcp` is useful for protocol parity testing and
+/// for tools that are only exposed through `tools/call`; `Rest` keeps the
+/// control-plane behavior strict and never silently changes transports.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum TransportMode {
+    #[default]
+    Auto,
+    Rest,
+    Mcp,
+}
 #[derive(Debug, Error)]
 pub enum ClientError {
     #[error(transparent)]
@@ -23,6 +38,7 @@ pub enum ClientError {
 pub struct DccMcpClient {
     endpoint: Endpoint,
     gateway: HttpGateway,
+    transport: TransportMode,
 }
 
 impl DccMcpClient {
@@ -30,12 +46,23 @@ impl DccMcpClient {
         Self {
             endpoint,
             gateway: HttpGateway::default(),
+            transport: TransportMode::Auto,
         }
     }
 
     #[must_use]
     pub fn with_gateway(endpoint: Endpoint, gateway: HttpGateway) -> Self {
-        Self { endpoint, gateway }
+        Self {
+            endpoint,
+            gateway,
+            transport: TransportMode::Auto,
+        }
+    }
+
+    #[must_use]
+    pub fn with_transport(mut self, transport: TransportMode) -> Self {
+        self.transport = transport;
+        self
     }
 
     pub async fn health(&self) -> Result<Value, ClientError> {
@@ -145,6 +172,9 @@ impl DccMcpClient {
 
     pub async fn call(&self, request: CallRequest) -> Result<Value, ClientError> {
         let request_id = next_request_id();
+        if self.transport == TransportMode::Mcp {
+            return self.call_mcp_tool(request, &request_id).await;
+        }
         let body = json!({
             "tool_slug": &request.tool_slug,
             "arguments": &request.arguments,
@@ -156,7 +186,7 @@ impl DccMcpClient {
             .await
         {
             Ok(value) => Ok(value),
-            Err(error) if is_unknown_rest_tool(&error) => {
+            Err(error) if self.transport == TransportMode::Auto && is_unknown_rest_tool(&error) => {
                 self.call_mcp_tool(request, &request_id).await
             }
             Err(error) => Err(error.into()),

--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -13,7 +13,7 @@ use serde_json::{Value, json};
 
 use dcc_mcp_models::FeedbackReport;
 
-use crate::application::client::{ClientError, DccMcpClient};
+use crate::application::client::{ClientError, DccMcpClient, TransportMode};
 use crate::application::gateway_profile::GatewayTarget;
 use crate::application::instance_selection::{
     InstanceSelectionError, instance_field, select_instances,
@@ -38,6 +38,7 @@ pub struct DccControlPlane {
     registry_dir: PathBuf,
     require_gateway: bool,
     auto_gateway_enabled: bool,
+    transport: TransportMode,
 }
 
 impl DccControlPlane {
@@ -54,12 +55,19 @@ impl DccControlPlane {
             registry_dir,
             require_gateway,
             auto_gateway_enabled: true,
+            transport: TransportMode::Auto,
         }
     }
 
     #[must_use]
     pub fn with_auto_gateway_enabled(mut self, enabled: bool) -> Self {
         self.auto_gateway_enabled = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn with_transport(mut self, transport: TransportMode) -> Self {
+        self.transport = transport;
         self
     }
 
@@ -162,6 +170,14 @@ impl DccControlPlane {
         timeout: Duration,
     ) -> anyhow::Result<Value> {
         let direct_local = self.uses_direct_local();
+        if !direct_local
+            && self.transport == TransportMode::Mcp
+            && (dcc_type.is_some() || instance_id.is_some())
+        {
+            anyhow::bail!(
+                "--transport mcp requires a gateway tool slug; direct backend calls need REST routing"
+            );
+        }
         let value = if direct_local {
             local_control::call_local(
                 self.registry_dir.clone(),
@@ -177,7 +193,8 @@ impl DccControlPlane {
             let client = DccMcpClient::with_gateway(
                 self.endpoint.clone(),
                 HttpGateway::with_timeout(timeout),
-            );
+            )
+            .with_transport(self.transport);
             match (dcc_type, instance_id) {
                 (Some(dcc_type), Some(instance_id)) => client
                     .direct_call(DirectCallRequest {
@@ -502,10 +519,14 @@ impl DccControlPlane {
     }
 
     pub async fn call_batch(&self, body: Value, timeout: Duration) -> anyhow::Result<Value> {
+        if self.transport == TransportMode::Mcp {
+            anyhow::bail!("--transport mcp does not support REST-only batch calls yet");
+        }
         // Local mode owns and auto-starts the machine gateway, so batches use
         // its REST endpoint even though single calls can take the direct MCP path.
         let value =
             DccMcpClient::with_gateway(self.endpoint.clone(), HttpGateway::with_timeout(timeout))
+                .with_transport(self.transport)
                 .call_batch(body)
                 .await
                 .map_err(anyhow::Error::from)?;

--- a/crates/dcc-mcp-cli/src/application/control_plane.rs
+++ b/crates/dcc-mcp-cli/src/application/control_plane.rs
@@ -72,7 +72,7 @@ impl DccControlPlane {
     }
 
     fn uses_direct_local(&self) -> bool {
-        self.target.is_local() && !self.require_gateway
+        self.target.is_local() && !self.require_gateway && self.transport != TransportMode::Rest
     }
 
     pub async fn list_instances(&self) -> anyhow::Result<Value> {

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -11,7 +11,7 @@ use super::output::{ExitCode, OutputFormat, OutputWriter, failure_envelope, to_j
 use crate::application::call_attribution::{
     attach_agent_session_id, attach_batch_agent_session_id,
 };
-use crate::application::client::{DccMcpClient, TransportMode};
+use crate::application::client::DccMcpClient;
 use crate::application::control_plane::DccControlPlane;
 use crate::application::doctor::{DoctorContext, run_doctor};
 use crate::application::gateway_ctrl;
@@ -33,6 +33,7 @@ mod job_progress;
 mod lint;
 mod marketplace_output;
 mod record_replay;
+mod transport_args;
 mod ui_control_output;
 
 #[cfg(test)]
@@ -41,6 +42,7 @@ use image_artifacts::{default_image_artifact_root, materialize_call_images};
 use job_progress::JobProgressReporter;
 use marketplace_output::reload_marketplace_value;
 use record_replay::{RecordReplayAction, run_record_replay};
+use transport_args::TransportArgs;
 use ui_control_output::compact_ui_control_result;
 
 use super::feedback_cmd::FeedbackArgs;
@@ -99,15 +101,8 @@ pub struct Args {
     /// Global timeout in seconds for all operations.
     #[arg(long, global = true, env = "DCC_MCP_TIMEOUT_SECS")]
     timeout_secs: Option<u64>,
-    /// Tool-call transport: auto (REST, then MCP fallback), rest, or mcp.
-    #[arg(
-        long,
-        global = true,
-        env = "DCC_MCP_CLI_TRANSPORT",
-        value_enum,
-        default_value_t = TransportMode::Auto
-    )]
-    transport: TransportMode,
+    #[command(flatten)]
+    transport: TransportArgs,
     #[command(subcommand)]
     command: Command,
 }
@@ -582,10 +577,11 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         output,
         non_interactive,
         timeout_secs: global_timeout_secs,
-        transport,
+        transport: transport_args,
         command,
     } = args;
 
+    let transport = transport_args.transport;
     let output = match &command {
         Command::Feedback(args) => args.resolve_output(output),
         Command::Install { json: true, .. } => Ok(OutputFormat::Json),
@@ -1476,7 +1472,6 @@ fn endpoint_for_mcp(raw: &str) -> String {
     }
 }
 
-/// Check whether a command timeout would be ignored in favor of a distinct global timeout.
 fn command_has_distinct_per_timeout(command: &Command, global_timeout_secs: Option<u64>) -> bool {
     let per_command_timeout = match command {
         Command::Smoke { timeout_secs, .. }

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -11,7 +11,7 @@ use super::output::{ExitCode, OutputFormat, OutputWriter, failure_envelope, to_j
 use crate::application::call_attribution::{
     attach_agent_session_id, attach_batch_agent_session_id,
 };
-use crate::application::client::DccMcpClient;
+use crate::application::client::{DccMcpClient, TransportMode};
 use crate::application::control_plane::DccControlPlane;
 use crate::application::doctor::{DoctorContext, run_doctor};
 use crate::application::gateway_ctrl;
@@ -99,6 +99,15 @@ pub struct Args {
     /// Global timeout in seconds for all operations.
     #[arg(long, global = true, env = "DCC_MCP_TIMEOUT_SECS")]
     timeout_secs: Option<u64>,
+    /// Tool-call transport: auto (REST, then MCP fallback), rest, or mcp.
+    #[arg(
+        long,
+        global = true,
+        env = "DCC_MCP_CLI_TRANSPORT",
+        value_enum,
+        default_value_t = TransportMode::Auto
+    )]
+    transport: TransportMode,
     #[command(subcommand)]
     command: Command,
 }
@@ -573,6 +582,7 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         output,
         non_interactive,
         timeout_secs: global_timeout_secs,
+        transport,
         command,
     } = args;
 
@@ -604,7 +614,8 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
         gateway_ensure::default_registry_dir(),
         require_gateway,
     )
-    .with_auto_gateway_enabled(!no_auto_gateway);
+    .with_auto_gateway_enabled(!no_auto_gateway)
+    .with_transport(transport);
     let doctor = DoctorContext::new(
         profile_path.clone(),
         profile_store,

--- a/crates/dcc-mcp-cli/src/presentation/cli/transport_args.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli/transport_args.rs
@@ -1,0 +1,14 @@
+use crate::application::client::TransportMode;
+
+#[derive(Debug, Clone, clap::Args)]
+pub(crate) struct TransportArgs {
+    /// Tool-call transport: auto (REST, then MCP fallback), rest, or mcp.
+    #[arg(
+        long,
+        global = true,
+        env = "DCC_MCP_CLI_TRANSPORT",
+        value_enum,
+        default_value_t = TransportMode::Auto
+    )]
+    pub(crate) transport: TransportMode,
+}

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -408,37 +408,6 @@ fn call_falls_back_to_mcp_for_core_tool_missing_from_rest_catalog() {
         &[],
     );
     assert!(stderr.contains("job-404"), "stderr: {stderr}");
-
-    let explicit_mcp = run_json(&[
-        "--base-url",
-        &fixture.base_url,
-        "--transport",
-        "mcp",
-        "call",
-        "jobs_get_status",
-        "--json",
-        r#"{"job_id":"job-42"}"#,
-    ]);
-    assert_eq!(explicit_mcp["slug"], "jobs_get_status");
-    assert_eq!(explicit_mcp["output"]["status"], "completed");
-
-    let explicit_rest = run_failure_with_env(
-        &[
-            "--base-url",
-            &fixture.base_url,
-            "--transport",
-            "rest",
-            "call",
-            "jobs_get_status",
-            "--json",
-            r#"{"job_id":"job-42"}"#,
-        ],
-        &[],
-    );
-    assert!(
-        explicit_rest.contains("invalid tool slug"),
-        "REST-only transport should not silently fall back to MCP: {explicit_rest}"
-    );
 }
 
 #[test]

--- a/crates/dcc-mcp-cli/tests/cli_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_e2e.rs
@@ -408,6 +408,37 @@ fn call_falls_back_to_mcp_for_core_tool_missing_from_rest_catalog() {
         &[],
     );
     assert!(stderr.contains("job-404"), "stderr: {stderr}");
+
+    let explicit_mcp = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "--transport",
+        "mcp",
+        "call",
+        "jobs_get_status",
+        "--json",
+        r#"{"job_id":"job-42"}"#,
+    ]);
+    assert_eq!(explicit_mcp["slug"], "jobs_get_status");
+    assert_eq!(explicit_mcp["output"]["status"], "completed");
+
+    let explicit_rest = run_failure_with_env(
+        &[
+            "--base-url",
+            &fixture.base_url,
+            "--transport",
+            "rest",
+            "call",
+            "jobs_get_status",
+            "--json",
+            r#"{"job_id":"job-42"}"#,
+        ],
+        &[],
+    );
+    assert!(
+        explicit_rest.contains("invalid tool slug"),
+        "REST-only transport should not silently fall back to MCP: {explicit_rest}"
+    );
 }
 
 #[test]

--- a/crates/dcc-mcp-cli/tests/cli_transport_e2e.rs
+++ b/crates/dcc-mcp-cli/tests/cli_transport_e2e.rs
@@ -1,0 +1,38 @@
+mod support;
+
+use support::{run_failure_with_env, run_json, spawn_gateway_fixture};
+
+#[test]
+fn selectable_cli_transport_uses_mcp_or_strict_rest() {
+    let fixture = spawn_gateway_fixture();
+    let explicit_mcp = run_json(&[
+        "--base-url",
+        &fixture.base_url,
+        "--transport",
+        "mcp",
+        "call",
+        "jobs_get_status",
+        "--json",
+        r#"{"job_id":"job-42"}"#,
+    ]);
+    assert_eq!(explicit_mcp["slug"], "jobs_get_status");
+    assert_eq!(explicit_mcp["output"]["status"], "completed");
+
+    let explicit_rest = run_failure_with_env(
+        &[
+            "--base-url",
+            &fixture.base_url,
+            "--transport",
+            "rest",
+            "call",
+            "jobs_get_status",
+            "--json",
+            r#"{"job_id":"job-42"}"#,
+        ],
+        &[],
+    );
+    assert!(
+        explicit_rest.contains("invalid tool slug"),
+        "REST-only transport should not silently fall back to MCP: {explicit_rest}"
+    );
+}

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -103,8 +103,8 @@ when the REST catalog reports an unknown tool. `--transport rest` is strict and
 never falls back; `--transport mcp` sends a JSON-RPC `tools/call` directly to
 `/mcp`, which is useful for protocol-parity checks and MCP-only tools. Batch
 calls and direct backend calls with `--dcc-type`/`--instance-id` remain REST
-operations. Local direct-instance calls already use MCP regardless of this
-flag.
+operations. In the default `auto` mode, local direct-instance calls continue to
+use MCP; selecting `rest` routes them through the local gateway REST surface.
 
 Add `--require-gateway` (or set `DCC_MCP_CLI_REQUIRE_GATEWAY=true`) when local
 calls must be retained by Gateway audit/stats. This route is fail-closed and

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -96,6 +96,16 @@ dcc-mcp-cli gateway set local
 and `DCC_MCP_BASE_URL` remain supported as direct endpoint overrides for legacy
 scripts and smoke checks.
 
+Tool calls accept `--transport auto|rest|mcp` (or
+`DCC_MCP_CLI_TRANSPORT`). The default `auto` mode keeps the compatibility path:
+it calls gateway `POST /v1/call` first and falls back to MCP `tools/call` only
+when the REST catalog reports an unknown tool. `--transport rest` is strict and
+never falls back; `--transport mcp` sends a JSON-RPC `tools/call` directly to
+`/mcp`, which is useful for protocol-parity checks and MCP-only tools. Batch
+calls and direct backend calls with `--dcc-type`/`--instance-id` remain REST
+operations. Local direct-instance calls already use MCP regardless of this
+flag.
+
 Add `--require-gateway` (or set `DCC_MCP_CLI_REQUIRE_GATEWAY=true`) when local
 calls must be retained by Gateway audit/stats. This route is fail-closed and
 does not fall back to direct MCP. Add `--agent-session-id <task-id>` (or
@@ -165,6 +175,7 @@ dcc-mcp-cli search --query "create sphere" --dcc-type maya --instance-id abc1234
 dcc-mcp-cli describe maya.abc12345.create_sphere
 dcc-mcp-cli load-skill workflow --dcc-type 3dsmax --instance-id 80321760
 dcc-mcp-cli call maya.abc12345.create_sphere --require-gateway --agent-session-id task-42 --json '{"radius":2}'
+dcc-mcp-cli --transport mcp call jobs_get_status --json '{"job_id":"job-42"}'
 dcc-mcp-cli call unity.abc12345.run_tests --require-gateway --wait --wait-timeout-secs 600 --json '{}'
 dcc-mcp-cli call maya_scene__get_session_info --dcc-type maya --instance-id abc12345 --json '{}'
 dcc-mcp-cli wait-ready --dcc-type maya --instance-id abc12345 --require skill_catalog,host_execution_bridge

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -80,6 +80,15 @@ dcc-mcp-cli gateway set local
 `--gateway <name>` 可为单次命令覆盖当前 profile。`--base-url` 与
 `DCC_MCP_BASE_URL` 继续作为旧脚本和 smoke check 的直接 endpoint override。
 
+工具调用支持 `--transport auto|rest|mcp`（或设置
+`DCC_MCP_CLI_TRANSPORT`）。默认 `auto` 保持兼容路径：先调用 gateway 的
+`POST /v1/call`，只有 REST catalog 报告工具未知时才回退到 MCP
+`tools/call`。`--transport rest` 是严格 REST 模式，不会回退；
+`--transport mcp` 会直接向 `/mcp` 发送 JSON-RPC `tools/call`，适合协议一致性
+检查和只在 MCP 暴露的工具。批量调用以及带 `--dcc-type`/`--instance-id` 的
+direct backend 调用仍是 REST 操作；local profile 的 direct-instance 调用本来就
+走 MCP，此标志不会改变它。
+
 如果本地调用必须进入 Gateway audit/stats，请加 `--require-gateway`（或设置
 `DCC_MCP_CLI_REQUIRE_GATEWAY=true`）。该路径 fail-closed，不会静默回退到
 direct MCP。再加 `--agent-session-id <task-id>`（或
@@ -140,6 +149,7 @@ dcc-mcp-cli search --query sphere --dcc-type maya --instance-id abc12345
 dcc-mcp-cli describe maya.abc12345.create_sphere
 dcc-mcp-cli load-skill workflow --dcc-type 3dsmax --instance-id 80321760
 dcc-mcp-cli call maya.abc12345.create_sphere --require-gateway --agent-session-id task-42 --json '{"radius":2}'
+dcc-mcp-cli --transport mcp call jobs_get_status --json '{"job_id":"job-42"}'
 dcc-mcp-cli call maya_scene__get_session_info --dcc-type maya --instance-id abc12345 --json '{}'
 dcc-mcp-cli wait-ready --dcc-type maya --instance-id abc12345 --require skill_catalog,host_execution_bridge
 dcc-mcp-cli stop-instance --dcc-type maya --instance-id abc12345 --expected-owner release-smoke-test

--- a/docs/zh/guide/cli-reference.md
+++ b/docs/zh/guide/cli-reference.md
@@ -87,7 +87,7 @@ dcc-mcp-cli gateway set local
 `--transport mcp` 会直接向 `/mcp` 发送 JSON-RPC `tools/call`，适合协议一致性
 检查和只在 MCP 暴露的工具。批量调用以及带 `--dcc-type`/`--instance-id` 的
 direct backend 调用仍是 REST 操作；local profile 的 direct-instance 调用本来就
-走 MCP，此标志不会改变它。
+走 MCP；选择 `rest` 时则会改为通过本机 gateway 的 REST control plane 路由。
 
 如果本地调用必须进入 Gateway audit/stats，请加 `--require-gateway`（或设置
 `DCC_MCP_CLI_REQUIRE_GATEWAY=true`）。该路径 fail-closed，不会静默回退到


### PR DESCRIPTION
## Summary\n- add global --transport auto|rest|mcp for tool calls\n- preserve REST-first auto fallback and make strict transports explicit\n- document transport behavior in English and Chinese CLI references\n\n## Validation\n- cargo fmt --all -- --check\n- cargo test -p dcc-mcp-cli --lib\n- cargo test -p dcc-mcp-cli --test cli_e2e call_falls_back_to_mcp_for_core_tool_missing_from_rest_catalog -- --nocapture\n- git diff --check