### PR TITLE
feat: package MCP 2026 support in Python wheels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,6 +283,9 @@ job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]
 # default — when disabled, zero admin UI code or front-end assets are
 # compiled into the wheel.
 admin = ["dcc-mcp-gateway/admin", "dcc-mcp-http/admin"]
+# Route explicitly negotiated MCP 2026-07-28 requests through the stateless
+# HTTP service while retaining the legacy session path.
+mcp-2026-07-28 = ["dcc-mcp-http/mcp-2026-07-28"]
 # Persist gateway admin state in SQLite (bundled `rusqlite`). Off by default
 # so the admin-persist-sqlite path no longer compiles the bundled `rusqlite`
 # driver (issue #2182). Note: the gateway's traffic-capture sink still depends

--- a/crates/dcc-mcp-http-py/Cargo.toml
+++ b/crates/dcc-mcp-http-py/Cargo.toml
@@ -57,3 +57,5 @@ stub-gen = [
 ]
 prometheus = ["dcc-mcp-http/prometheus"]
 job-persist-sqlite = ["dcc-mcp-http/job-persist-sqlite"]
+# Forward the opt-in MCP 2026 stateless HTTP path into the PyO3 wheel.
+mcp-2026-07-28 = ["dcc-mcp-http/mcp-2026-07-28"]

--- a/docs/adr/010-mcp-2026-07-28-dual-protocol-migration.md
+++ b/docs/adr/010-mcp-2026-07-28-dual-protocol-migration.md
@@ -90,6 +90,15 @@ fn select_protocol_mode(req: &HttpRequest) -> ProtocolMode {
 - 特性开关: `mcp-2026-07-28` feature flag, off by default
 - 无状态路径的 session store / TTL 驱逐逻辑完全跳过
 
+Python abi3 wheels include the `mcp-2026-07-28` feature so an explicit
+`MCP-Protocol-Version: 2026-07-28` header can reach the stateless handler.
+
+Native CPython 3.7 wheels carry the same feature. The py37-lite wheel remains
+pure-Python and delegates HTTP serving to the separately distributed
+`dcc-mcp-server` binary; it must be validated independently. Adapter packages
+must not advertise 2026 support until the corresponding wheel and sidecar
+artifact smoke tests pass.
+
 **交付物:**
 - `crates/dcc-mcp-http-server/src/stateless/` — 无状态服务实现
 - `dcc-mcp-jsonrpc` 新增 `server/discover` 类型

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ set shell := ["sh", "-cu"]
 # Opt-in Cargo features that must ship in every wheel. Add new features here
 # and every recipe below — as well as CI workflows invoking `just build-*` —
 # will pick them up automatically.
-OPT_FEATURES := "workflow,scheduler,prometheus,job-persist-sqlite,admin"
+OPT_FEATURES := "workflow,scheduler,prometheus,job-persist-sqlite,admin,mcp-2026-07-28"
 CLI_BIN := if os_family() == "windows" { ".\\target\\release\\dcc-mcp-cli.exe" } else { "./target/release/dcc-mcp-cli" }
 
 # Feature set for `maturin develop` (no abi3, extension-module linkage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ module-name = "dcc_mcp_core._core"
 # Feature list MUST stay in sync with `WHEEL_FEATURES` in the root justfile.
 # The justfile is the single source of truth for CI; this list only matters
 # for downstream `pip install .` / sdist rebuilds that bypass our CI.
-features = ["python-bindings", "ext-module", "abi3-py38", "workflow", "scheduler", "prometheus", "job-persist-sqlite", "admin"]
+features = ["python-bindings", "ext-module", "abi3-py38", "workflow", "scheduler", "prometheus", "job-persist-sqlite", "admin", "mcp-2026-07-28"]
 bindings = "pyo3"
 [tool.mypy]
 python_version = "3.7"

--- a/tests/test_python_support_contract.py
+++ b/tests/test_python_support_contract.py
@@ -27,12 +27,15 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_pyproject_maturin_features_match_canonical_wheel_features(tmp_path: Path) -> None:
-    (tmp_path / "justfile").write_text((_REPO_ROOT / "justfile").read_text(encoding="utf-8"), encoding="utf-8")
+    justfile = (_REPO_ROOT / "justfile").read_text(encoding="utf-8")
+    assert "mcp-2026-07-28" in justfile
+    (tmp_path / "justfile").write_text(justfile, encoding="utf-8")
     pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
     assert collect_wheel_feature_projection_errors(tmp_path) == []
 
-    (tmp_path / "pyproject.toml").write_text(pyproject.replace(', "admin"]', "]", 1), encoding="utf-8")
+    weakened = pyproject.replace(', "admin", "mcp-2026-07-28"]', ', "mcp-2026-07-28"]', 1)
+    (tmp_path / "pyproject.toml").write_text(weakened, encoding="utf-8")
     errors = collect_wheel_feature_projection_errors(tmp_path)
     assert any("missing=['admin']" in error for error in errors)
 


### PR DESCRIPTION
## Summary

- include `mcp-2026-07-28` in the canonical Python wheel feature projection
- keep the pure-Python py37-lite path explicitly separate from native wheels
- add a support-contract regression assertion and document adapter rollout gates

Closes #2428.

## Validation

- `python scripts/ci/check_python_support.py`
- `python -m pytest tests/test_python_support_contract.py -q` (20 passed)
- `cargo fmt --all -- --check`
- `cargo check -p dcc-mcp-http --features mcp-2026-07-28`
- `cargo test -p dcc-mcp-http --features mcp-2026-07-28` (71 passed, 2 doctests passed, 1 ignored)