### PR TITLE
feat: add shared MCP HTTP protocol classifier

### DIFF
--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -171,6 +171,36 @@ pub fn select_protocol_mode(
     }
 }
 
+/// Request-level hints used by HTTP routers before JSON-RPC parsing.
+///
+/// The protocol version is the authoritative routing signal.  `Accept`,
+/// `Mcp-Method`, and `Mcp-Name` are intentionally retained as optional hints
+/// so gateways can make the same decision without re-parsing request bodies.
+/// They are not used to upgrade an unversioned legacy request to stateless
+/// mode; doing so would silently change the lifecycle contract for old MCP
+/// clients.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProtocolRequestHints<'a> {
+    pub protocol_version: Option<&'a str>,
+    pub has_session_id: bool,
+    pub accept: Option<&'a str>,
+    pub method: Option<&'a str>,
+    pub name: Option<&'a str>,
+}
+
+/// Select the HTTP protocol route from transport headers.
+///
+/// This is the shared classifier for `/mcp` implementations.  A request is
+/// routed statelessly only when the client explicitly advertises
+/// `2026-07-28`; the remaining headers are metadata available to middleware.
+/// The helper deliberately does not require `Accept`, `Mcp-Method`, or
+/// `Mcp-Name`, because discovery and intermediary clients may omit one of
+/// those hints while still negotiating the version explicitly.
+#[must_use]
+pub fn select_protocol_mode_from_headers(hints: ProtocolRequestHints<'_>) -> ProtocolMode {
+    select_protocol_mode(hints.protocol_version, hints.has_session_id)
+}
+
 /// The `Mcp-Session-Id` HTTP header name.
 pub const MCP_SESSION_HEADER: &str = "Mcp-Session-Id";
 
@@ -288,6 +318,35 @@ mod tests {
         assert_eq!(
             select_protocol_mode(Some("3000-01-01"), false),
             ProtocolMode::default()
+        );
+    }
+
+    #[cfg(feature = "mcp-2026-07-28")]
+    #[test]
+    fn header_classifier_uses_explicit_version_over_optional_transport_hints() {
+        let hints = ProtocolRequestHints {
+            protocol_version: Some(MCP_PROTOCOL_VERSION_2026),
+            has_session_id: true,
+            accept: Some("application/json, text/event-stream"),
+            method: Some("tools/call"),
+            name: Some("blender_scene__new_scene"),
+        };
+        assert_eq!(
+            select_protocol_mode_from_headers(hints),
+            ProtocolMode::Stateless
+        );
+    }
+
+    #[test]
+    fn header_classifier_keeps_unversioned_requests_on_legacy_route() {
+        let hints = ProtocolRequestHints {
+            accept: Some("application/json"),
+            method: Some("tools/list"),
+            ..Default::default()
+        };
+        assert_eq!(
+            select_protocol_mode_from_headers(hints),
+            ProtocolMode::Session
         );
     }
 }

--- a/docs/adr/033-mcp-http-protocol-router.md
+++ b/docs/adr/033-mcp-http-protocol-router.md
@@ -1,0 +1,34 @@
+# ADR-033: Explicit MCP HTTP protocol routing
+
+Status: Proposed
+
+## Context
+
+The 2026-07-28 MCP transport removes lifecycle sessions and introduces
+request-level protocol headers.  Existing DCC servers and gateways still need
+to accept 2025.x clients, so changing the `/mcp` default would be a breaking
+change.
+
+## Decision
+
+HTTP routers use `MCP-Protocol-Version` as the authoritative route signal:
+
+- `2026-07-28` routes to the stateless handler;
+- `2025-06-18`, `2025-03-26`, an absent header, or an unknown version routes to
+  the existing session-compatible handler;
+- `Mcp-Session-Id` never upgrades a request to stateless mode;
+- `Accept`, `Mcp-Method`, and `Mcp-Name` are optional middleware hints and are
+  not sufficient to upgrade an unversioned request.
+
+The shared `dcc-mcp-jsonrpc::select_protocol_mode_from_headers` helper owns
+this decision so the embedded HTTP server, gateway, and CLI cannot drift.
+Phase 2 HTTP integration may add validation of the optional hints, but must
+preserve the legacy default until the stateless handler is enabled by the
+caller and covered by end-to-end tests.
+
+## Consequences
+
+This is an additive seam: current clients retain their existing route, while
+2026 clients can opt in explicitly.  A later release can change the default
+only after all adapters and the gateway advertise and exercise the stateless
+handler.


### PR DESCRIPTION
## Summary\n- add a shared header classifier seam for 2026 stateless vs legacy MCP routing\n- preserve legacy default for missing or unknown protocol headers\n- document Phase 2 routing contract in ADR-033\n\n## Validation\n- cargo test -p dcc-mcp-jsonrpc\n- cargo test -p dcc-mcp-jsonrpc --features mcp-2026-07-28\n- cargo fmt --all -- --check\n\nThis PR intentionally does not switch the /mcp handler; it provides the shared classifier for the follow-up HTTP integration.