### PR TITLE
fix: keep initialize on the legacy protocol lifecycle

### DIFF
--- a/crates/dcc-mcp-http/tests/protocol_lifecycle.rs
+++ b/crates/dcc-mcp-http/tests/protocol_lifecycle.rs
@@ -1,0 +1,103 @@
+//! The request header selects a lifecycle; initialize cannot upgrade it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dcc_mcp_actions::ToolRegistry;
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+use dcc_mcp_jsonrpc::JsonRpcRequestBuilder;
+use serde_json::{Value, json};
+
+async fn request(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    params: Value,
+    protocol_header: Option<&str>,
+) -> Value {
+    let envelope = JsonRpcRequestBuilder::new("lifecycle-check", method)
+        .with_params(params)
+        .to_value();
+    let mut request = client
+        .post(url)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&envelope);
+    if let Some(version) = protocol_header {
+        request = request.header("MCP-Protocol-Version", version);
+    }
+    let response = request.send().await.expect("MCP response");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("JSON-RPC body");
+    assert_eq!(body["id"], "lifecycle-check");
+    body
+}
+
+fn initialize_params(version: Option<&str>) -> Value {
+    let mut params = json!({
+        "capabilities": {},
+        "clientInfo": {"name": "protocol-contract", "version": "1"}
+    });
+    if let Some(version) = version {
+        params["protocolVersion"] = json!(version);
+    }
+    params
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_header_selects_lifecycle_independently_of_initialize_body() {
+    let mut config = McpHttpConfig::default();
+    config.server.port = 0;
+    config.gateway.gateway_port = 0;
+    let handle = McpHttpServer::new(Arc::new(ToolRegistry::new()), config)
+        .start()
+        .await
+        .expect("start server");
+    let url = format!("http://127.0.0.1:{}/mcp", handle.port);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    for (requested, expected) in [
+        (Some("2025-03-26"), "2025-03-26"),
+        (Some("2025-06-18"), "2025-06-18"),
+        (Some("2026-07-28"), "2025-06-18"),
+        (Some("2099-01-01"), "2025-06-18"),
+        (None, "2025-06-18"),
+    ] {
+        let body = request(
+            &client,
+            &url,
+            "initialize",
+            initialize_params(requested),
+            None,
+        )
+        .await;
+        assert_eq!(body["result"]["protocolVersion"], expected, "{requested:?}");
+    }
+
+    #[cfg(feature = "mcp-2026-07-28")]
+    {
+        let discovery = request(
+            &client,
+            &url,
+            "server/discover",
+            json!({}),
+            Some("2026-07-28"),
+        )
+        .await;
+        assert_eq!(discovery["result"]["protocolVersion"], "2026-07-28");
+        let initialize = request(
+            &client,
+            &url,
+            "initialize",
+            initialize_params(Some("2026-07-28")),
+            Some("2026-07-28"),
+        )
+        .await;
+        assert_eq!(initialize["error"]["code"], -32601);
+        assert!(initialize.get("result").is_none());
+    }
+
+    handle.shutdown().await;
+}

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -68,10 +68,7 @@ pub use tools::{
 
 // ── Protocol-version negotiation + session/header/method constants ─────────
 
-/// MCP protocol version this server implements (default / latest).
-///
-/// Phase 1 (0.19.0): still `2025-06-18`; will become `2026-07-28` in Phase 2
-/// (0.21.0) per ADR-010.
+/// Default MCP protocol version for the legacy `initialize` lifecycle.
 pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
 
 /// The MCP 2026-07-28 protocol version string.
@@ -82,11 +79,8 @@ pub const MCP_PROTOCOL_VERSION_2026_07_28: &str = MCP_PROTOCOL_VERSION_2026;
 
 /// All protocol versions this server can speak, newest first.
 ///
-/// `2026-07-28` is listed first so that `negotiate_protocol_version` returns it
-/// when a client explicitly requests it, even though `MCP_PROTOCOL_VERSION` is
-/// still `2025-06-18` in Phase 1.  The ordering here is used only for fallback
-/// when the client requests an *unknown* version — which remains `2025-06-18`
-/// until Phase 2.
+/// This includes both lifecycles. The HTTP protocol header selects the
+/// stateless lifecycle; `initialize` negotiates only legacy versions.
 #[cfg(feature = "mcp-2026-07-28")]
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-06-18", "2025-03-26"];
 
@@ -95,26 +89,25 @@ pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
 /// Legacy (session-based) protocol versions (2025-x and earlier).
 ///
-/// Used by [`select_protocol_mode`] to decide whether to route to the
-/// session-based or stateless handler.
+/// Used by [`select_protocol_mode`] for routing and by
+/// [`negotiate_protocol_version`] for `initialize` negotiation.
 pub const LEGACY_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
-/// Negotiate the protocol version to use for a session.
+/// Negotiate the protocol version for the legacy `initialize` lifecycle.
 ///
-/// If the client requests a version we support, we use it; otherwise we fall
-/// back to the Phase 1 default (`2025-06-18`), keeping old clients working.
-///
-/// In Phase 2 this will change to fall back to `2026-07-28`.
+/// Supported legacy versions are echoed; missing or unsupported versions
+/// fall back to `2025-06-18`. Even when stateless support is compiled in,
+/// requesting `2026-07-28` here cannot switch lifecycles: that protocol uses
+/// an explicit HTTP header and `server/discover`, not `initialize`.
 pub fn negotiate_protocol_version(client_requested: Option<&str>) -> &'static str {
     if let Some(requested) = client_requested {
-        for &v in SUPPORTED_PROTOCOL_VERSIONS {
+        for &v in LEGACY_PROTOCOL_VERSIONS {
             if v == requested {
                 return v;
             }
         }
     }
-    // Client asked for an unknown version (or didn't specify one) — fall back to
-    // the Phase 1 default so existing session-based clients are not broken.
+    // Keep the negotiated version consistent with the selected lifecycle.
     MCP_PROTOCOL_VERSION
 }
 
@@ -249,10 +242,9 @@ mod tests {
 
     // ── negotiate_protocol_version ──────────────────────────────────────────
 
-    #[cfg(feature = "mcp-2026-07-28")]
     #[test]
-    fn negotiate_returns_2026_when_client_requests_it() {
-        assert_eq!(negotiate_protocol_version(Some("2026-07-28")), "2026-07-28");
+    fn initialize_negotiation_does_not_select_the_stateless_lifecycle() {
+        assert_eq!(negotiate_protocol_version(Some("2026-07-28")), "2025-06-18");
     }
 
     #[test]

--- a/docs/adr/033-mcp-http-protocol-router.md
+++ b/docs/adr/033-mcp-http-protocol-router.md
@@ -20,6 +20,12 @@ HTTP routers use `MCP-Protocol-Version` as the authoritative route signal:
 - `Accept`, `Mcp-Method`, and `Mcp-Name` are optional middleware hints and are
   not sufficient to upgrade an unversioned request.
 
+The `initialize` body does not select a lifecycle. Its version negotiation
+is restricted to `2025-06-18` and `2025-03-26`; requesting `2026-07-28` (or
+another unsupported version) falls back to `2025-06-18`. Clients opting into
+the stateless header use `server/discover`; that route rejects `initialize`
+as an unsupported method.
+
 The shared `dcc-mcp-jsonrpc::select_protocol_mode_from_headers` helper owns
 this decision so the embedded HTTP server, gateway, and CLI cannot drift.
 Phase 2 HTTP integration may add validation of the optional hints, but must

--- a/tests/test_mcp_protocol_lifecycle.py
+++ b/tests/test_mcp_protocol_lifecycle.py
@@ -1,0 +1,71 @@
+"""Keep legacy initialize and explicit stateless discovery on separate lifecycles."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+@pytest.fixture(scope="module")
+def protocol_server():
+    server = McpHttpServer(ToolRegistry(), McpHttpConfig(port=0))
+    with server.start() as handle:
+        yield handle.mcp_url()
+
+
+def _request(url, method, params, protocol_header=None):
+    headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+    if protocol_header is not None:
+        headers["MCP-Protocol-Version"] = protocol_header
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"jsonrpc": "2.0", "id": "lifecycle-check", "method": method, "params": params}).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        assert response.status == 200
+        body = json.loads(response.read())
+    assert body["id"] == "lifecycle-check"
+    return body
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        ("2025-03-26", "2025-03-26"),
+        ("2025-06-18", "2025-06-18"),
+        ("2026-07-28", "2025-06-18"),
+        ("2099-01-01", "2025-06-18"),
+        (None, "2025-06-18"),
+    ],
+)
+def test_headerless_initialize_stays_on_legacy_lifecycle(protocol_server, requested, expected):
+    params = {"capabilities": {}, "clientInfo": {"name": "protocol-contract", "version": "1"}}
+    if requested is not None:
+        params["protocolVersion"] = requested
+    response = _request(protocol_server, "initialize", params)
+    assert response["result"]["protocolVersion"] == expected
+
+
+def test_explicit_stateless_header_uses_discover_not_initialize(protocol_server):
+    response = _request(protocol_server, "server/discover", {}, "2026-07-28")
+    assert response["result"]["protocolVersion"] == "2026-07-28"
+    response = _request(
+        protocol_server,
+        "initialize",
+        {
+            "protocolVersion": "2026-07-28",
+            "capabilities": {},
+            "clientInfo": {"name": "protocol-contract", "version": "1"},
+        },
+        "2026-07-28",
+    )
+    assert response["error"]["code"] == -32601
+    assert "result" not in response


### PR DESCRIPTION
## Summary
- Restrict initialize negotiation to supported legacy versions, including when stateless support is compiled in.
- Preserve explicit 2026 discovery routing and reject initialize on that route.
- Add shared negotiation, real HTTP, and Python wheel regression coverage.

## Validation
- Released 0.20.23 reproduces the bug: 1 failed, 5 passed in the new HTTP regression.
- Fixed-head Rust: 27 shared protocol tests and the real HTTP lifecycle integration pass with the 2026 feature enabled.
- Windows wheel from CI run 34106859171: 35 Python HTTP tests pass with official MCP SDK 1.29.1, including all 6 new regressions and legacy SDK initialize/list/call.
- Ruff and Rust formatting pass; remaining cross-platform CI is pending.
- SDK 2.1.1 needs the pre-existing client fixtures migrated from three transport return values to two before wire testing; tracked separately in #2436.

Fixes #2432