### PR TITLE
test: stabilize gateway lifecycle fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "socket2",
  "sysinfo",
  "tempfile",
  "tokio",

--- a/crates/dcc-mcp-sidecar/Cargo.toml
+++ b/crates/dcc-mcp-sidecar/Cargo.toml
@@ -49,6 +49,7 @@ mdns = [
 prometheus = ["dcc-mcp-gateway?/prometheus"]
 
 [dev-dependencies]
+socket2.workspace = true
 tempfile.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 dcc-mcp-test-utils = { workspace = true }

--- a/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
+++ b/crates/dcc-mcp-sidecar/src/sidecar_gateway.rs
@@ -286,7 +286,119 @@ mod tests {
     use axum::Router;
     use axum::http::StatusCode;
     use axum::routing::get;
+    use axum::serve::ListenerExt;
     use dcc_mcp_transport::discovery::types::GATEWAY_SENTINEL_DCC_TYPE;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn spawn_gateway_fixture(
+        listener: tokio::net::TcpListener,
+        app: Router,
+        reset_on_close: bool,
+    ) -> (
+        tokio::sync::oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        // Model a crash/RST, not FIN/graceful TCP recovery. A server-first FIN
+        // leaves Linux TIME_WAIT behind and legitimately blocks the production
+        // election's exclusive bind, regardless of the test's wait budget.
+        let listener = listener.tap_io(move |stream| {
+            socket2::SockRef::from(&*stream)
+                .set_linger(reset_on_close.then_some(Duration::ZERO))
+                .unwrap();
+        });
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = stop_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        // Axum drains its spawned connection tasks before returning. Aborting
+        // only the listener task neither joins those tasks nor guarantees RST.
+        (stop_tx, server)
+    }
+
+    #[tokio::test]
+    async fn crash_fixture_releases_exclusive_port_with_keepalive_and_inflight_request() {
+        bind_after_fixture_shutdown(true).await.unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn fin_fixture_retains_exclusive_port_with_keepalive_and_inflight_request() {
+        // Negative control: removing RST from the otherwise identical fixture
+        // must reproduce the kernel-owned port that caused the CI timeout.
+        let error = bind_after_fixture_shutdown(false).await.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::AddrInUse);
+    }
+
+    async fn bind_after_fixture_shutdown(reset_on_close: bool) -> std::io::Result<()> {
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let entered_tx = Arc::new(tokio::sync::Mutex::new(Some(entered_tx)));
+        let release_rx = Arc::new(tokio::sync::Mutex::new(Some(release_rx)));
+        let app = Router::new()
+            .route("/idle", get(|| async { "ready" }))
+            .route(
+                "/inflight",
+                get(move || {
+                    let entered_tx = entered_tx.clone();
+                    let release_rx = release_rx.clone();
+                    async move {
+                        entered_tx.lock().await.take().unwrap().send(()).unwrap();
+                        release_rx.lock().await.take().unwrap().await.unwrap();
+                        "finished"
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (stop_tx, server) = spawn_gateway_fixture(listener, app, reset_on_close);
+
+        let mut idle = tokio::net::TcpStream::connect(addr).await.unwrap();
+        idle.write_all(b"GET /idle HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        while !response.ends_with(b"ready") {
+            let mut buffer = [0; 256];
+            let count = tokio::time::timeout(Duration::from_secs(2), idle.read(&mut buffer))
+                .await
+                .expect("fixture must answer the keep-alive request")
+                .unwrap();
+            assert_ne!(count, 0, "keep-alive response ended early");
+            response.extend_from_slice(&buffer[..count]);
+        }
+        let mut inflight = tokio::net::TcpStream::connect(addr).await.unwrap();
+        inflight
+            .write_all(b"GET /inflight HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), entered_rx)
+            .await
+            .expect("fixture must begin the in-flight request")
+            .unwrap();
+        stop_tx.send(()).unwrap();
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), server)
+            .await
+            .expect("fixture must drain accepted connection tasks")
+            .unwrap();
+
+        // Keep both clients alive until after shutdown to force server-first
+        // closure. Match gateway/bind.rs rather than a reuse-enabled listener.
+        let replacement =
+            socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None).unwrap();
+        replacement.set_reuse_address(false).unwrap();
+        #[cfg(unix)]
+        replacement.set_reuse_port(false).unwrap();
+        replacement.bind(&addr.into())?;
+        replacement.listen(128)?;
+        drop((idle, inflight));
+        Ok(())
+    }
 
     async fn probe_with_routes(health_status: StatusCode) -> bool {
         let app = Router::new()
@@ -388,9 +500,7 @@ mod tests {
                 }),
             )
             .route("/health", get(|| async { StatusCode::OK }));
-        let stale_server = tokio::spawn(async move {
-            axum::serve(stale_listener, stale_app).await.unwrap();
-        });
+        let (stale_stop, stale_server) = spawn_gateway_fixture(stale_listener, stale_app, true);
 
         let runner = Arc::new(
             GatewayRunner::new(GatewayConfig {
@@ -427,9 +537,18 @@ mod tests {
         );
 
         stale_readyz_seen.notified().await;
-        tokio::time::sleep(Duration::from_millis(25)).await;
-        stale_server.abort();
-        let _ = stale_server.await;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while failover.read().await.challenger_abort.is_none() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("unhealthy readiness must trigger election before the fixture exits");
+        stale_stop.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), stale_server)
+            .await
+            .expect("stale fixture must drain before election")
+            .unwrap();
 
         tokio::time::timeout(Duration::from_secs(15), async {
             loop {

--- a/tests/test_e2e_gateway_prompts_sse.py
+++ b/tests/test_e2e_gateway_prompts_sse.py
@@ -206,11 +206,6 @@ class TestGatewayPromptsListChangedSse:
             if subscriber.error is not None:
                 pytest.fail(f"SSE subscription failed: {subscriber.error!r}")
 
-            # Let the baseline prompts fingerprint settle (empty set) so
-            # the load-triggered transition isn't collapsed into any
-            # initial-state broadcast.
-            time.sleep(AGGREGATOR_TICK_S + 0.5)
-
             load_resp = _post_mcp(
                 gateway_url,
                 "tools/call",
@@ -257,14 +252,6 @@ class TestGatewayPromptsListChangedSse:
         """Symmetric unload path — a regression in only one direction must still be caught."""
         gateway_url = gateway_with_prompts_skill["gateway_url"]
 
-        # Precondition: load the skill so the fingerprint is non-empty.
-        pre = _post_mcp(
-            gateway_url,
-            "tools/call",
-            {"name": "load_skill", "arguments": {"skill_name": "maya-prompts-demo"}},
-        )
-        assert "result" in pre, f"precondition load_skill failed: {pre}"
-
         events: queue.Queue[dict] = queue.Queue()
         stop = threading.Event()
         subscriber = _SseSubscriber(gateway_url, events, stop)
@@ -274,7 +261,26 @@ class TestGatewayPromptsListChangedSse:
             if subscriber.error is not None:
                 pytest.fail(f"SSE subscription failed: {subscriber.error!r}")
 
-            time.sleep(AGGREGATOR_TICK_S + 0.5)
+            # Subscribe before loading and consume the actual load notification.
+            # A fixed sleep neither proves that the watcher sampled the loaded
+            # state nor prevents its delayed load event satisfying the unload
+            # assertion. The two transitions need separate observable evidence.
+            pre = _post_mcp(
+                gateway_url,
+                "tools/call",
+                {"name": "load_skill", "arguments": {"skill_name": "maya-prompts-demo"}},
+            )
+            assert "result" in pre, f"precondition load_skill failed: {pre}"
+            loaded = json.loads(pre["result"]["content"][0]["text"])
+            assert loaded.get("loaded") or loaded.get("newly_loaded"), loaded
+            load_notification = _drain_for_notification(
+                events,
+                "notifications/prompts/list_changed",
+                budget=SSE_NOTIFICATION_BUDGET_S,
+            )
+            assert load_notification is not None, "watcher did not observe the loaded prompt set before unload"
+            before_unload = _post_mcp(gateway_url, "prompts/list")
+            assert before_unload["result"]["prompts"], before_unload
 
             unload_resp = _post_mcp(
                 gateway_url,
@@ -292,6 +298,9 @@ class TestGatewayPromptsListChangedSse:
                 "gateway did not push notifications/prompts/list_changed within "
                 f"{SSE_NOTIFICATION_BUDGET_S}s after unload_skill"
             )
+            assert notif.get("jsonrpc") == "2.0"
+            after_unload = _post_mcp(gateway_url, "prompts/list")
+            assert after_unload["result"]["prompts"] == [], after_unload
         finally:
             stop.set()
             subscriber.join(timeout=1.0)

--- a/tests/test_inprocess_executor.py
+++ b/tests/test_inprocess_executor.py
@@ -3,7 +3,10 @@
 # Import built-in modules
 from __future__ import annotations
 
+from concurrent.futures import FIRST_COMPLETED
+from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait
 import importlib.util
 import os
 from pathlib import Path
@@ -315,51 +318,72 @@ def test_shutdown_stays_bounded_when_request_stop_blocks(
 
     (tmp_path / "_state.py").write_text(
         "stop_release = None\n"
+        "stop_started = None\n"
         "cleaned = None\n"
-        "def configure(stop_event, cleaned_event):\n"
-        "    global stop_release, cleaned\n"
-        "    stop_release, cleaned = stop_event, cleaned_event\n"
-        "def request_stop(): stop_release.wait(5)\n"
+        "def configure(stop_event, started_event, cleaned_event):\n"
+        "    global stop_release, stop_started, cleaned\n"
+        "    stop_release, stop_started, cleaned = stop_event, started_event, cleaned_event\n"
+        "def request_stop():\n"
+        "    stop_started.set()\n"
+        "    stop_release.wait(5)\n"
         "def cleanup(): cleaned.set()\n",
         encoding="utf-8",
     )
     script = _write_script(
         tmp_path,
         "from ._state import configure\n"
-        "def main(started, release, stop_release, cleaned):\n"
-        "    configure(stop_release, cleaned)\n"
-        "    started.set()\n"
+        "def main(ready, release, stop_release, stop_started, cleaned):\n"
+        "    configure(stop_release, stop_started, cleaned)\n"
+        "    ready.set_result(None)\n"
         "    release.wait(5)\n"
         "    return 'done'\n",
     )
-    started = threading.Event()
+    ready: Future[None] = Future()
     release = threading.Event()
     stop_release = threading.Event()
+    stop_started = threading.Event()
     cleaned = threading.Event()
     bridge = HostExecutionBridge()
     monkeypatch.setattr(inprocess_executor, "_SCRIPT_PACKAGE_CLEAR_TIMEOUT_SECS", 0.05)
 
-    with ThreadPoolExecutor(max_workers=1) as pool:
-        call = pool.submit(
-            bridge.execute_script,
-            str(script),
-            {
-                "started": started,
-                "release": release,
-                "stop_release": stop_release,
-                "cleaned": cleaned,
-            },
-        )
-        assert started.wait(1)
-        before = time.monotonic()
-        assert bridge.shutdown_script_execution() == 0
-        assert time.monotonic() - before < 0.5
+    # Cold imports and worker scheduling are setup, not the shutdown contract.
+    fixture_timeout = 5
+    try:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            call = pool.submit(
+                bridge.execute_script,
+                str(script),
+                {
+                    "ready": ready,
+                    "release": release,
+                    "stop_release": stop_release,
+                    "stop_started": stop_started,
+                    "cleaned": cleaned,
+                },
+            )
+            try:
+                completed, _ = wait((ready, call), timeout=fixture_timeout, return_when=FIRST_COMPLETED)
+                if call in completed:
+                    call.result()  # Surface import/worker errors instead of a readiness timeout.
+                    pytest.fail("script exited before the active-call shutdown check")
+                assert ready in completed, "script did not become ready before the setup deadline"
+                before = time.monotonic()
+                assert bridge.shutdown_script_execution() == 0
+                assert time.monotonic() - before < 0.5
+                assert stop_started.wait(fixture_timeout)
+                assert not call.done()
+                assert not cleaned.is_set()
 
-        release.set()
-        assert call.result(timeout=1) == "done"
-        assert not cleaned.is_set()
-        stop_release.set()
-        assert cleaned.wait(1)
+                release.set()
+                assert call.result(timeout=fixture_timeout) == "done"
+                assert not cleaned.is_set()
+                stop_release.set()
+                assert cleaned.wait(fixture_timeout)
+            finally:
+                release.set()
+                stop_release.set()
+    finally:
+        bridge.shutdown_script_execution()
 
 
 def test_run_skill_script_supports_single_dict_main(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Model stale gateway loss as crash/RST, drain Axum connection tasks, and verify keep-alive/in-flight cleanup with a Linux FIN negative control.
- Await observed prompt-load notifications before asserting the separate unload notification and empty-list readback.
- Keep production binding, election behavior, and notification deadlines unchanged. Consolidates #2448 so both shared fixture failures are verified together.

## Validation

- Failover parent: Linux Rust CI passed; seven focused tests and 60 repeated lifecycle runs passed locally.
- Prompt transition fixture: 20 repeated tests passed against the failover parent CI wheel with installed-native origin verification.
- Combined head: four prompt SSE tests passed against that same native artifact; exact-head full CI is required before merge.

Unblocks the shared gateway test failures seen in the protocol and lock-sync PRs. No live-DCC or full protocol conformance claim.