### PR TITLE
fix: advertise only implemented stateless capabilities

### DIFF
--- a/crates/dcc-mcp-http-server/src/stateless/service.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/service.rs
@@ -20,9 +20,8 @@ use serde_json::{Value, json};
 use tracing::debug;
 
 use dcc_mcp_jsonrpc::{
-    DiscoverResult, JsonRpcRequest, JsonRpcResponse, MCP_PROTOCOL_VERSION_2026_07_28,
-    PromptsCapability, ResourcesCapability, ServerInfo, StatelessServerCapabilities,
-    TasksCapability, ToolsCapability, error_codes,
+    DiscoverResult, JsonRpcRequest, JsonRpcResponse, MCP_PROTOCOL_VERSION_2026_07_28, ServerInfo,
+    StatelessServerCapabilities, ToolsCapability, error_codes,
 };
 
 use crate::mcp_tool_list_builder::{assemble_full_tool_list, slice_tools_page};
@@ -101,23 +100,13 @@ impl StatelessMcpService {
 
     fn build_stateless_capabilities(&self) -> StatelessServerCapabilities {
         StatelessServerCapabilities {
-            tools: Some(ToolsCapability { list_changed: true }),
-            resources: if self.state.features.enable_resources {
-                Some(ResourcesCapability {
-                    subscribe: true,
-                    list_changed: true,
-                })
-            } else {
-                None
-            },
-            prompts: if self.state.features.enable_prompts {
-                Some(PromptsCapability { list_changed: true })
-            } else {
-                None
-            },
-            // Tasks are a first-class capability in 2026-07-28.
-            tasks: Some(TasksCapability {}),
-            experimental: None,
+            // This path has no subscription stream. Resources and prompts
+            // remain unadvertised until their read/get handlers are wired.
+            // The final 2026 revision does not include the task wire surface.
+            tools: Some(ToolsCapability {
+                list_changed: false,
+            }),
+            ..Default::default()
         }
     }
 
@@ -277,8 +266,48 @@ mod tests {
         assert_eq!(result["protocolVersion"], MCP_PROTOCOL_VERSION_2026_07_28);
         assert_eq!(result["serverInfo"]["name"], "dcc-mcp-http");
         assert!(result["capabilities"]["tools"].is_object());
-        assert!(result["capabilities"]["tasks"].is_object());
+        assert!(result["capabilities"].get("tasks").is_none());
         assert!(result["instructions"].is_string());
+    }
+
+    #[tokio::test]
+    async fn discovery_advertises_only_implemented_stateless_capabilities() {
+        for enable_resources in [false, true] {
+            for enable_prompts in [false, true] {
+                let mut svc = make_service();
+                svc.state.features.enable_resources = enable_resources;
+                svc.state.features.enable_prompts = enable_prompts;
+                let req = make_request("server/discover", json!("capabilities"), None);
+                let resp = svc.handle_request(&req).await.expect("has id");
+
+                assert_eq!(
+                    resp["result"]["capabilities"],
+                    json!({"tools": {"listChanged": false}}),
+                    "resources={enable_resources}, prompts={enable_prompts}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unadvertised_stateless_methods_remain_unsupported() {
+        let svc = make_service();
+        for method in [
+            "resources/read",
+            "prompts/get",
+            "subscriptions/listen",
+            "tasks/get",
+            "tasks/cancel",
+        ] {
+            let req = make_request(method, json!(method), Some(json!({})));
+            let resp = svc.handle_request(&req).await.expect("has id");
+            assert_eq!(
+                resp["error"]["code"],
+                error_codes::METHOD_NOT_FOUND,
+                "{method}"
+            );
+            assert!(resp.get("result").is_none(), "{method}");
+        }
     }
 
     #[tokio::test]

--- a/crates/dcc-mcp-http/tests/stateless_capabilities.rs
+++ b/crates/dcc-mcp-http/tests/stateless_capabilities.rs
@@ -1,0 +1,98 @@
+//! Capability declarations must match the selected lifecycle's handlers.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dcc_mcp_actions::ToolRegistry;
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+use dcc_mcp_jsonrpc::JsonRpcRequestBuilder;
+use serde_json::{Value, json};
+
+async fn request(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    mut params: Value,
+    modern: bool,
+) -> Value {
+    let mut request = client
+        .post(url)
+        .header("Accept", "application/json, text/event-stream");
+    if modern {
+        request = request
+            .header("MCP-Protocol-Version", "2026-07-28")
+            .header("Mcp-Method", method);
+        params["_meta"] = json!({
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "capability-contract", "version": "1"
+            }
+        });
+    }
+    let envelope = JsonRpcRequestBuilder::new("capability-check", method)
+        .with_params(params)
+        .to_value();
+    let response = request.json(&envelope).send().await.expect("MCP response");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("JSON-RPC body");
+    assert_eq!(body["id"], "capability-check");
+    body
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_capabilities_match_staged_support_without_changing_legacy() {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("HTTP client");
+    for enable_resources in [false, true] {
+        for enable_prompts in [false, true] {
+            let mut config = McpHttpConfig::default();
+            config.server.port = 0;
+            config.gateway.gateway_port = 0;
+            config.features.enable_resources = enable_resources;
+            config.features.enable_prompts = enable_prompts;
+            let handle = McpHttpServer::new(Arc::new(ToolRegistry::new()), config)
+                .start()
+                .await
+                .expect("start server");
+            let url = format!("http://127.0.0.1:{}/mcp", handle.port);
+
+            #[cfg(feature = "mcp-2026-07-28")]
+            {
+                let discovery = request(&client, &url, "server/discover", json!({}), true).await;
+                assert_eq!(
+                    discovery["result"]["capabilities"],
+                    json!({"tools": {"listChanged": false}}),
+                    "resources={enable_resources}, prompts={enable_prompts}"
+                );
+                let tools = request(&client, &url, "tools/list", json!({}), true).await;
+                assert!(
+                    !tools["result"]["tools"]
+                        .as_array()
+                        .expect("tools")
+                        .is_empty()
+                );
+            }
+
+            let legacy = request(
+                &client,
+                &url,
+                "initialize",
+                json!({
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "capability-contract", "version": "1"}
+                }),
+                false,
+            )
+            .await;
+            let capabilities = &legacy["result"]["capabilities"];
+            assert_eq!(capabilities.get("resources").is_some(), enable_resources);
+            assert_eq!(capabilities.get("prompts").is_some(), enable_prompts);
+            assert_eq!(capabilities["tools"]["listChanged"], true);
+            handle.shutdown().await;
+        }
+    }
+}

--- a/docs/adr/033-mcp-http-protocol-router.md
+++ b/docs/adr/033-mcp-http-protocol-router.md
@@ -32,3 +32,14 @@ This is an additive seam: current clients retain their existing route, while
 2026 clients can opt in explicitly.  A later release can change the default
 only after all adapters and the gateway advertise and exercise the stateless
 handler.
+
+## Staged stateless capabilities
+
+The opt-in stateless endpoint currently advertises only tools, with
+`listChanged: false`: no subscription stream is implemented. Resources and
+prompts stay unadvertised until their read/get provider handlers are wired
+(#2434), regardless of the legacy feature flags. The final 2026 revision
+does not include the task wire surface, so tasks are not advertised (#2433).
+Legacy capability behavior is unchanged. These declarations do not claim
+full final-2026 wire compatibility; the independent SDK round-trip and wire
+validation work is tracked in #2436.

--- a/tests/test_stateless_capabilities.py
+++ b/tests/test_stateless_capabilities.py
@@ -1,0 +1,59 @@
+"""Advertise only executable capabilities on the staged stateless endpoint."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+def _request(url, method, params, modern=False):
+    headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+    if modern:
+        headers.update({"MCP-Protocol-Version": "2026-07-28", "Mcp-Method": method})
+        params = dict(params)
+        params["_meta"] = {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": {"name": "capability-contract", "version": "1"},
+        }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"jsonrpc": "2.0", "id": "capability-check", "method": method, "params": params}).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        assert response.status == 200
+        body = json.loads(response.read())
+    assert body["id"] == "capability-check"
+    return body
+
+
+@pytest.mark.parametrize("enable_resources", [False, True])
+@pytest.mark.parametrize("enable_prompts", [False, True])
+def test_stateless_discovery_advertises_only_implemented_capabilities(enable_resources, enable_prompts):
+    config = McpHttpConfig(port=0)
+    config.enable_resources = enable_resources
+    config.enable_prompts = enable_prompts
+    server = McpHttpServer(ToolRegistry(), config)
+    with server.start() as handle:
+        response = _request(handle.mcp_url(), "server/discover", {}, modern=True)
+        legacy = _request(
+            handle.mcp_url(),
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "capability-contract", "version": "1"},
+            },
+        )
+    assert response["result"]["capabilities"] == {"tools": {"listChanged": False}}
+    assert ("resources" in legacy["result"]["capabilities"]) is enable_resources
+    assert ("prompts" in legacy["result"]["capabilities"]) is enable_prompts
+    assert legacy["result"]["capabilities"]["tools"]["listChanged"] is True


### PR DESCRIPTION
Fixes #2433.

- Advertise tools without change notifications on the staged stateless endpoint.
- Omit unsupported tasks, resources and prompts; preserve legacy capability flags.
- Add Rust/Python HTTP flag-matrix regressions and document deferred provider/wire work (#2434, #2436).

Validation:

- 13 stateless Rust tests passed.
- HTTP capability matrices passed with --no-default-features, both with and without mcp-2026-07-28.
- cargo fmt, Ruff and diff checks passed.
- Published 0.20.23 wheel reproduced all four expected Python regression failures; fixed-wheel Python validation runs in CI. No live-DCC acceptance is claimed.

No public Skill update is required for this capability-only correction: it adds no workflow or authoring API. Full final-2026 compatibility remains separate.