### PR TITLE
fix: align modern MCP response contracts

### DIFF
--- a/crates/dcc-mcp-http-server/src/stateless/service.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/service.rs
@@ -20,8 +20,8 @@ use serde_json::{Value, json};
 use tracing::debug;
 
 use dcc_mcp_jsonrpc::{
-    DiscoverResult, JsonRpcRequest, JsonRpcResponse, SUPPORTED_PROTOCOL_VERSIONS, ServerInfo,
-    StatelessServerCapabilities, ToolsCapability, complete_modern_result, error_codes,
+    DiscoverResult, JsonRpcRequest, JsonRpcResponse, SUPPORTED_MODERN_PROTOCOL_VERSIONS,
+    ServerInfo, StatelessServerCapabilities, ToolsCapability, complete_modern_result, error_codes,
 };
 
 use crate::mcp_tool_list_builder::{assemble_full_tool_list, slice_tools_page};
@@ -93,7 +93,7 @@ impl StatelessMcpService {
     fn handle_discover(&self, id: Value) -> Value {
         let caps = self.build_stateless_capabilities();
         let result = DiscoverResult {
-            supported_versions: SUPPORTED_PROTOCOL_VERSIONS
+            supported_versions: SUPPORTED_MODERN_PROTOCOL_VERSIONS
                 .iter()
                 .map(|v| (*v).to_string())
                 .collect(),
@@ -277,8 +277,8 @@ mod tests {
         assert_eq!(resp["id"], 1);
         let result = &resp["result"];
         assert_eq!(
-            result["supportedVersions"][0],
-            MCP_PROTOCOL_VERSION_2026_07_28
+            result["supportedVersions"],
+            json!([MCP_PROTOCOL_VERSION_2026_07_28])
         );
         assert_eq!(
             result["_meta"][SERVER_INFO_META_KEY]["name"],

--- a/crates/dcc-mcp-http-server/src/stateless/service.rs
+++ b/crates/dcc-mcp-http-server/src/stateless/service.rs
@@ -20,8 +20,8 @@ use serde_json::{Value, json};
 use tracing::debug;
 
 use dcc_mcp_jsonrpc::{
-    DiscoverResult, JsonRpcRequest, JsonRpcResponse, MCP_PROTOCOL_VERSION_2026_07_28, ServerInfo,
-    StatelessServerCapabilities, ToolsCapability, error_codes,
+    DiscoverResult, JsonRpcRequest, JsonRpcResponse, SUPPORTED_PROTOCOL_VERSIONS, ServerInfo,
+    StatelessServerCapabilities, ToolsCapability, complete_modern_result, error_codes,
 };
 
 use crate::mcp_tool_list_builder::{assemble_full_tool_list, slice_tools_page};
@@ -59,7 +59,7 @@ impl StatelessMcpService {
         let meta = req.params.as_ref().and_then(|p| p.get("_meta")).cloned();
         let _request_meta = RequestMeta::from_value(meta.as_ref());
 
-        let response = match req.method.as_str() {
+        let mut response = match req.method.as_str() {
             "server/discover" => self.handle_discover(id),
             "ping" => json!({"jsonrpc": "2.0", "id": id, "result": {}}),
             "tools/list" => self.handle_tools_list(id, req).await,
@@ -72,6 +72,18 @@ impl StatelessMcpService {
                 serde_json::to_value(error).unwrap_or_else(|_| json!(null))
             }
         };
+        if let Some(result) = response.get_mut("result").and_then(Value::as_object_mut) {
+            let server_info = ServerInfo {
+                name: self.state.server_name.clone(),
+                version: self.state.server_version.clone(),
+            };
+            if let Err(message) = complete_modern_result(&req.method, result, &server_info) {
+                return Some(
+                    serde_json::to_value(JsonRpcResponse::internal_error(req.id.clone(), message))
+                        .unwrap_or(Value::Null),
+                );
+            }
+        }
         Some(response)
     }
 
@@ -81,17 +93,17 @@ impl StatelessMcpService {
     fn handle_discover(&self, id: Value) -> Value {
         let caps = self.build_stateless_capabilities();
         let result = DiscoverResult {
-            protocol_version: MCP_PROTOCOL_VERSION_2026_07_28.to_string(),
-            server_info: ServerInfo {
-                name: self.state.server_name.clone(),
-                version: self.state.server_version.clone(),
-            },
+            supported_versions: SUPPORTED_PROTOCOL_VERSIONS
+                .iter()
+                .map(|v| (*v).to_string())
+                .collect(),
             capabilities: caps,
             instructions: Some(
                 "Direct DCC workflow: search_tools(query) → load_skill → tools/call. \
                  tools/list is paginated; follow nextCursor if you list it."
                     .to_string(),
             ),
+            ..Default::default()
         };
         let result_value =
             serde_json::to_value(result).unwrap_or_else(|_| json!({"error": "serialize_failed"}));
@@ -224,6 +236,7 @@ mod tests {
     use std::sync::Arc;
 
     use dcc_mcp_actions::{ToolDispatcher, ToolRegistry};
+    use dcc_mcp_jsonrpc::{MCP_PROTOCOL_VERSION_2026_07_28, SERVER_INFO_META_KEY};
     use dcc_mcp_skill_rest::StaticReadiness;
     use dcc_mcp_skills::SkillCatalog;
     use serde_json::json;
@@ -263,8 +276,19 @@ mod tests {
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 1);
         let result = &resp["result"];
-        assert_eq!(result["protocolVersion"], MCP_PROTOCOL_VERSION_2026_07_28);
-        assert_eq!(result["serverInfo"]["name"], "dcc-mcp-http");
+        assert_eq!(
+            result["supportedVersions"][0],
+            MCP_PROTOCOL_VERSION_2026_07_28
+        );
+        assert_eq!(
+            result["_meta"][SERVER_INFO_META_KEY]["name"],
+            "dcc-mcp-http"
+        );
+        assert!(result.get("protocolVersion").is_none());
+        assert!(result.get("serverInfo").is_none());
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(result["ttlMs"], 0);
+        assert_eq!(result["cacheScope"], "private");
         assert!(result["capabilities"]["tools"].is_object());
         assert!(result["capabilities"].get("tasks").is_none());
         assert!(result["instructions"].is_string());
@@ -349,7 +373,10 @@ mod tests {
         let req = make_request("ping", json!(4), None);
         let resp = svc.handle_request(&req).await.expect("has id");
 
-        assert_eq!(resp["result"], json!({}));
+        assert_eq!(resp["result"]["resultType"], "complete");
+        assert!(resp["result"]["_meta"][SERVER_INFO_META_KEY].is_object());
+        assert!(resp["result"].get("ttlMs").is_none());
+        assert!(resp["result"].get("cacheScope").is_none());
     }
 
     #[tokio::test]
@@ -387,5 +414,8 @@ mod tests {
         // for unknown tools rather than Err.
         let result = &resp["result"];
         assert_eq!(result["isError"], true);
+        assert_eq!(result["resultType"], "complete");
+        assert!(result["_meta"][SERVER_INFO_META_KEY].is_object());
+        assert!(result.get("ttlMs").is_none());
     }
 }

--- a/crates/dcc-mcp-http/tests/stateless_response_contract.rs
+++ b/crates/dcc-mcp-http/tests/stateless_response_contract.rs
@@ -1,0 +1,120 @@
+//! Modern response projection over HTTP, independent of request validation work.
+
+#![cfg(feature = "mcp-2026-07-28")]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dcc_mcp_actions::ToolRegistry;
+use dcc_mcp_http::{McpHttpConfig, McpHttpServer};
+use dcc_mcp_jsonrpc::{JsonRpcRequestBuilder, SERVER_INFO_META_KEY};
+use serde_json::{Value, json};
+
+async fn modern_request(
+    client: &reqwest::Client,
+    url: &str,
+    method: &str,
+    mut params: Value,
+) -> Value {
+    params["_meta"] = json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {"name": "response-contract", "version": "1"},
+        "io.modelcontextprotocol/clientCapabilities": {}
+    });
+    let mut request = client
+        .post(url)
+        .header("Accept", "application/json, text/event-stream")
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", method);
+    if let Some(name) = params.get("name").and_then(Value::as_str) {
+        request = request.header("Mcp-Name", name);
+    }
+    let response = request
+        .json(
+            &JsonRpcRequestBuilder::new(method, method)
+                .with_params(params)
+                .to_value(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert!(response.headers().get("Mcp-Session-Id").is_none());
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["id"], method);
+    body
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_list_call_and_errors_use_the_modern_response_boundary() {
+    let mut config = McpHttpConfig::default();
+    config.server.port = 0;
+    config.gateway.gateway_port = 0;
+    let handle = McpHttpServer::new(Arc::new(ToolRegistry::new()), config)
+        .start()
+        .await
+        .unwrap();
+    let url = format!("http://127.0.0.1:{}/mcp", handle.port);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    for (method, params, cacheable) in [
+        ("server/discover", json!({}), true),
+        ("tools/list", json!({}), true),
+        (
+            "tools/call",
+            json!({"name": "search_tools", "arguments": {"query": "scene"}}),
+            false,
+        ),
+        ("ping", json!({}), false),
+    ] {
+        let body = modern_request(&client, &url, method, params).await;
+        assert!(body.get("error").is_none(), "{body}");
+        let result = &body["result"];
+        assert_eq!(result["resultType"], "complete");
+        assert!(result["_meta"][SERVER_INFO_META_KEY]["name"].is_string());
+        assert!(result["_meta"][SERVER_INFO_META_KEY]["version"].is_string());
+        if cacheable {
+            assert_eq!(result["ttlMs"], 0);
+            assert_eq!(result["cacheScope"], "private");
+        } else {
+            assert!(result.get("ttlMs").is_none());
+            assert!(result.get("cacheScope").is_none());
+        }
+        if method == "server/discover" {
+            assert_eq!(result["supportedVersions"][0], "2026-07-28");
+            assert!(result.get("serverInfo").is_none());
+            assert!(result.get("protocolVersion").is_none());
+        } else if method == "tools/call" {
+            assert_ne!(result["isError"], true, "{result}");
+            assert!(result["content"].is_array());
+        }
+    }
+    let error = modern_request(&client, &url, "tools/call", json!({"arguments": {}})).await;
+    assert_eq!(error["error"]["code"], -32602);
+    assert!(error.get("result").is_none());
+    assert!(error.get("resultType").is_none());
+
+    // Optional real SDK check against this exact build, never an installed wheel.
+    // Install tests/interop/mcp-2026 dependencies, then set DCC_MCP_SDK_SMOKE=1.
+    if std::env::var_os("DCC_MCP_SDK_SMOKE").is_some() {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/interop/mcp-2026/client.mjs");
+        let output = std::process::Command::new("node")
+            .arg(script)
+            .arg(&url)
+            .output()
+            .expect("run pinned official SDK");
+        assert!(
+            output.status.success(),
+            "SDK stdout: {}\nSDK stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+    }
+
+    handle.shutdown().await;
+}

--- a/crates/dcc-mcp-http/tests/stateless_response_contract.rs
+++ b/crates/dcc-mcp-http/tests/stateless_response_contract.rs
@@ -84,7 +84,7 @@ async fn discover_list_call_and_errors_use_the_modern_response_boundary() {
             assert!(result.get("cacheScope").is_none());
         }
         if method == "server/discover" {
-            assert_eq!(result["supportedVersions"][0], "2026-07-28");
+            assert_eq!(result["supportedVersions"], json!(["2026-07-28"]));
             assert!(result.get("serverInfo").is_none());
             assert!(result.get("protocolVersion").is_none());
         } else if method == "tools/call" {

--- a/crates/dcc-mcp-jsonrpc/src/discover.rs
+++ b/crates/dcc-mcp-jsonrpc/src/discover.rs
@@ -9,77 +9,39 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::modern::{CacheScope, CompleteResultType};
+
+// Keep the historical public names without maintaining duplicate wire types.
+pub use crate::lifecycle::{
+    PromptsCapability as Discover2026PromptsCapability,
+    ResourcesCapability as Discover2026ResourcesCapability, ServerInfo as DiscoverServerInfo,
+    StatelessServerCapabilities as DiscoverCapabilities,
+    ToolsCapability as Discover2026ToolsCapability,
+};
+
 /// Result payload for `server/discover` (MCP 2026-07-28).
 ///
 /// Returned verbatim as the `result` field of a JSON-RPC 2.0 response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-pub struct ServerDiscoverResult {
-    /// Protocol version the server will use for this request.
-    pub protocol_version: String,
-    pub server_info: DiscoverServerInfo,
+pub struct DiscoverResult {
+    /// Protocol versions supported by this endpoint, newest first.
+    pub supported_versions: Vec<String>,
     pub capabilities: DiscoverCapabilities,
     /// Optional natural-language instructions for MCP clients / agents.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Discovery always returns a complete result, never an input request.
+    pub result_type: CompleteResultType,
+    /// Conservative defaults do not permit stale cross-principal discovery.
+    pub ttl_ms: u64,
+    pub cache_scope: CacheScope,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<serde_json::Map<String, Value>>,
 }
 
-/// Abbreviated `serverInfo` block (name + version), same shape as the 2025 spec.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DiscoverServerInfo {
-    pub name: String,
-    pub version: String,
-}
-
-/// 2026-07-28 capabilities block.
-///
-/// The structure is intentionally a superset of the 2025-06-18 `ServerCapabilities`
-/// so that new fields can be added without breaking old deserializers. Fields that
-/// existed in older specs (`tools`, `resources`, `prompts`, `logging`) keep the
-/// same JSON key names; new fields (`tasks`, `tracing`, `caching`) are additions.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct DiscoverCapabilities {
-    /// Tools capability (unchanged from 2025 spec).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Discover2026ToolsCapability>,
-    /// Resources capability (unchanged from 2025 spec).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resources: Option<Discover2026ResourcesCapability>,
-    /// Prompts capability (unchanged from 2025 spec).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompts: Option<Discover2026PromptsCapability>,
-    /// Tasks — first-class in 2026-07-28 (SEP-2663).
-    ///
-    /// Present when the server supports `tasks/get` and `tasks/cancel`.
-    /// `tasks/list` was removed from the spec; do **not** advertise it.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tasks: Option<TasksCapability>,
-    /// Vendor-extension capabilities.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub experimental: Option<Value>,
-}
-
-/// `tools` capability for 2026-07-28 sessions (same shape as 2025 `ToolsCapability`).
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct Discover2026ToolsCapability {
-    pub list_changed: bool,
-}
-
-/// `resources` capability for 2026-07-28 sessions.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct Discover2026ResourcesCapability {
-    pub subscribe: bool,
-    pub list_changed: bool,
-}
-
-/// `prompts` capability for 2026-07-28 sessions.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct Discover2026PromptsCapability {
-    pub list_changed: bool,
-}
+/// Compatibility name for the single canonical final-revision discovery type.
+pub type ServerDiscoverResult = DiscoverResult;
 
 /// `tasks` capability — new in MCP 2026-07-28, SEP-2663.
 ///
@@ -139,11 +101,7 @@ mod tests {
     #[test]
     fn server_discover_result_serialises_to_camel_case() {
         let result = ServerDiscoverResult {
-            protocol_version: "2026-07-28".to_string(),
-            server_info: DiscoverServerInfo {
-                name: "dcc-mcp-core".to_string(),
-                version: "0.19.0".to_string(),
-            },
+            supported_versions: vec!["2026-07-28".to_string()],
             capabilities: DiscoverCapabilities {
                 tools: Some(Discover2026ToolsCapability { list_changed: true }),
                 resources: Some(Discover2026ResourcesCapability {
@@ -155,17 +113,22 @@ mod tests {
                 experimental: None,
             },
             instructions: Some("Direct DCC workflow".to_string()),
+            ..Default::default()
         };
 
         let json = serde_json::to_value(&result).unwrap();
 
         // Top-level keys must be camelCase.
         assert!(
-            json.get("protocolVersion").is_some(),
-            "expected protocolVersion, got: {json}"
+            json.get("supportedVersions").is_some(),
+            "expected supportedVersions, got: {json}"
         );
-        assert_eq!(json["protocolVersion"], "2026-07-28");
-        assert!(json.get("serverInfo").is_some(), "expected serverInfo");
+        assert_eq!(json["supportedVersions"], json!(["2026-07-28"]));
+        assert!(json.get("protocolVersion").is_none());
+        assert!(json.get("serverInfo").is_none());
+        assert_eq!(json["resultType"], "complete");
+        assert_eq!(json["ttlMs"], 0);
+        assert_eq!(json["cacheScope"], "private");
         assert!(json.get("capabilities").is_some(), "expected capabilities");
         assert!(json.get("instructions").is_some(), "expected instructions");
 
@@ -179,13 +142,10 @@ mod tests {
     #[test]
     fn server_discover_result_optional_fields_omitted_when_none() {
         let result = ServerDiscoverResult {
-            protocol_version: "2026-07-28".to_string(),
-            server_info: DiscoverServerInfo {
-                name: "test".to_string(),
-                version: "0.0.1".to_string(),
-            },
+            supported_versions: vec!["2026-07-28".to_string()],
             capabilities: DiscoverCapabilities::default(),
             instructions: None,
+            ..Default::default()
         };
 
         let json = serde_json::to_value(&result).unwrap();
@@ -202,11 +162,7 @@ mod tests {
     #[test]
     fn server_discover_result_roundtrip() {
         let original = ServerDiscoverResult {
-            protocol_version: "2026-07-28".to_string(),
-            server_info: DiscoverServerInfo {
-                name: "dcc-mcp-core".to_string(),
-                version: "0.19.0".to_string(),
-            },
+            supported_versions: vec!["2026-07-28".to_string()],
             capabilities: DiscoverCapabilities {
                 tools: Some(Discover2026ToolsCapability { list_changed: true }),
                 resources: None,
@@ -215,11 +171,12 @@ mod tests {
                 experimental: Some(json!({"dcc-mcp": {"compactResponses": true}})),
             },
             instructions: None,
+            ..Default::default()
         };
         let json_str = serde_json::to_string(&original).unwrap();
         let recovered: ServerDiscoverResult = serde_json::from_str(&json_str).unwrap();
-        assert_eq!(recovered.protocol_version, original.protocol_version);
-        assert_eq!(recovered.server_info.name, original.server_info.name);
+        assert_eq!(recovered.supported_versions, original.supported_versions);
+        assert_eq!(recovered.result_type, CompleteResultType::Complete);
         assert!(recovered.capabilities.tools.is_some());
         assert!(recovered.capabilities.tasks.is_some());
         assert!(recovered.capabilities.resources.is_none());

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -92,6 +92,16 @@ pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-06-18", "
 #[cfg(not(feature = "mcp-2026-07-28"))]
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26"];
 
+/// Modern protocol versions advertised by `server/discover`, newest first.
+///
+/// Discovery must never advertise a legacy `initialize` revision. An opt-out
+/// build has no modern protocol support to advertise.
+#[cfg(feature = "mcp-2026-07-28")]
+pub const SUPPORTED_MODERN_PROTOCOL_VERSIONS: &[&str] = &[MCP_PROTOCOL_VERSION_2026_07_28];
+
+#[cfg(not(feature = "mcp-2026-07-28"))]
+pub const SUPPORTED_MODERN_PROTOCOL_VERSIONS: &[&str] = &[];
+
 /// Legacy (session-based) protocol versions (2025-x and earlier).
 ///
 /// Used by [`select_protocol_mode`] for routing and by

--- a/crates/dcc-mcp-jsonrpc/src/lib.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lib.rs
@@ -30,6 +30,7 @@
 mod discover;
 mod jsonrpc;
 mod lifecycle;
+mod modern;
 mod notification_builder;
 mod prompts;
 mod resources;
@@ -50,6 +51,10 @@ pub use lifecycle::{
     ElicitationCreateParams, ElicitationCreateResult, InitializeParams, InitializeResult,
     LoggingCapability, LoggingSetLevelParams, PromptsCapability, ResourcesCapability,
     RootsListResult, ServerCapabilities, ServerInfo, StatelessServerCapabilities, ToolsCapability,
+};
+pub use modern::{
+    CACHEABLE_RESULT_METHODS, CacheScope, CompleteResultType, SERVER_INFO_META_KEY,
+    complete_modern_result,
 };
 pub use notification_builder::{JsonRpcRequestBuilder, NotificationBuilder};
 pub use prompts::{

--- a/crates/dcc-mcp-jsonrpc/src/lifecycle.rs
+++ b/crates/dcc-mcp-jsonrpc/src/lifecycle.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-pub use crate::discover::TasksCapability;
+pub use crate::discover::{DiscoverResult, TasksCapability};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -80,20 +80,20 @@ pub struct ServerCapabilities {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct ToolsCapability {
     pub list_changed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct ResourcesCapability {
     pub subscribe: bool,
     pub list_changed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", default)]
 pub struct PromptsCapability {
     pub list_changed: bool,
 }
@@ -156,23 +156,4 @@ pub struct StatelessServerCapabilities {
     /// Vendor-extension capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<serde_json::Value>,
-}
-
-/// Result payload for `server/discover` (MCP 2026-07-28, SEP-2575).
-///
-/// Replaces `initialize` in the 2026-07-28 stateless protocol.  Every
-/// request is self-contained (no session), so the client calls
-/// `server/discover` once (or caches the result) to learn server capabilities.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DiscoverResult {
-    /// The protocol version this server is speaking (`"2026-07-28"`).
-    pub protocol_version: String,
-    /// Server name and version.
-    pub server_info: ServerInfo,
-    /// Server capabilities under the 2026-07-28 model.
-    pub capabilities: StatelessServerCapabilities,
-    /// Optional human-readable workflow hint for AI agents.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub instructions: Option<String>,
 }

--- a/crates/dcc-mcp-jsonrpc/src/modern.rs
+++ b/crates/dcc-mcp-jsonrpc/src/modern.rs
@@ -1,0 +1,82 @@
+//! Final MCP 2026-07-28 result encoding, separate from legacy wire models.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+use crate::ServerInfo;
+
+pub const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+
+/// Closed set of final-revision `CacheableResult` methods (SEP-2549).
+pub const CACHEABLE_RESULT_METHODS: &[&str] = &[
+    "server/discover",
+    "tools/list",
+    "prompts/list",
+    "resources/list",
+    "resources/templates/list",
+    "resources/read",
+];
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompleteResultType {
+    #[default]
+    Complete,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheScope {
+    Public,
+    #[default]
+    Private,
+}
+
+/// Complete a modern result without changing business content or vendor metadata.
+///
+/// Call only at a modern success-response boundary, never for JSON-RPC errors
+/// or legacy responses. A tool's `isError: true` is still a completed result.
+/// This codec does not implement multi-round-trip input requests; reject a
+/// different result kind rather than incorrectly reporting it as complete.
+/// Valid handler-authored cache hints and server identity take precedence.
+pub fn complete_modern_result(
+    method: &str,
+    result: &mut Map<String, Value>,
+    server_info: &ServerInfo,
+) -> Result<(), &'static str> {
+    if result
+        .get("resultType")
+        .is_some_and(|kind| kind != "complete")
+    {
+        return Err("Unsupported modern result type");
+    }
+    if result.get("_meta").is_some_and(|meta| !meta.is_object()) {
+        return Err("Modern result metadata must be an object");
+    }
+
+    result.insert(
+        "resultType".to_string(),
+        json!(CompleteResultType::Complete),
+    );
+    if CACHEABLE_RESULT_METHODS.contains(&method) {
+        // JSON clients cannot safely represent integers outside this range.
+        const MAX_SAFE_INTEGER: u64 = (1_u64 << 53) - 1;
+        let ttl_ms = result
+            .get("ttlMs")
+            .and_then(Value::as_u64)
+            .filter(|value| *value <= MAX_SAFE_INTEGER)
+            .unwrap_or(0);
+        let scope = match result.get("cacheScope").and_then(Value::as_str) {
+            Some("public") => CacheScope::Public,
+            _ => CacheScope::Private,
+        };
+        result.insert("ttlMs".to_string(), json!(ttl_ms));
+        result.insert("cacheScope".to_string(), json!(scope));
+    }
+    let meta = result.entry("_meta").or_insert_with(|| json!({}));
+    if let Some(meta) = meta.as_object_mut() {
+        meta.entry(SERVER_INFO_META_KEY)
+            .or_insert_with(|| json!(server_info));
+    }
+    Ok(())
+}

--- a/crates/dcc-mcp-jsonrpc/src/modern.rs
+++ b/crates/dcc-mcp-jsonrpc/src/modern.rs
@@ -39,6 +39,8 @@ pub enum CacheScope {
 /// This codec does not implement multi-round-trip input requests; reject a
 /// different result kind rather than incorrectly reporting it as complete.
 /// Valid handler-authored cache hints and server identity take precedence.
+/// Missing or malformed identity falls back to the configured server without
+/// changing the completed business result or unrelated vendor metadata.
 pub fn complete_modern_result(
     method: &str,
     result: &mut Map<String, Value>,
@@ -75,8 +77,12 @@ pub fn complete_modern_result(
     }
     let meta = result.entry("_meta").or_insert_with(|| json!({}));
     if let Some(meta) = meta.as_object_mut() {
-        meta.entry(SERVER_INFO_META_KEY)
-            .or_insert_with(|| json!(server_info));
+        let valid_identity = meta
+            .get(SERVER_INFO_META_KEY)
+            .is_some_and(|value| serde_json::from_value::<ServerInfo>(value.clone()).is_ok());
+        if !valid_identity {
+            meta.insert(SERVER_INFO_META_KEY.to_string(), json!(server_info));
+        }
     }
     Ok(())
 }

--- a/crates/dcc-mcp-jsonrpc/tests/fixtures/modern_discover_response.json
+++ b/crates/dcc-mcp-jsonrpc/tests/fixtures/modern_discover_response.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "id": "discover-1",
+  "result": {
+    "resultType": "complete",
+    "supportedVersions": ["2026-07-28"],
+    "capabilities": {
+      "tools": {},
+      "resources": {}
+    },
+    "_meta": {
+      "io.modelcontextprotocol/serverInfo": {
+        "name": "ExampleServer",
+        "version": "1.0.0"
+      }
+    },
+    "ttlMs": 3600000,
+    "cacheScope": "public"
+  }
+}

--- a/crates/dcc-mcp-jsonrpc/tests/modern_response_contract.rs
+++ b/crates/dcc-mcp-jsonrpc/tests/modern_response_contract.rs
@@ -2,7 +2,8 @@
 
 use dcc_mcp_jsonrpc::{
     CACHEABLE_RESULT_METHODS, DiscoverResult, InitializeResult, SERVER_INFO_META_KEY,
-    ServerCapabilities, ServerDiscoverResult, ServerInfo, complete_modern_result,
+    SUPPORTED_MODERN_PROTOCOL_VERSIONS, ServerCapabilities, ServerDiscoverResult, ServerInfo,
+    complete_modern_result,
 };
 use serde_json::{Value, json};
 
@@ -16,6 +17,14 @@ fn identity() -> ServerInfo {
 fn stamp(method: &str, mut result: Value) -> Value {
     complete_modern_result(method, result.as_object_mut().unwrap(), &identity()).unwrap();
     result
+}
+
+#[test]
+fn modern_versions_match_compiled_support_without_legacy_revisions() {
+    #[cfg(feature = "mcp-2026-07-28")]
+    assert_eq!(SUPPORTED_MODERN_PROTOCOL_VERSIONS, &["2026-07-28"]);
+    #[cfg(not(feature = "mcp-2026-07-28"))]
+    assert!(SUPPORTED_MODERN_PROTOCOL_VERSIONS.is_empty());
 }
 
 #[test]
@@ -90,13 +99,40 @@ fn business_payload_and_authored_metadata_are_preserved() {
             "content": [{"type": "text", "text": "readback"}],
             "structuredContent": {"host": "blender", "value": 3},
             "isError": is_error,
-            "_meta": {"dcc.next_tools": ["inspect"], SERVER_INFO_META_KEY: {"name": "adapter", "version": "2"}}
+            "_meta": {"dcc.next_tools": ["inspect"], SERVER_INFO_META_KEY: {"name": "adapter", "version": "2", "title": "Adapter identity"}}
         });
         let stamped = stamp("tools/call", original.clone());
         for field in ["content", "structuredContent", "isError", "_meta"] {
             assert_eq!(stamped[field], original[field]);
         }
         assert_eq!(stamped["resultType"], "complete");
+    }
+}
+
+#[test]
+fn malformed_authored_identity_uses_configured_identity_without_losing_payload() {
+    for invalid in [
+        json!(null),
+        json!(false),
+        json!("adapter"),
+        json!([]),
+        json!({}),
+        json!({"name": "adapter"}),
+        json!({"name": 3, "version": "2"}),
+    ] {
+        let result = stamp(
+            "tools/call",
+            json!({
+                "content": [{"type": "text", "text": "completed"}],
+                "isError": false,
+                "_meta": {"dcc.readback": true, SERVER_INFO_META_KEY: invalid}
+            }),
+        );
+        assert_eq!(result["_meta"][SERVER_INFO_META_KEY], json!(identity()));
+        assert_eq!(result["_meta"]["dcc.readback"], true);
+        assert_eq!(result["content"][0]["text"], "completed");
+        assert_eq!(result["isError"], false);
+        assert_eq!(result["resultType"], "complete");
     }
 }
 

--- a/crates/dcc-mcp-jsonrpc/tests/modern_response_contract.rs
+++ b/crates/dcc-mcp-jsonrpc/tests/modern_response_contract.rs
@@ -1,0 +1,158 @@
+//! Focused final-revision response checks; not a full protocol conformance suite.
+
+use dcc_mcp_jsonrpc::{
+    CACHEABLE_RESULT_METHODS, DiscoverResult, InitializeResult, SERVER_INFO_META_KEY,
+    ServerCapabilities, ServerDiscoverResult, ServerInfo, complete_modern_result,
+};
+use serde_json::{Value, json};
+
+fn identity() -> ServerInfo {
+    ServerInfo {
+        name: "dcc-mcp-test".into(),
+        version: "1".into(),
+    }
+}
+
+fn stamp(method: &str, mut result: Value) -> Value {
+    complete_modern_result(method, result.as_object_mut().unwrap(), &identity()).unwrap();
+    result
+}
+
+#[test]
+fn official_discovery_fixture_uses_the_single_canonical_type() {
+    // Official SDK commit 5119ee7fd7790e335a3fb60ef36f85334e2a6326:
+    // packages/core-internal/test/corpus/fixtures/2026-07-28/
+    // DiscoverResultResponse/discover-result-response.json
+    let fixture: Value =
+        serde_json::from_str(include_str!("fixtures/modern_discover_response.json")).unwrap();
+    let result: DiscoverResult = serde_json::from_value(fixture["result"].clone()).unwrap();
+    let alias: ServerDiscoverResult = result;
+    let encoded = serde_json::to_value(alias).unwrap();
+    for field in [
+        "supportedVersions",
+        "resultType",
+        "ttlMs",
+        "cacheScope",
+        "_meta",
+    ] {
+        assert_eq!(encoded[field], fixture["result"][field], "{field}");
+    }
+    assert!(encoded.get("serverInfo").is_none());
+    assert!(encoded.get("protocolVersion").is_none());
+    for required in ["supportedVersions", "resultType", "ttlMs", "cacheScope"] {
+        let mut invalid = fixture["result"].clone();
+        invalid.as_object_mut().unwrap().remove(required);
+        assert!(
+            serde_json::from_value::<DiscoverResult>(invalid).is_err(),
+            "{required}"
+        );
+    }
+}
+
+#[test]
+fn modern_cache_fill_is_a_closed_method_set() {
+    assert_eq!(CACHEABLE_RESULT_METHODS.len(), 6);
+    for method in [
+        "server/discover",
+        "tools/list",
+        "prompts/list",
+        "resources/list",
+        "resources/templates/list",
+        "resources/read",
+    ] {
+        let result = stamp(method, json!({}));
+        assert_eq!(result["resultType"], "complete", "{method}");
+        assert_eq!(result["ttlMs"], 0, "{method}");
+        assert_eq!(result["cacheScope"], "private", "{method}");
+        assert_eq!(
+            result["_meta"][SERVER_INFO_META_KEY]["name"],
+            "dcc-mcp-test"
+        );
+    }
+    for method in [
+        "tools/call",
+        "prompts/get",
+        "ping",
+        "completion/complete",
+        "custom/read",
+    ] {
+        let result = stamp(method, json!({}));
+        assert_eq!(result["resultType"], "complete");
+        assert!(result.get("ttlMs").is_none(), "{method}");
+        assert!(result.get("cacheScope").is_none(), "{method}");
+    }
+}
+
+#[test]
+fn business_payload_and_authored_metadata_are_preserved() {
+    for is_error in [false, true] {
+        let original = json!({
+            "content": [{"type": "text", "text": "readback"}],
+            "structuredContent": {"host": "blender", "value": 3},
+            "isError": is_error,
+            "_meta": {"dcc.next_tools": ["inspect"], SERVER_INFO_META_KEY: {"name": "adapter", "version": "2"}}
+        });
+        let stamped = stamp("tools/call", original.clone());
+        for field in ["content", "structuredContent", "isError", "_meta"] {
+            assert_eq!(stamped[field], original[field]);
+        }
+        assert_eq!(stamped["resultType"], "complete");
+    }
+}
+
+#[test]
+fn cache_hints_preserve_valid_values_and_default_invalid_values() {
+    let hinted = stamp(
+        "resources/read",
+        json!({"ttlMs": 125, "cacheScope": "public"}),
+    );
+    assert_eq!(hinted["ttlMs"], 125);
+    assert_eq!(hinted["cacheScope"], "public");
+    for invalid in [
+        json!(-1),
+        json!(1.5),
+        json!("1000"),
+        json!(null),
+        json!(true),
+        json!(9007199254740992_u64),
+    ] {
+        let stamped = stamp(
+            "resources/read",
+            json!({"ttlMs": invalid, "cacheScope": "shared"}),
+        );
+        assert_eq!(stamped["ttlMs"], 0);
+        assert_eq!(stamped["cacheScope"], "private");
+    }
+}
+
+#[test]
+fn unsupported_result_kinds_and_malformed_metadata_fail_before_changes() {
+    for mut result in [
+        json!({"resultType": "input_required", "requestState": "opaque"}),
+        json!({"_meta": false}),
+    ] {
+        let before = result.clone();
+        assert!(
+            complete_modern_result("tools/call", result.as_object_mut().unwrap(), &identity())
+                .is_err()
+        );
+        assert_eq!(result, before);
+    }
+}
+
+#[test]
+fn legacy_initialize_serialization_has_no_modern_result_fields() {
+    let result = InitializeResult {
+        protocol_version: "2025-06-18".into(),
+        capabilities: ServerCapabilities::default(),
+        server_info: identity(),
+        instructions: None,
+    };
+    assert_eq!(
+        serde_json::to_value(result).unwrap(),
+        json!({
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "serverInfo": {"name": "dcc-mcp-test", "version": "1"}
+        })
+    );
+}

--- a/docs/adr/034-modern-response-contract.md
+++ b/docs/adr/034-modern-response-contract.md
@@ -1,0 +1,44 @@
+# ADR-034: Final-revision modern response projection
+
+Status: Proposed
+
+## Decision
+
+Keep MCP 2026-07-28 response encoding in one transport-neutral codec, applied
+once at the stateless service's result boundary. The legacy serializer and
+`initialize` behavior are unchanged. Business handlers continue returning
+their existing content, structured content, and vendor metadata.
+
+`DiscoverResult` is the single canonical discovery type. The historical
+`ServerDiscoverResult` export is an alias, not a second schema. Rust callers
+constructing the former RC shape must migrate `protocol_version` to
+`supported_versions` and move `server_info` into result metadata. The final
+wire result carries `supportedVersions`, `resultType`, `ttlMs`, `cacheScope`,
+and optional `_meta`; it does not emit RC `protocolVersion` or `serverInfo`.
+
+The modern codec stamps `resultType: complete` and the server identity under
+`_meta["io.modelcontextprotocol/serverInfo"]`. Existing handler-authored
+identity and vendor metadata are retained. A different result kind fails
+closed; this change does not implement multi-round-trip input requests.
+JSON-RPC error responses are not success results and bypass the codec.
+
+Only discovery, tool/prompt/resource lists, resource-template lists, and
+resource reads receive default cache fields (`ttlMs: 0`, `cacheScope:
+private`). Valid authored hints take precedence; invalid hints fall back
+conservatively. No positive TTL or shared authorization-context cache is
+enabled by default.
+
+## Validation and boundaries
+
+Pure codec tests pin the closed method set, final discovery fixture,
+metadata preservation, malformed-result rejection, and unchanged legacy
+serialization. HTTP and opt-in official SDK 2.0.0 smoke tests cover discovery,
+list, and call with auto and pinned modern negotiation.
+
+This addresses the response portion of #2436, not full protocol conformance.
+The request-routing decision in ADR-033, envelope/header validation, standard
+errors, and parameter-header support remain separate follow-up work.
+Capability truthfulness and resource/prompt provider wiring are separate
+changes. No adapter execution, thread-affinity, or public Skill authoring
+contract changes are required; no agent-plugins Skill update is needed for
+this response-only correction.

--- a/docs/adr/034-modern-response-contract.md
+++ b/docs/adr/034-modern-response-contract.md
@@ -15,11 +15,16 @@ constructing the former RC shape must migrate `protocol_version` to
 `supported_versions` and move `server_info` into result metadata. The final
 wire result carries `supportedVersions`, `resultType`, `ttlMs`, `cacheScope`,
 and optional `_meta`; it does not emit RC `protocolVersion` or `serverInfo`.
+Discovery uses `SUPPORTED_MODERN_PROTOCOL_VERSIONS`, containing only compiled
+modern revisions, never legacy `initialize` versions. This follows the
+[official SDK era contract](https://github.com/modelcontextprotocol/typescript-sdk/blob/5119ee7fd7790e335a3fb60ef36f85334e2a6326/packages/core-internal/src/shared/protocolEras.ts).
 
 The modern codec stamps `resultType: complete` and the server identity under
-`_meta["io.modelcontextprotocol/serverInfo"]`. Existing handler-authored
-identity and vendor metadata are retained. A different result kind fails
-closed; this change does not implement multi-round-trip input requests.
+`_meta["io.modelcontextprotocol/serverInfo"]`. Valid handler-authored identity
+and vendor metadata are retained. Missing or malformed identity falls back to
+the configured server identity without losing a completed business result.
+A different result kind fails closed; this change does not implement
+multi-round-trip input requests.
 JSON-RPC error responses are not success results and bypass the codec.
 
 Only discovery, tool/prompt/resource lists, resource-template lists, and

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,8 @@ Decision / Consequences / Alternatives considered.
 | 030 | [Preserve Published Crate Identities Across Boundary Cleanup](./030-preserve-published-crate-identities.md) | Accepted |
 | 031 | [Python API Ownership and Compatibility Boundaries](./031-python-api-ownership.md) | Accepted |
 | 032 | [Keep Public Agent Skills in dcc-mcp-agent-plugins](./032-public-agent-skill-ownership.md) | Accepted |
+| 033 | [Explicit MCP HTTP protocol routing](./033-mcp-http-protocol-router.md) | Proposed |
+| 034 | [Final-revision modern response projection](./034-modern-response-contract.md) | Proposed |
 
 > Numbering is strictly sequential and never reused. ADR 001 is reserved for
 > the first historical record; filling it in is tracked separately from any

--- a/tests/interop/mcp-2026/.gitignore
+++ b/tests/interop/mcp-2026/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tests/interop/mcp-2026/README.md
+++ b/tests/interop/mcp-2026/README.md
@@ -1,0 +1,28 @@
+# MCP 2026 response interoperability
+
+This bounded smoke exercises `server/discover`, `tools/list`, and `tools/call`
+through the official `@modelcontextprotocol/client` **2.0.0**, using both auto
+negotiation and a `2026-07-28` pin. The Rust HTTP test owns the server and shuts
+it down; no installed wheel or live DCC is substituted.
+
+```sh
+npm ci --prefix tests/interop/mcp-2026 --ignore-scripts
+DCC_MCP_SDK_SMOKE=1 cargo test -p dcc-mcp-http --no-default-features \
+  --features mcp-2026-07-28 --test stateless_response_contract -- --nocapture
+```
+
+On PowerShell, set `$env:DCC_MCP_SDK_SMOKE = "1"` before the Cargo command.
+The Node subprocess is opt-in and has a 30-second deadline. The ordinary Rust
+test still checks the same raw HTTP result fields without Node dependencies.
+
+The upstream discovery fixture is pinned to official SDK source commit
+`5119ee7fd7790e335a3fb60ef36f85334e2a6326`, at
+`packages/core-internal/test/corpus/fixtures/2026-07-28/DiscoverResultResponse/discover-result-response.json`.
+The authoritative specification schema is pinned to
+`modelcontextprotocol/modelcontextprotocol` commit
+`e76e9c572c6f2bfcb730357101acc90f2f802e02`, at
+`schema/2026-07-28/schema.ts`.
+
+This is **not** a full conformance claim. Request-envelope validation,
+header/body consistency, standard errors, parameter header mirroring,
+subscriptions, and multi-round-trip execution require separate acceptance.

--- a/tests/interop/mcp-2026/client.mjs
+++ b/tests/interop/mcp-2026/client.mjs
@@ -15,7 +15,7 @@ try {
     try {
       await client.connect(transport);
       assert.equal(client.getProtocolEra(), 'modern');
-      assert.ok(client.getDiscoverResult().supportedVersions.includes('2026-07-28'));
+      assert.deepEqual(client.getDiscoverResult().supportedVersions, ['2026-07-28']);
       assert.equal(typeof client.getServerVersion().name, 'string');
       const tools = await client.listTools();
       assert.ok(tools.tools.some((tool) => tool.name === 'search_tools'));

--- a/tests/interop/mcp-2026/client.mjs
+++ b/tests/interop/mcp-2026/client.mjs
@@ -1,0 +1,32 @@
+// Focused response interoperability only, not full MCP 2026 conformance.
+import assert from 'node:assert/strict';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+
+const url = new URL(process.argv[2]);
+assert.equal(url.hostname, '127.0.0.1', 'smoke must use the test-owned loopback server');
+const deadline = setTimeout(() => { console.error('SDK smoke deadline exceeded'); process.exit(1); }, 30_000);
+try {
+  for (const mode of ['auto', { pin: '2026-07-28' }]) {
+    const client = new Client(
+      { name: 'dcc-response-contract', version: '1' },
+      { versionNegotiation: { mode } },
+    );
+    const transport = new StreamableHTTPClientTransport(url);
+    try {
+      await client.connect(transport);
+      assert.equal(client.getProtocolEra(), 'modern');
+      assert.ok(client.getDiscoverResult().supportedVersions.includes('2026-07-28'));
+      assert.equal(typeof client.getServerVersion().name, 'string');
+      const tools = await client.listTools();
+      assert.ok(tools.tools.some((tool) => tool.name === 'search_tools'));
+      const result = await client.callTool({ name: 'search_tools', arguments: { query: 'scene' } });
+      assert.notEqual(result.isError, true);
+      assert.ok(Array.isArray(result.content));
+      console.log(JSON.stringify({ mode, era: client.getProtocolEra(), discover: true, list: true, call: true }));
+    } finally {
+      await client.close();
+    }
+  }
+} finally {
+  clearTimeout(deadline);
+}

--- a/tests/interop/mcp-2026/package-lock.json
+++ b/tests/interop/mcp-2026/package-lock.json
@@ -1,0 +1,156 @@
+{
+  "name": "dcc-mcp-modern-response-interop",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dcc-mcp-modern-response-interop",
+      "dependencies": {
+        "@modelcontextprotocol/client": "2.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/tests/interop/mcp-2026/package.json
+++ b/tests/interop/mcp-2026/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dcc-mcp-modern-response-interop",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "smoke": "node client.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/client": "2.0.0"
+  }
+}

--- a/tests/test_mcp_modern_responses.py
+++ b/tests/test_mcp_modern_responses.py
@@ -1,0 +1,88 @@
+"""Final-revision response projection through the native Python HTTP binding."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+import pytest
+
+from dcc_mcp_core import McpHttpConfig
+from dcc_mcp_core import McpHttpServer
+from dcc_mcp_core import ToolRegistry
+
+
+@pytest.fixture(scope="module")
+def modern_response_server():
+    server = McpHttpServer(ToolRegistry(), McpHttpConfig(port=0))
+    with server.start() as handle:
+        yield handle.mcp_url()
+
+
+def _request(url, method, params):
+    params = dict(params)
+    params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {"name": "response-contract", "version": "1"},
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": method,
+    }
+    if "name" in params:
+        headers["Mcp-Name"] = params["name"]
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"jsonrpc": "2.0", "id": method, "method": method, "params": params}).encode(),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        assert response.status == 200
+        assert response.headers.get("Mcp-Session-Id") is None
+        body = json.loads(response.read())
+    assert body["id"] == method
+    return body
+
+
+@pytest.mark.parametrize(
+    ("method", "params", "cacheable"),
+    [
+        ("server/discover", {}, True),
+        ("tools/list", {}, True),
+        ("tools/call", {"name": "search_tools", "arguments": {"query": "blender scene"}}, False),
+        ("tools/call", {"name": "search_tools", "arguments": {"query": "maya scene"}}, False),
+        ("ping", {}, False),
+    ],
+)
+def test_modern_success_response_fields(modern_response_server, method, params, cacheable):
+    body = _request(modern_response_server, method, params)
+    assert "error" not in body
+    result = body["result"]
+    assert result["resultType"] == "complete"
+    identity = result["_meta"]["io.modelcontextprotocol/serverInfo"]
+    assert isinstance(identity["name"], str)
+    assert isinstance(identity["version"], str)
+    if cacheable:
+        assert result["ttlMs"] == 0
+        assert result["cacheScope"] == "private"
+    else:
+        assert "ttlMs" not in result
+        assert "cacheScope" not in result
+    if method == "server/discover":
+        assert result["supportedVersions"][0] == "2026-07-28"
+        assert "protocolVersion" not in result
+        assert "serverInfo" not in result
+    elif method == "tools/call":
+        assert result.get("isError") is not True
+        assert isinstance(result["content"], list)
+
+
+def test_json_rpc_errors_are_not_stamped_as_success(modern_response_server):
+    body = _request(modern_response_server, "tools/call", {"arguments": {}})
+    assert body["error"]["code"] == -32602
+    assert "result" not in body
+    assert "resultType" not in body

--- a/tests/test_mcp_modern_responses.py
+++ b/tests/test_mcp_modern_responses.py
@@ -73,7 +73,7 @@ def test_modern_success_response_fields(modern_response_server, method, params, 
         assert "ttlMs" not in result
         assert "cacheScope" not in result
     if method == "server/discover":
-        assert result["supportedVersions"][0] == "2026-07-28"
+        assert result["supportedVersions"] == ["2026-07-28"]
         assert "protocolVersion" not in result
         assert "serverInfo" not in result
     elif method == "tools/call":

--- a/tests/test_mcp_protocol_lifecycle.py
+++ b/tests/test_mcp_protocol_lifecycle.py
@@ -56,7 +56,9 @@ def test_headerless_initialize_stays_on_legacy_lifecycle(protocol_server, reques
 
 def test_explicit_stateless_header_uses_discover_not_initialize(protocol_server):
     response = _request(protocol_server, "server/discover", {}, "2026-07-28")
-    assert response["result"]["protocolVersion"] == "2026-07-28"
+    assert response["result"]["supportedVersions"] == ["2026-07-28"]
+    assert response["result"]["resultType"] == "complete"
+    assert "protocolVersion" not in response["result"]
     response = _request(
         protocol_server,
         "initialize",


### PR DESCRIPTION
## Summary
- Unify discovery on the final supportedVersions contract.
- Stamp modern resultType/server identity centrally and default cache hints only on six specified methods; preserve legacy serialization and business metadata.
- Add pinned official SDK 2.0.0 auto/pinned discovery-list-call smoke, fixture, raw HTTP, and Python-binding coverage.

## Validation
- Rust: 30 tests without the feature, 33 with it, 11 stateless tests, and 1 HTTP integration test passed.
- Official SDK auto and 2026-07-28 pin both passed against this build.
- Rust formatting and Python lint passed. Python-binding runtime tests await the PR wheel.

Refs #2436. Response batch only; request/header validation and parameter mirroring remain separate. No full protocol conformance claim.