### PR TITLE
fix: pin trusted lock validator after uv isolation

### DIFF
--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -29,7 +29,7 @@ jobs:
     name: Sync generated Cargo metadata
     runs-on: ubuntu-latest
     env:
-      TRUSTED_VALIDATOR_REF: 3ee3cbf1445a5f3a909788443c7bdbec0c2ca3da
+      TRUSTED_VALIDATOR_REF: 3667e8786549cc890e701dffba6512b2f6a5b5e7
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
         name: Checkout trusted lock validator
         with:
-          ref: 3ee3cbf1445a5f3a909788443c7bdbec0c2ca3da
+          ref: 3667e8786549cc890e701dffba6512b2f6a5b5e7
           path: trusted-lock-validator
           persist-credentials: false
 

--- a/tests/test_uv_lock_consistency.py
+++ b/tests/test_uv_lock_consistency.py
@@ -23,7 +23,7 @@ CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 VERSION_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "version-consistency.yml"
 EXPECTED_ROOT_PACKAGE = "dcc-mcp-core"
 TRUSTED_VALIDATOR_PATH = "scripts/ci/generated_lock_sync.py"
-TRUSTED_VALIDATOR_COMMIT = "3ee3cbf1445a5f3a909788443c7bdbec0c2ca3da"
+TRUSTED_VALIDATOR_COMMIT = "3667e8786549cc890e701dffba6512b2f6a5b5e7"
 
 
 def _load_checker_module():


### PR DESCRIPTION
Use the merged uv config isolation fix for release lock generation.