### PR TITLE
feat: add native Install SOP validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ version = "0.20.23"
 dependencies = [
  "dcc-mcp-naming",
  "dcc-mcp-pybridge",
+ "jsonschema",
  "pyo3",
  "pyo3-stub-gen",
  "pyo3-stub-gen-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ dcc-mcp-test-utils = { path = "crates/dcc-mcp-test-utils" }
 pyo3 = { version = "0.28", features = ["multiple-pymethods"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+jsonschema = "0.28"
 serde_yaml_ng = "0.10"
 semver = "1.0"
 toon-format = { version = "0.5", default-features = false }

--- a/crates/dcc-mcp-catalog/Cargo.toml
+++ b/crates/dcc-mcp-catalog/Cargo.toml
@@ -9,7 +9,7 @@ description = "Public DCC-MCP catalog for ecosystem discovery — adapters, skil
 
 [dependencies]
 dcc-mcp-gateway-search = { workspace = true }
-jsonschema = "0.28"
+jsonschema.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/dcc-mcp-models/Cargo.toml
+++ b/crates/dcc-mcp-models/Cargo.toml
@@ -9,6 +9,7 @@ description = "Core data models for the DCC-MCP ecosystem (ActionResultModel, Sk
 
 [dependencies]
 pyo3 = { workspace = true, optional = true }
+jsonschema = { workspace = true, optional = true }
 
 # Type-stub generation (opt-in via `stub-gen` feature).
 pyo3-stub-gen = { workspace = true, optional = true }
@@ -26,7 +27,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
 default = []
-python-bindings = ["pyo3", "dcc-mcp-naming/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]
+python-bindings = ["pyo3", "dep:jsonschema", "dcc-mcp-naming/python-bindings", "dep:dcc-mcp-pybridge", "dcc-mcp-pybridge/python-bindings"]
 # Enable `pyo3-stub-gen` annotations on this crate's PyO3 types.
 stub-gen = ["python-bindings", "dep:pyo3-stub-gen", "dep:pyo3-stub-gen-derive"]
 # Expose the shared `registry::testing` harness so downstream crates can call

--- a/crates/dcc-mcp-models/src/lib.rs
+++ b/crates/dcc-mcp-models/src/lib.rs
@@ -15,6 +15,8 @@ pub mod tool_call_event;
 
 #[cfg(feature = "python-bindings")]
 mod python;
+#[cfg(feature = "python-bindings")]
+mod schema_validation;
 
 pub use action_result::ActionResultModel as ToolResult;
 pub use action_result::{
@@ -55,3 +57,5 @@ pub use python::{
     py_deserialize_result, py_error_result, py_from_exception, py_serialize_result,
     py_success_result, py_validate_action_result,
 };
+#[cfg(feature = "python-bindings")]
+pub use schema_validation::register as register_schema_validation;

--- a/crates/dcc-mcp-models/src/schema_validation.rs
+++ b/crates/dcc-mcp-models/src/schema_validation.rs
@@ -1,0 +1,66 @@
+//! Native JSON Schema validation used by public Python contracts.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+const MAX_VALIDATION_ERRORS: usize = 32;
+
+fn validate_draft_2020_12(schema_json: &str, instance_json: &str) -> Result<Vec<String>, String> {
+    let schema: serde_json::Value = serde_json::from_str(schema_json)
+        .map_err(|error| format!("invalid JSON schema document: {error}"))?;
+    let instance: serde_json::Value = serde_json::from_str(instance_json)
+        .map_err(|error| format!("invalid JSON instance document: {error}"))?;
+    let validator = jsonschema::options()
+        .with_draft(jsonschema::Draft::Draft202012)
+        .build(&schema)
+        .map_err(|error| format!("failed to compile Draft 2020-12 schema: {error}"))?;
+
+    Ok(validator
+        .iter_errors(&instance)
+        .take(MAX_VALIDATION_ERRORS)
+        .map(|error| {
+            format!(
+                "instance={} schema={}: {}",
+                error.instance_path, error.schema_path, error
+            )
+        })
+        .collect())
+}
+
+/// Validate a JSON document against a JSON Schema Draft 2020-12 document.
+///
+/// This intentionally remains a private native primitive. Public callers use
+/// `dcc_mcp_core.deployment.validate_install_sop_report`, which owns the
+/// packaged schema and stable exception contract.
+#[pyfunction]
+fn _validate_json_schema_draft_2020_12(
+    schema_json: &str,
+    instance_json: &str,
+) -> PyResult<Vec<String>> {
+    validate_draft_2020_12(schema_json, instance_json).map_err(PyValueError::new_err)
+}
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(_validate_json_schema_draft_2020_12, m)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_draft_2020_12;
+
+    #[test]
+    fn reports_instance_and_schema_paths() {
+        let schema = r#"{
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {"name": {"type": "string", "minLength": 1}},
+            "required": ["name"]
+        }"#;
+        let errors = validate_draft_2020_12(schema, r#"{"name":""}"#).unwrap();
+
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("instance=/name"));
+        assert!(errors[0].contains("schema=/properties/name/minLength"));
+    }
+}

--- a/crates/dcc-mcp-models/src/schema_validation.rs
+++ b/crates/dcc-mcp-models/src/schema_validation.rs
@@ -1,66 +1,394 @@
-//! Native JSON Schema validation used by public Python contracts.
+//! Native validation for the canonical Install SOP v1 report contract.
+
+use std::fmt;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use sha2::{Digest, Sha256};
 
+const INSTALL_SOP_SCHEMA_ID: &str =
+    "https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json";
+const INSTALL_SOP_SCHEMA_DIALECT: &str = "https://json-schema.org/draft/2020-12/schema";
+const INSTALL_SOP_SCHEMA_SHA256: &str =
+    "3ca25788439917b4d4c0617230a762f9797756b5b54f45c8c4149f975b90f904";
+const DUPLICATE_JSON_KEY: &str = "duplicate_json_object_key";
 const MAX_VALIDATION_ERRORS: usize = 32;
+const MAX_DIAGNOSTIC_BYTES: usize = 512;
+const MAX_DIAGNOSTICS_BYTES: usize = 8192;
+const MAX_PATH_BYTES: usize = 192;
+const MAX_KEYWORD_BYTES: usize = 48;
+const TRUNCATED_DIAGNOSTIC: &str =
+    "code=validation_truncated keyword=truncated instance=/ schema=/";
 
-fn validate_draft_2020_12(schema_json: &str, instance_json: &str) -> Result<Vec<String>, String> {
-    let schema: serde_json::Value = serde_json::from_str(schema_json)
-        .map_err(|error| format!("invalid JSON schema document: {error}"))?;
-    let instance: serde_json::Value = serde_json::from_str(instance_json)
-        .map_err(|error| format!("invalid JSON instance document: {error}"))?;
+struct UniqueJson(serde_json::Value);
+
+impl<'de> Deserialize<'de> for UniqueJson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(UniqueJsonVisitor)
+    }
+}
+
+struct UniqueJsonVisitor;
+
+impl<'de> Visitor<'de> for UniqueJsonVisitor {
+    type Value = UniqueJson;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::Number(value.into())))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::Number(value.into())))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        serde_json::Number::from_f64(value)
+            .map(serde_json::Value::Number)
+            .map(UniqueJson)
+            .ok_or_else(|| E::custom("non_finite_json_number"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::String(value.to_owned())))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::String(value)))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::Null))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(UniqueJson(serde_json::Value::Null))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        UniqueJson::deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element::<UniqueJson>()? {
+            values.push(value.0);
+        }
+        Ok(UniqueJson(serde_json::Value::Array(values)))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = serde_json::Map::new();
+        while let Some((key, value)) = object.next_entry::<String, UniqueJson>()? {
+            if values.contains_key(&key) {
+                return Err(de::Error::custom(DUPLICATE_JSON_KEY));
+            }
+            values.insert(key, value.0);
+        }
+        Ok(UniqueJson(serde_json::Value::Object(values)))
+    }
+}
+
+fn parse_unique_json(document: &str, prefix: &str) -> Result<serde_json::Value, String> {
+    serde_json::from_str::<UniqueJson>(document)
+        .map(|value| value.0)
+        .map_err(|error| {
+            if error.to_string().contains(DUPLICATE_JSON_KEY) {
+                format!("{prefix}_duplicate_key")
+            } else {
+                format!("{prefix}_invalid_json")
+            }
+        })
+}
+
+fn contains_external_ref(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Array(values) => values.iter().any(contains_external_ref),
+        serde_json::Value::Object(values) => values.iter().any(|(key, value)| {
+            if matches!(key.as_str(), "$ref" | "$dynamicRef" | "$recursiveRef") {
+                return value
+                    .as_str()
+                    .map(|reference| reference != "#" && !reference.starts_with("#/"))
+                    .unwrap_or(true);
+            }
+            contains_external_ref(value)
+        }),
+        _ => false,
+    }
+}
+
+fn validate_schema_identity(schema_json: &str, schema: &serde_json::Value) -> Result<(), String> {
+    if schema.get("$id").is_some()
+        && schema.get("$id").and_then(serde_json::Value::as_str) != Some(INSTALL_SOP_SCHEMA_ID)
+    {
+        return Err("install_sop_schema_identity_mismatch".to_owned());
+    }
+    if schema.get("$schema").is_some()
+        && schema.get("$schema").and_then(serde_json::Value::as_str)
+            != Some(INSTALL_SOP_SCHEMA_DIALECT)
+    {
+        return Err("install_sop_schema_dialect_mismatch".to_owned());
+    }
+    if contains_external_ref(schema) {
+        return Err("install_sop_schema_external_ref".to_owned());
+    }
+
+    let digest: String = Sha256::digest(schema_json.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    if digest != INSTALL_SOP_SCHEMA_SHA256 {
+        return Err("install_sop_schema_digest_mismatch".to_owned());
+    }
+    if schema.get("$id").and_then(serde_json::Value::as_str) != Some(INSTALL_SOP_SCHEMA_ID) {
+        return Err("install_sop_schema_identity_mismatch".to_owned());
+    }
+    if schema.get("$schema").and_then(serde_json::Value::as_str) != Some(INSTALL_SOP_SCHEMA_DIALECT)
+    {
+        return Err("install_sop_schema_dialect_mismatch".to_owned());
+    }
+    Ok(())
+}
+
+fn bounded_text(value: &str, limit: usize) -> String {
+    let mut output = String::new();
+    for character in value.chars() {
+        let character = if character.is_control() {
+            '?'
+        } else {
+            character
+        };
+        if output.len() + character.len_utf8() > limit.saturating_sub(1) {
+            output.push('~');
+            return output;
+        }
+        output.push(character);
+    }
+    output
+}
+
+fn bounded_pointer(value: &str) -> String {
+    if value.is_empty() {
+        "/".to_owned()
+    } else {
+        bounded_text(value, MAX_PATH_BYTES)
+    }
+}
+
+fn bounded_keyword(schema_path: &str) -> String {
+    let keyword = schema_path.rsplit('/').next().unwrap_or("unknown");
+    let keyword: String = keyword
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '$') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let keyword = bounded_text(&keyword, MAX_KEYWORD_BYTES);
+    if keyword.is_empty() {
+        "unknown".to_owned()
+    } else {
+        keyword
+    }
+}
+
+fn validation_diagnostics(
+    validator: &jsonschema::Validator,
+    instance: &serde_json::Value,
+) -> Vec<String> {
+    let mut diagnostics = Vec::new();
+    let mut total_bytes = 0;
+
+    for error in validator.iter_errors(instance) {
+        let instance_path = bounded_pointer(&error.instance_path.to_string());
+        let schema_path = bounded_pointer(&error.schema_path.to_string());
+        let keyword = bounded_keyword(&error.schema_path.to_string());
+        let diagnostic = format!(
+            "code=schema_validation keyword={keyword} instance={instance_path} schema={schema_path}"
+        );
+        debug_assert!(diagnostic.len() <= MAX_DIAGNOSTIC_BYTES);
+
+        if diagnostics.len() >= MAX_VALIDATION_ERRORS.saturating_sub(1)
+            || total_bytes + diagnostic.len() + TRUNCATED_DIAGNOSTIC.len() > MAX_DIAGNOSTICS_BYTES
+        {
+            diagnostics.push(TRUNCATED_DIAGNOSTIC.to_owned());
+            break;
+        }
+        total_bytes += diagnostic.len();
+        diagnostics.push(diagnostic);
+    }
+    diagnostics
+}
+
+fn validate_install_sop_report_json(
+    schema_json: &str,
+    instance_json: &str,
+) -> Result<Vec<String>, String> {
+    let schema = parse_unique_json(schema_json, "install_sop_schema")?;
+    validate_schema_identity(schema_json, &schema)?;
+    let instance = parse_unique_json(instance_json, "install_sop_report")?;
     let validator = jsonschema::options()
         .with_draft(jsonschema::Draft::Draft202012)
         .build(&schema)
-        .map_err(|error| format!("failed to compile Draft 2020-12 schema: {error}"))?;
+        .map_err(|_| "install_sop_schema_compile_failed".to_owned())?;
 
-    Ok(validator
-        .iter_errors(&instance)
-        .take(MAX_VALIDATION_ERRORS)
-        .map(|error| {
-            format!(
-                "instance={} schema={}: {}",
-                error.instance_path, error.schema_path, error
-            )
-        })
-        .collect())
+    Ok(validation_diagnostics(&validator, &instance))
 }
 
-/// Validate a JSON document against a JSON Schema Draft 2020-12 document.
+/// Validate report JSON against the byte-pinned Install SOP v1 schema.
 ///
-/// This intentionally remains a private native primitive. Public callers use
-/// `dcc_mcp_core.deployment.validate_install_sop_report`, which owns the
-/// packaged schema and stable exception contract.
+/// This private native primitive accepts schema bytes so the Python package and
+/// native wheel must agree on one canonical document before validation runs.
 #[pyfunction]
-fn _validate_json_schema_draft_2020_12(
+fn _validate_install_sop_report_json(
     schema_json: &str,
     instance_json: &str,
 ) -> PyResult<Vec<String>> {
-    validate_draft_2020_12(schema_json, instance_json).map_err(PyValueError::new_err)
+    validate_install_sop_report_json(schema_json, instance_json).map_err(PyValueError::new_err)
 }
 
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(_validate_json_schema_draft_2020_12, m)?)?;
+    m.add_function(wrap_pyfunction!(_validate_install_sop_report_json, m)?)?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate_draft_2020_12;
+    use super::{
+        MAX_DIAGNOSTIC_BYTES, MAX_DIAGNOSTICS_BYTES, TRUNCATED_DIAGNOSTIC,
+        validate_install_sop_report_json,
+    };
+
+    const INSTALL_SOP_SCHEMA: &str =
+        include_str!("../../../python/dcc_mcp_core/schemas/adapter-install-sop-v1.schema.json");
 
     #[test]
     fn reports_instance_and_schema_paths() {
-        let schema = r#"{
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "object",
-            "properties": {"name": {"type": "string", "minLength": 1}},
-            "required": ["name"]
+        let report = r#"{
+            "schema_version": 2,
+            "status": "planned",
+            "dcc_type": "example",
+            "adapter_version": "1.2.3",
+            "core_version": "0.20.23",
+            "steps": [],
+            "next_steps": [],
+            "receipt_path": null,
+            "verify": {
+                "directly_usable": false,
+                "failure_stage": null,
+                "failure_reason": null
+            }
         }"#;
-        let errors = validate_draft_2020_12(schema, r#"{"name":""}"#).unwrap();
+        let errors = validate_install_sop_report_json(INSTALL_SOP_SCHEMA, report).unwrap();
 
         assert_eq!(errors.len(), 1);
-        assert!(errors[0].contains("instance=/name"));
-        assert!(errors[0].contains("schema=/properties/name/minLength"));
+        assert!(errors[0].contains("instance=/schema_version"));
+        assert!(errors[0].contains("schema=/properties/schema_version/const"));
+        assert!(errors[0].contains("keyword=const"));
+    }
+
+    #[test]
+    fn rejects_untrusted_install_sop_schema_documents() {
+        assert_eq!(
+            validate_install_sop_report_json(r#"{"type":"object"}"#, "{}"),
+            Err("install_sop_schema_digest_mismatch".to_owned())
+        );
+        assert_eq!(
+            validate_install_sop_report_json(r#"{"$id":"x","$id":"y"}"#, "{}"),
+            Err("install_sop_schema_duplicate_key".to_owned())
+        );
+        assert_eq!(
+            validate_install_sop_report_json(
+                r##"{"$id":"https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json","$schema":"https://json-schema.org/draft/2020-12/schema","$ref":"https://attacker.invalid/schema"}"##,
+                "{}",
+            ),
+            Err("install_sop_schema_external_ref".to_owned())
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_report_object_keys() {
+        assert_eq!(
+            validate_install_sop_report_json(
+                INSTALL_SOP_SCHEMA,
+                r#"{"schema_version":1,"schema_version":2}"#,
+            ),
+            Err("install_sop_report_duplicate_key".to_owned())
+        );
+    }
+
+    #[test]
+    fn diagnostics_are_deterministic_bounded_and_value_free() {
+        let private_value = format!("PRIVATE-VALUE-{}", "x".repeat(4096));
+        let next_steps: Vec<_> = (0..48)
+            .map(|index| {
+                serde_json::json!({
+                    "id": format!("step-{index}"),
+                    "description": "Execute the install plan.",
+                    "why": "Planning does not mutate the host.",
+                    "command": ["dcc-mcp-example", " ".repeat(4096)]
+                })
+            })
+            .collect();
+        let report = serde_json::json!({
+            "schema_version": 1,
+            "status": private_value,
+            "dcc_type": "example",
+            "adapter_version": "1.2.3",
+            "core_version": "0.20.23",
+            "steps": [],
+            "next_steps": next_steps,
+            "receipt_path": null,
+            "verify": {
+                "directly_usable": false,
+                "failure_stage": null,
+                "failure_reason": null
+            }
+        })
+        .to_string();
+
+        let first = validate_install_sop_report_json(INSTALL_SOP_SCHEMA, &report).unwrap();
+        let second = validate_install_sop_report_json(INSTALL_SOP_SCHEMA, &report).unwrap();
+
+        assert_eq!(first, second);
+        assert!(!first.is_empty());
+        assert!(first.iter().all(|entry| !entry.contains("PRIVATE-VALUE")));
+        assert!(
+            first
+                .iter()
+                .all(|entry| entry.len() <= MAX_DIAGNOSTIC_BYTES)
+        );
+        assert!(first.iter().map(String::len).sum::<usize>() <= MAX_DIAGNOSTICS_BYTES);
+        assert!(first.iter().all(|entry| {
+            entry.contains("code=") && entry.contains("instance=") && entry.contains("schema=")
+        }));
+        assert_eq!(first.last().map(String::as_str), Some(TRUNCATED_DIAGNOSTIC));
     }
 }

--- a/docs/guide/adapter-install-sop.md
+++ b/docs/guide/adapter-install-sop.md
@@ -128,6 +128,19 @@ from dcc_mcp_core.deployment import load_install_sop_schema
 schema = load_install_sop_schema()
 ```
 
+Adapters should validate emitted reports through Core's full Draft 2020-12
+implementation instead of adding a Python `jsonschema` runtime dependency:
+
+```python
+from dcc_mcp_core.deployment import validate_install_sop_report
+
+validate_install_sop_report(report)
+```
+
+This validator requires an official native Core wheel. The import-light
+`py37-lite` wheel can still load the schema document, but it intentionally does
+not pretend to provide native report validation.
+
 The same document is packaged as
 `dcc_mcp_core/schemas/adapter-install-sop-v1.schema.json` with canonical id
 `https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json`.

--- a/docs/guide/adapter-install-sop.md
+++ b/docs/guide/adapter-install-sop.md
@@ -141,6 +141,18 @@ This validator requires an official native Core wheel. The import-light
 `py37-lite` wheel can still load the schema document, but it intentionally does
 not pretend to provide native report validation.
 
+### Validation and authorization boundary
+
+Schema validation is not a complete safety gate and does not grant authority to
+execute a returned next step. It verifies the byte-pinned canonical schema,
+report structure, unique step and next-step IDs, and control-character
+constraints. The downstream installer or agent remains the authorization
+boundary: immediately before mutation it MUST resolve file targets against an
+approved root, reject path traversal and unauthorized absolute paths, authorize
+the executable, and review all command arguments against the active policy. A
+structurally valid `command` or `file_edit` is data to authorize, not permission
+to execute.
+
 The same document is packaged as
 `dcc_mcp_core/schemas/adapter-install-sop-v1.schema.json` with canonical id
 `https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json`.

--- a/docs/guide/adapter-install-sop.md
+++ b/docs/guide/adapter-install-sop.md
@@ -145,13 +145,15 @@ not pretend to provide native report validation.
 
 Schema validation is not a complete safety gate and does not grant authority to
 execute a returned next step. It verifies the byte-pinned canonical schema,
-report structure, unique step and next-step IDs, and control-character
-constraints. The downstream installer or agent remains the authorization
-boundary: immediately before mutation it MUST resolve file targets against an
-approved root, reject path traversal and unauthorized absolute paths, authorize
-the executable, and review all command arguments against the active policy. A
-structurally valid `command` or `file_edit` is data to authorize, not permission
-to execute.
+report structure, unique step and next-step IDs, and Unicode General Category
+`Cc` control-character constraints (including C0 and C1). Schema and semantic
+checks consume the same captured canonical JSON document, so later changes to a
+caller-owned mapping cannot change what the semantic pass observes. The
+downstream installer or agent remains the authorization boundary: immediately
+before mutation it MUST resolve file targets against an approved root, reject
+path traversal and unauthorized absolute paths, authorize the executable, and
+review all command arguments against the active policy. A structurally valid
+`command` or `file_edit` is data to authorize, not permission to execute.
 
 The same document is packaged as
 `dcc_mcp_core/schemas/adapter-install-sop-v1.schema.json` with canonical id

--- a/docs/guide/new-adapter-onboarding.md
+++ b/docs/guide/new-adapter-onboarding.md
@@ -78,7 +78,7 @@ shared constants and schema from the ownership namespace:
 
 ```python
 from dcc_mcp_core.deployment import INSTALL_EXIT_CODES
-from dcc_mcp_core.deployment import load_install_sop_schema
+from dcc_mcp_core.deployment import validate_install_sop_report
 ```
 
 Before the first release, prove these behaviors:
@@ -94,8 +94,9 @@ Before the first release, prove these behaviors:
   idempotent;
 - verify checks digest, package/version, target-interpreter import, bootstrap
   diagnostics, and a typed readiness probe where the host can run; and
-- plan/install/status/verify/uninstall/upgrade JSON validates against the
-  shared schema with machine-executable `next_steps`.
+- plan/install/status/verify/uninstall/upgrade JSON passes
+  `validate_install_sop_report()` with machine-executable `next_steps` and no
+  adapter-owned Python JSON Schema runtime.
 
 The adapter catalog `instructions_url` must be:
 

--- a/python/dcc_mcp_core/_exports.py
+++ b/python/dcc_mcp_core/_exports.py
@@ -606,6 +606,7 @@ _ALL_LAZY: dict[str, str] = {
     "inspect_install_root": "dcc_mcp_core.deployment",
     "launch_sidecar": "dcc_mcp_core.deployment",
     "load_install_sop_schema": "dcc_mcp_core.deployment",
+    "validate_install_sop_report": "dcc_mcp_core.deployment",
     "plan_runtime_updates": "dcc_mcp_core.deployment",
     "probe_sidecar_tool": "dcc_mcp_core.deployment",
     "query_runtime_state": "dcc_mcp_core.deployment",

--- a/python/dcc_mcp_core/deployment/__init__.py
+++ b/python/dcc_mcp_core/deployment/__init__.py
@@ -15,6 +15,7 @@ from dcc_mcp_core.deployment.install_sop import INSTALL_EXIT_REQUIRES_RESTART
 from dcc_mcp_core.deployment.install_sop import INSTALL_EXIT_VERIFY
 from dcc_mcp_core.deployment.install_sop import INSTALL_SOP_SCHEMA_VERSION
 from dcc_mcp_core.deployment.install_sop import load_install_sop_schema
+from dcc_mcp_core.deployment.install_sop import validate_install_sop_report
 from dcc_mcp_core.install_lifecycle import *  # noqa: F403
 from dcc_mcp_core.install_lifecycle import __all__ as _LIFECYCLE_EXPORTS
 
@@ -29,4 +30,5 @@ __all__ = [
     "INSTALL_EXIT_VERIFY",
     "INSTALL_SOP_SCHEMA_VERSION",
     "load_install_sop_schema",
+    "validate_install_sop_report",
 ]

--- a/python/dcc_mcp_core/deployment/install_sop.py
+++ b/python/dcc_mcp_core/deployment/install_sop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -25,65 +26,215 @@ INSTALL_EXIT_CODES = {
     "requires_restart": INSTALL_EXIT_REQUIRES_RESTART,
 }
 
+_INSTALL_SOP_SCHEMA_ID = "https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json"
+_INSTALL_SOP_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+_INSTALL_SOP_SCHEMA_SHA256 = "3ca25788439917b4d4c0617230a762f9797756b5b54f45c8c4149f975b90f904"
+_MAX_NATIVE_DIAGNOSTIC_BYTES = 512
+_MAX_NATIVE_DIAGNOSTICS_BYTES = 8192
+_MAX_SEMANTIC_ERRORS = 32
 _SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schemas" / "adapter-install-sop-v1.schema.json"
 
 
+class _DuplicateJsonKeyError(ValueError):
+    """Internal marker for duplicate JSON object keys."""
+
+
+def _unique_json_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError("duplicate_json_object_key")
+        result[key] = value
+    return result
+
+
+def _decode_unique_json(document: str) -> Any:
+    return json.loads(document, object_pairs_hook=_unique_json_object)
+
+
+def _contains_external_ref(value: Any) -> bool:
+    if isinstance(value, list):
+        return any(_contains_external_ref(item) for item in value)
+    if not isinstance(value, dict):
+        return False
+    for key, item in value.items():
+        if key in {"$ref", "$dynamicRef", "$recursiveRef"}:
+            if not isinstance(item, str) or (item != "#" and not item.startswith("#/")):
+                return True
+        elif _contains_external_ref(item):
+            return True
+    return False
+
+
+def _schema_integrity_error(code: str) -> RuntimeError:
+    return RuntimeError(f"Install SOP schema integrity error: {code}")
+
+
+def _load_install_sop_schema_document() -> tuple[str, dict[str, Any]]:
+    try:
+        schema_bytes = _SCHEMA_PATH.read_bytes()
+    except OSError as exc:
+        raise _schema_integrity_error("schema_unavailable") from exc
+
+    try:
+        schema_json = schema_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _schema_integrity_error("schema_invalid_utf8") from exc
+
+    try:
+        schema = _decode_unique_json(schema_json)
+    except _DuplicateJsonKeyError as exc:
+        raise _schema_integrity_error("schema_duplicate_key") from exc
+    except (TypeError, ValueError) as exc:
+        raise _schema_integrity_error("schema_invalid_json") from exc
+
+    if not isinstance(schema, dict):
+        raise _schema_integrity_error("schema_invalid_json")
+    if schema.get("$id") != _INSTALL_SOP_SCHEMA_ID:
+        raise _schema_integrity_error("schema_identity_mismatch")
+    if schema.get("$schema") != _INSTALL_SOP_SCHEMA_DIALECT:
+        raise _schema_integrity_error("schema_dialect_mismatch")
+    if _contains_external_ref(schema):
+        raise _schema_integrity_error("schema_external_ref")
+    if hashlib.sha256(schema_bytes).hexdigest() != _INSTALL_SOP_SCHEMA_SHA256:
+        raise _schema_integrity_error("schema_digest_mismatch")
+    return schema_json, schema
+
+
 def load_install_sop_schema() -> dict[str, Any]:
-    """Return a fresh copy of the packaged Install SOP JSON Schema."""
-    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    """Return a verified fresh copy of the packaged Install SOP JSON Schema."""
+    return _load_install_sop_schema_document()[1]
+
+
+def _contains_control_character(value: str) -> bool:
+    return any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+
+
+def _semantic_validation_errors(report: Mapping[str, Any]) -> list[str]:
+    errors = []
+    truncated = False
+
+    def add(code: str, path: str) -> None:
+        nonlocal truncated
+        if len(errors) >= _MAX_SEMANTIC_ERRORS:
+            truncated = True
+            return
+        errors.append(f"code={code} path={path}")
+
+    for collection_name in ("steps", "next_steps"):
+        collection = report.get(collection_name)
+        if not isinstance(collection, list):
+            continue
+        item_name = "step" if collection_name == "steps" else "next_step"
+        seen_ids = set()
+        for index, item in enumerate(collection):
+            if not isinstance(item, Mapping):
+                continue
+            item_id = item.get("id")
+            if isinstance(item_id, str):
+                if item_id in seen_ids:
+                    add(f"duplicate_{item_name}_id", f"/{collection_name}/{index}/id")
+                else:
+                    seen_ids.add(item_id)
+                if _contains_control_character(item_id):
+                    add("control_character", f"/{collection_name}/{index}/id")
+
+            if collection_name != "next_steps":
+                continue
+            command = item.get("command")
+            if isinstance(command, list):
+                for argument_index, argument in enumerate(command):
+                    if isinstance(argument, str) and _contains_control_character(argument):
+                        add(
+                            "control_character",
+                            f"/next_steps/{index}/command/{argument_index}",
+                        )
+            file_edit = item.get("file_edit")
+            if isinstance(file_edit, Mapping):
+                path = file_edit.get("path")
+                if isinstance(path, str) and _contains_control_character(path):
+                    add("control_character", f"/next_steps/{index}/file_edit/path")
+
+    receipt_path = report.get("receipt_path")
+    if isinstance(receipt_path, str) and _contains_control_character(receipt_path):
+        add("control_character", "/receipt_path")
+
+    if truncated:
+        errors[-1] = "code=semantic_validation_truncated path=/"
+    return errors
+
+
+def _raise_native_runtime_error(code: str, cause: Exception | None = None) -> None:
+    error = RuntimeError(f"Install SOP validator runtime error: {code}")
+    if cause is None:
+        raise error
+    raise error from cause
 
 
 def validate_install_sop_report(report: Mapping[str, Any]) -> None:
-    """Validate an Install SOP report with full JSON Schema Draft 2020-12 semantics.
+    """Validate the canonical Install SOP v1 schema and bounded semantics.
 
-    The validator is compiled into the native Core wheel, so adapters do not
-    need the third-party Python ``jsonschema`` package. The pure ``py37-lite``
-    wheel intentionally cannot provide this native API.
+    Validation checks report structure, duplicate IDs, and control characters.
+    It does not authorize command execution or filesystem targets; callers own
+    those policy decisions immediately before applying a returned next step.
 
     Raises:
         TypeError: If *report* is not a mapping.
-        RuntimeError: If the native Core validation binding is unavailable.
-        ValueError: If the report is not JSON-compatible or violates the schema.
+        RuntimeError: If schema integrity or the native validator ABI fails.
+        ValueError: If the report is not JSON-compatible or violates the contract.
 
     """
     if not isinstance(report, Mapping):
         raise TypeError("Install SOP report must be a mapping")
 
+    schema_json, _ = _load_install_sop_schema_document()
     try:
-        schema_json = json.dumps(
-            load_install_sop_schema(),
-            ensure_ascii=False,
-            allow_nan=False,
-            separators=(",", ":"),
-        )
         report_json = json.dumps(
             report,
             ensure_ascii=False,
             allow_nan=False,
             separators=(",", ":"),
         )
+        _decode_unique_json(report_json)
+    except _DuplicateJsonKeyError as exc:
+        raise ValueError("Install SOP report is not JSON-compatible: duplicate_object_key") from exc
     except (TypeError, ValueError) as exc:
-        raise ValueError(f"Install SOP report is not JSON-compatible: {exc}") from exc
+        raise ValueError("Install SOP report is not JSON-compatible") from exc
 
     try:
         from dcc_mcp_core import _core
     except ImportError as exc:
         raise RuntimeError(
-            "Install SOP validation requires a native dcc-mcp-core wheel; "
-            "the py37-lite wheel does not include Draft 2020-12 validation"
+            "Install SOP validator runtime error: native_module_unavailable; native dcc-mcp-core wheel required"
         ) from exc
 
-    validator = getattr(_core, "_validate_json_schema_draft_2020_12", None)
-    if validator is None:
-        raise RuntimeError(
-            "Installed dcc-mcp-core native wheel does not provide Install SOP "
-            "Draft 2020-12 validation; upgrade dcc-mcp-core"
-        )
+    validator = getattr(_core, "_validate_install_sop_report_json", None)
+    if not callable(validator):
+        _raise_native_runtime_error("native_symbol_unavailable")
 
-    errors = validator(schema_json, report_json)
+    try:
+        errors = validator(schema_json, report_json)
+    except Exception as exc:
+        _raise_native_runtime_error("native_call_failed", exc)
+
+    if type(errors) is not list:
+        _raise_native_runtime_error("native_result_type")
+    if any(type(error) is not str for error in errors):
+        _raise_native_runtime_error("native_result_entry_type")
+    diagnostic_sizes = [len(error.encode("utf-8")) for error in errors]
+    if (
+        any(size > _MAX_NATIVE_DIAGNOSTIC_BYTES for size in diagnostic_sizes)
+        or sum(diagnostic_sizes) > _MAX_NATIVE_DIAGNOSTICS_BYTES
+    ):
+        _raise_native_runtime_error("native_result_bounds")
     if errors:
         details = "\n".join(f"- {error}" for error in errors)
         raise ValueError(f"Install SOP report failed schema validation:\n{details}")
+
+    semantic_errors = _semantic_validation_errors(report)
+    if semantic_errors:
+        details = "\n".join(f"- {error}" for error in semantic_errors)
+        raise ValueError(f"Install SOP report failed semantic validation:\n{details}")
 
 
 __all__ = [

--- a/python/dcc_mcp_core/deployment/install_sop.py
+++ b/python/dcc_mcp_core/deployment/install_sop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from typing import Mapping
 
 INSTALL_SOP_SCHEMA_VERSION = 1
 
@@ -32,6 +33,59 @@ def load_install_sop_schema() -> dict[str, Any]:
     return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
+def validate_install_sop_report(report: Mapping[str, Any]) -> None:
+    """Validate an Install SOP report with full JSON Schema Draft 2020-12 semantics.
+
+    The validator is compiled into the native Core wheel, so adapters do not
+    need the third-party Python ``jsonschema`` package. The pure ``py37-lite``
+    wheel intentionally cannot provide this native API.
+
+    Raises:
+        TypeError: If *report* is not a mapping.
+        RuntimeError: If the native Core validation binding is unavailable.
+        ValueError: If the report is not JSON-compatible or violates the schema.
+
+    """
+    if not isinstance(report, Mapping):
+        raise TypeError("Install SOP report must be a mapping")
+
+    try:
+        schema_json = json.dumps(
+            load_install_sop_schema(),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+        report_json = json.dumps(
+            report,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Install SOP report is not JSON-compatible: {exc}") from exc
+
+    try:
+        from dcc_mcp_core import _core
+    except ImportError as exc:
+        raise RuntimeError(
+            "Install SOP validation requires a native dcc-mcp-core wheel; "
+            "the py37-lite wheel does not include Draft 2020-12 validation"
+        ) from exc
+
+    validator = getattr(_core, "_validate_json_schema_draft_2020_12", None)
+    if validator is None:
+        raise RuntimeError(
+            "Installed dcc-mcp-core native wheel does not provide Install SOP "
+            "Draft 2020-12 validation; upgrade dcc-mcp-core"
+        )
+
+    errors = validator(schema_json, report_json)
+    if errors:
+        details = "\n".join(f"- {error}" for error in errors)
+        raise ValueError(f"Install SOP report failed schema validation:\n{details}")
+
+
 __all__ = [
     "INSTALL_EXIT_ACQUIRE",
     "INSTALL_EXIT_CODES",
@@ -42,4 +96,5 @@ __all__ = [
     "INSTALL_EXIT_VERIFY",
     "INSTALL_SOP_SCHEMA_VERSION",
     "load_install_sop_schema",
+    "validate_install_sop_report",
 ]

--- a/python/dcc_mcp_core/deployment/install_sop.py
+++ b/python/dcc_mcp_core/deployment/install_sop.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 from typing import Mapping
+import unicodedata
 
 INSTALL_SOP_SCHEMA_VERSION = 1
 
@@ -107,7 +108,7 @@ def load_install_sop_schema() -> dict[str, Any]:
 
 
 def _contains_control_character(value: str) -> bool:
-    return any(ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+    return any(unicodedata.category(character) == "Cc" for character in value)
 
 
 def _semantic_validation_errors(report: Mapping[str, Any]) -> list[str]:
@@ -195,7 +196,7 @@ def validate_install_sop_report(report: Mapping[str, Any]) -> None:
             allow_nan=False,
             separators=(",", ":"),
         )
-        _decode_unique_json(report_json)
+        canonical_report = _decode_unique_json(report_json)
     except _DuplicateJsonKeyError as exc:
         raise ValueError("Install SOP report is not JSON-compatible: duplicate_object_key") from exc
     except (TypeError, ValueError) as exc:
@@ -231,7 +232,7 @@ def validate_install_sop_report(report: Mapping[str, Any]) -> None:
         details = "\n".join(f"- {error}" for error in errors)
         raise ValueError(f"Install SOP report failed schema validation:\n{details}")
 
-    semantic_errors = _semantic_validation_errors(report)
+    semantic_errors = _semantic_validation_errors(canonical_report)
     if semantic_errors:
         details = "\n".join(f"- {error}" for error in semantic_errors)
         raise ValueError(f"Install SOP report failed semantic validation:\n{details}")

--- a/scripts/ci/smoke_python37_runtime.py
+++ b/scripts/ci/smoke_python37_runtime.py
@@ -16,6 +16,56 @@ except ImportError:  # pragma: no cover - direct script execution
     from python_support_contract import load_contract
 
 
+def _install_sop_report() -> dict:
+    return {
+        "schema_version": 1,
+        "status": "planned",
+        "dcc_type": "example",
+        "adapter_version": "1.2.3",
+        "core_version": "0.20.23",
+        "steps": [{"id": "preflight", "status": "ok"}],
+        "next_steps": [
+            {
+                "id": "execute",
+                "description": "Execute the validated plan.",
+                "why": "Planning does not mutate the host.",
+                "command": ["dcc-mcp-example", "install", "--yes"],
+            }
+        ],
+        "receipt_path": None,
+        "verify": {
+            "directly_usable": False,
+            "failure_stage": None,
+            "failure_reason": None,
+        },
+    }
+
+
+def _verify_install_sop_validation(profile: str) -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = _install_sop_report()
+    if profile == "lite_py37":
+        try:
+            validate_install_sop_report(report)
+        except RuntimeError as exc:
+            if "native dcc-mcp-core wheel" not in str(exc):
+                raise
+        else:
+            raise RuntimeError("lite_py37 silently claimed native Install SOP validation")
+        return
+
+    validate_install_sop_report(report)
+    report["schema_version"] = 2
+    try:
+        validate_install_sop_report(report)
+    except ValueError as exc:
+        if "/schema_version" not in str(exc) or "const" not in str(exc):
+            raise
+    else:
+        raise RuntimeError("native_py37 accepted an unsupported Install SOP version")
+
+
 def _verify_profile(profile: str) -> None:
     contract = load_contract()
     expected = tuple(int(part) for part in contract["build"][profile]["python"].split("."))
@@ -25,6 +75,8 @@ def _verify_profile(profile: str) -> None:
 
     for module_name in contract["runtime_smoke"][profile]:
         importlib.import_module(module_name)
+
+    _verify_install_sop_validation(profile)
 
     if profile == "native_py37":
         from dcc_mcp_core import ToolRegistry

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ fn register_models(m: &Bound<'_, PyModule>) -> PyResult<()> {
         dcc_mcp_models::py_serialize_result,
         dcc_mcp_models::py_deserialize_result,
     );
+    dcc_mcp_models::register_schema_validation(m)?;
     Ok(())
 }
 

--- a/tests/test_install_sop_contract.py
+++ b/tests/test_install_sop_contract.py
@@ -368,6 +368,86 @@ def test_install_sop_validator_rejects_duplicate_ids_and_executable_controls(mut
         validate_install_sop_report(report)
 
 
+def test_install_sop_validator_uses_one_stable_document_for_schema_and_semantics(monkeypatch) -> None:
+    import dcc_mcp_core
+    from dcc_mcp_core import _core
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = _install_result_with_next_step(_command_next_step())
+    report["next_steps"].append(deepcopy(report["next_steps"][0]))
+    native_validator = _core._validate_install_sop_report_json
+
+    def validate_then_change_caller_mapping(schema_json: str, report_json: str):
+        errors = native_validator(schema_json, report_json)
+        report["next_steps"].pop()
+        return errors
+
+    monkeypatch.setattr(
+        dcc_mcp_core,
+        "_core",
+        SimpleNamespace(_validate_install_sop_report_json=validate_then_change_caller_mapping),
+    )
+
+    with pytest.raises(ValueError, match=r"code=duplicate_next_step_id path=/next_steps/1/id"):
+        validate_install_sop_report(report)
+
+    assert len(report["next_steps"]) == 1
+
+
+@pytest.mark.parametrize(
+    ("build_report", "mutate", "expected_path"),
+    [
+        (
+            lambda: _install_result_with_next_step(_command_next_step()),
+            lambda report: report["steps"][0].__setitem__("id", "preflight\u0080host"),
+            "/steps/0/id",
+        ),
+        (
+            lambda: _install_result_with_next_step(_command_next_step()),
+            lambda report: report["next_steps"][0].__setitem__("id", "execute\u0085install"),
+            "/next_steps/0/id",
+        ),
+        (
+            lambda: _install_result_with_next_step(_command_next_step()),
+            lambda report: report["next_steps"][0]["command"].__setitem__(1, "install\u009f--yes"),
+            "/next_steps/0/command/1",
+        ),
+        (
+            lambda: _install_result_with_next_step(_file_edit_next_step("update", include_content=True)),
+            lambda report: report["next_steps"][0]["file_edit"].__setitem__("path", "install\u0081outside.md"),
+            "/next_steps/0/file_edit/path",
+        ),
+        (
+            lambda: _install_result_with_next_step(_command_next_step()),
+            lambda report: report.__setitem__("receipt_path", "receipts/install\u009f.json"),
+            "/receipt_path",
+        ),
+    ],
+)
+def test_install_sop_validator_rejects_c1_control_characters(build_report, mutate, expected_path) -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = build_report()
+    mutate(report)
+
+    with pytest.raises(ValueError, match=r"Install SOP report failed semantic validation") as error:
+        validate_install_sop_report(report)
+
+    assert f"code=control_character path={expected_path}" in str(error.value)
+
+
+def test_install_sop_validator_allows_normal_unicode_text() -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = _install_result_with_next_step(_command_next_step())
+    report["steps"][0]["id"] = "preflight-检查"
+    report["next_steps"][0]["id"] = "execute-安装"
+    report["next_steps"][0]["command"][1] = "install\u00a0OBS"
+    report["receipt_path"] = "状态/收据-😀.json"
+
+    validate_install_sop_report(report)
+
+
 def test_install_sop_validator_rejects_control_characters_in_file_edit_paths() -> None:
     from dcc_mcp_core import validate_install_sop_report
 

--- a/tests/test_install_sop_contract.py
+++ b/tests/test_install_sop_contract.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import subprocess
 
 from jsonschema import Draft202012Validator
+import pytest
 from scripts.ci.python_support_contract import load_contract
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -61,8 +62,11 @@ def test_install_sop_schema_is_public_and_versioned() -> None:
     assert dcc_mcp_core.INSTALL_SOP_SCHEMA_VERSION == 1
     assert deployment.INSTALL_SOP_SCHEMA_VERSION == 1
     assert dcc_mcp_core.load_install_sop_schema is deployment.load_install_sop_schema
+    assert dcc_mcp_core.validate_install_sop_report is deployment.validate_install_sop_report
     assert "load_install_sop_schema" in dcc_mcp_core.__all__
+    assert "validate_install_sop_report" in dcc_mcp_core.__all__
     assert "load_install_sop_schema" in deployment.__all__
+    assert "validate_install_sop_report" in deployment.__all__
 
     schema = deployment.load_install_sop_schema()
 
@@ -186,6 +190,55 @@ def test_install_sop_schema_requires_exactly_one_executable_form() -> None:
 
     assert not validator.is_valid(dual_form)
     assert not validator.is_valid(missing_form)
+
+
+def test_install_sop_validator_enforces_full_draft_without_python_jsonschema(monkeypatch) -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    valid = _install_result_with_next_step(_command_next_step())
+    real_import = __import__
+
+    def reject_jsonschema(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "jsonschema" or name.startswith("jsonschema."):
+            raise AssertionError("production validation imported Python jsonschema")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", reject_jsonschema)
+    validate_install_sop_report(valid)
+
+    empty_command = deepcopy(valid)
+    empty_command["next_steps"][0]["command"] = []
+    with pytest.raises(ValueError) as empty_error:
+        validate_install_sop_report(empty_command)
+    assert "/next_steps/0/command" in str(empty_error.value)
+    assert "minItems" in str(empty_error.value)
+
+    dual_form = deepcopy(valid)
+    dual_form["next_steps"][0]["file_edit"] = {"path": "install.md", "action": "remove"}
+    with pytest.raises(ValueError) as dual_error:
+        validate_install_sop_report(dual_form)
+    assert "/next_steps/0" in str(dual_error.value)
+    assert "oneOf" in str(dual_error.value)
+
+    missing_content = _install_result_with_next_step(_file_edit_next_step("create", include_content=False))
+    with pytest.raises(ValueError) as content_error:
+        validate_install_sop_report(missing_content)
+    assert "/next_steps/0/file_edit" in str(content_error.value)
+    assert "required" in str(content_error.value)
+
+    blank_path = _install_result_with_next_step(_file_edit_next_step("update", include_content=True))
+    blank_path["next_steps"][0]["file_edit"]["path"] = "   "
+    with pytest.raises(ValueError) as path_error:
+        validate_install_sop_report(blank_path)
+    assert "/next_steps/0/file_edit/path" in str(path_error.value)
+    assert "pattern" in str(path_error.value)
+
+    unsupported_version = deepcopy(valid)
+    unsupported_version["schema_version"] = 2
+    with pytest.raises(ValueError) as version_error:
+        validate_install_sop_report(unsupported_version)
+    assert "/schema_version" in str(version_error.value)
+    assert "const" in str(version_error.value)
 
 
 def test_install_sop_schema_allows_additive_adapter_fields() -> None:

--- a/tests/test_install_sop_contract.py
+++ b/tests/test_install_sop_contract.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
 
 from jsonschema import Draft202012Validator
 import pytest
@@ -76,6 +77,8 @@ def test_install_sop_schema_is_public_and_versioned() -> None:
 
 
 def test_install_sop_schema_checkout_forces_the_canonical_git_blob_bytes() -> None:
+    from dcc_mcp_core.deployment import install_sop
+
     contract = load_contract(REPO_ROOT)
     resource = contract["distributions"]["dcc-mcp-core"]["wheel_resources"][0]
     git_blob = subprocess.run(
@@ -96,6 +99,7 @@ def test_install_sop_schema_checkout_forces_the_canonical_git_blob_bytes() -> No
     assert resource["source"] == INSTALL_SOP_SCHEMA_PATH.as_posix()
     assert resource["canonical_url"] == "https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json"
     assert hashlib.sha256(git_blob).hexdigest() == resource["sha256"]
+    assert resource["sha256"] == install_sop._INSTALL_SOP_SCHEMA_SHA256
 
 
 def test_install_sop_schema_requires_agent_executable_results() -> None:
@@ -239,6 +243,220 @@ def test_install_sop_validator_enforces_full_draft_without_python_jsonschema(mon
         validate_install_sop_report(unsupported_version)
     assert "/schema_version" in str(version_error.value)
     assert "const" in str(version_error.value)
+
+
+@pytest.mark.parametrize(
+    ("schema_bytes", "error_code"),
+    [
+        (b'{"$id":"x","$id":"y"}', "schema_duplicate_key"),
+        (
+            b'{"$id":"https://attacker.invalid/schema","$schema":"https://json-schema.org/draft/2020-12/schema"}',
+            "schema_identity_mismatch",
+        ),
+        (
+            b'{"$id":"https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json","$schema":"https://attacker.invalid/draft"}',
+            "schema_dialect_mismatch",
+        ),
+        (
+            b'{"$id":"https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json","$schema":"https://json-schema.org/draft/2020-12/schema","$ref":"file:///private/schema.json"}',
+            "schema_external_ref",
+        ),
+        (
+            b'{"$id":"https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json","$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}',
+            "schema_digest_mismatch",
+        ),
+        (b"\xff", "schema_invalid_utf8"),
+        (b'{"$id":', "schema_invalid_json"),
+    ],
+)
+def test_install_sop_schema_loader_rejects_untrusted_bytes(
+    monkeypatch, tmp_path: Path, schema_bytes: bytes, error_code: str
+) -> None:
+    from dcc_mcp_core.deployment import install_sop
+
+    schema_path = tmp_path / "untrusted.schema.json"
+    schema_path.write_bytes(schema_bytes)
+    monkeypatch.setattr(install_sop, "_SCHEMA_PATH", schema_path)
+
+    with pytest.raises(RuntimeError, match=rf"^Install SOP schema integrity error: {error_code}$") as error:
+        install_sop.load_install_sop_schema()
+
+    assert str(schema_path) not in str(error.value)
+
+
+def test_install_sop_schema_loader_redacts_missing_path(monkeypatch, tmp_path: Path) -> None:
+    from dcc_mcp_core.deployment import install_sop
+
+    schema_path = tmp_path / "missing-private.schema.json"
+    monkeypatch.setattr(install_sop, "_SCHEMA_PATH", schema_path)
+
+    with pytest.raises(RuntimeError, match=r"^Install SOP schema integrity error: schema_unavailable$") as error:
+        install_sop.load_install_sop_schema()
+
+    assert str(schema_path) not in str(error.value)
+
+
+def test_install_sop_validator_separates_schema_report_and_native_failures(monkeypatch, tmp_path: Path) -> None:
+    import dcc_mcp_core
+    from dcc_mcp_core.deployment import install_sop
+
+    report = _install_result_with_next_step(_command_next_step())
+    malformed_schema = tmp_path / "malformed-private.schema.json"
+    malformed_schema.write_text('{"$id":', encoding="utf-8")
+    monkeypatch.setattr(install_sop, "_SCHEMA_PATH", malformed_schema)
+    with pytest.raises(RuntimeError, match=r"schema_invalid_json") as schema_error:
+        install_sop.validate_install_sop_report(report)
+    assert str(malformed_schema) not in str(schema_error.value)
+
+    monkeypatch.undo()
+    invalid_report = deepcopy(report)
+    invalid_report["adapter_specific"] = object()
+    with pytest.raises(ValueError, match=r"^Install SOP report is not JSON-compatible$"):
+        install_sop.validate_install_sop_report(invalid_report)
+
+    def fail_native(*_):
+        raise ValueError("PRIVATE-NATIVE-DETAIL")
+
+    monkeypatch.setattr(
+        dcc_mcp_core,
+        "_core",
+        SimpleNamespace(_validate_install_sop_report_json=fail_native),
+    )
+    with pytest.raises(RuntimeError, match=r"^Install SOP validator runtime error: native_call_failed$") as error:
+        install_sop.validate_install_sop_report(report)
+    assert "PRIVATE-NATIVE-DETAIL" not in str(error.value)
+
+
+def test_install_sop_native_validator_rejects_untrusted_schema_and_duplicate_report_keys() -> None:
+    from dcc_mcp_core import _core
+
+    assert not hasattr(_core, "_validate_json_schema_draft_2020_12")
+    validator = _core._validate_install_sop_report_json
+    canonical_schema = (REPO_ROOT / INSTALL_SOP_SCHEMA_PATH).read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"^install_sop_schema_digest_mismatch$"):
+        validator('{"type":"object"}', "{}")
+    with pytest.raises(ValueError, match=r"^install_sop_schema_duplicate_key$"):
+        validator('{"$id":"x","$id":"y"}', "{}")
+    with pytest.raises(ValueError, match=r"^install_sop_schema_external_ref$"):
+        validator(
+            '{"$id":"https://dcc-mcp.github.io/schemas/adapter-install-sop-v1.schema.json",'
+            '"$schema":"https://json-schema.org/draft/2020-12/schema",'
+            '"$ref":"https://attacker.invalid/schema"}',
+            "{}",
+        )
+    with pytest.raises(ValueError, match=r"^install_sop_report_duplicate_key$"):
+        validator(canonical_schema, '{"schema_version":1,"schema_version":2}')
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda report: report["steps"].append(deepcopy(report["steps"][0])),
+        lambda report: report["next_steps"].append(deepcopy(report["next_steps"][0])),
+        lambda report: report["next_steps"][0]["command"].__setitem__(1, "install\x00--yes"),
+        lambda report: report["next_steps"][0]["command"].__setitem__(1, "install\n--yes"),
+    ],
+)
+def test_install_sop_validator_rejects_duplicate_ids_and_executable_controls(mutate) -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = _install_result_with_next_step(_command_next_step())
+    mutate(report)
+
+    with pytest.raises(ValueError, match=r"Install SOP report failed semantic validation"):
+        validate_install_sop_report(report)
+
+
+def test_install_sop_validator_rejects_control_characters_in_file_edit_paths() -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = _install_result_with_next_step(_file_edit_next_step("update", include_content=True))
+    report["next_steps"][0]["file_edit"]["path"] = "install.md\routside"
+
+    with pytest.raises(ValueError, match=r"Install SOP report failed semantic validation"):
+        validate_install_sop_report(report)
+
+
+def test_install_sop_validator_emits_bounded_value_free_diagnostics() -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    report = _install_result_with_next_step(_command_next_step())
+    private_value = "PRIVATE-VALUE-" + ("x" * 4096)
+    report["status"] = private_value
+    report["next_steps"] = [
+        {
+            "id": f"execute-{index}",
+            "description": "Execute the validated install plan.",
+            "why": "Planning does not mutate the host.",
+            "command": ["dcc-mcp-example", " " * 4096],
+        }
+        for index in range(48)
+    ]
+
+    messages = []
+    for _ in range(2):
+        with pytest.raises(ValueError) as error:
+            validate_install_sop_report(report)
+        messages.append(str(error.value))
+
+    assert messages[0] == messages[1]
+    assert "PRIVATE-VALUE" not in messages[0]
+    assert len(messages[0].encode("utf-8")) <= 16_384
+    details = messages[0].splitlines()[1:]
+    assert details
+    assert all(len(line.encode("utf-8")) <= 640 for line in details)
+    assert all("code=" in line and "instance=" in line and "schema=" in line for line in details)
+
+
+@pytest.mark.parametrize(
+    ("native_result", "error_code"),
+    [
+        (None, "native_result_type"),
+        (("error",), "native_result_type"),
+        ([1], "native_result_entry_type"),
+        (["ok", 1], "native_result_entry_type"),
+    ],
+)
+def test_install_sop_validator_rejects_native_result_shape(monkeypatch, native_result: object, error_code: str) -> None:
+    import dcc_mcp_core
+    from dcc_mcp_core import validate_install_sop_report
+
+    fake_core = SimpleNamespace(_validate_install_sop_report_json=lambda *_: native_result)
+    monkeypatch.setattr(dcc_mcp_core, "_core", fake_core)
+
+    with pytest.raises(RuntimeError, match=rf"^Install SOP validator runtime error: {error_code}$"):
+        validate_install_sop_report(_install_result_with_next_step(_command_next_step()))
+
+
+def test_install_sop_validator_requires_callable_native_symbol(monkeypatch) -> None:
+    import dcc_mcp_core
+    from dcc_mcp_core import validate_install_sop_report
+
+    monkeypatch.setattr(
+        dcc_mcp_core,
+        "_core",
+        SimpleNamespace(_validate_install_sop_report_json="not-callable"),
+    )
+
+    with pytest.raises(RuntimeError, match=r"^Install SOP validator runtime error: native_symbol_unavailable$"):
+        validate_install_sop_report(_install_result_with_next_step(_command_next_step()))
+
+
+def test_install_sop_validation_is_not_path_or_argv_authorization() -> None:
+    from dcc_mcp_core import validate_install_sop_report
+
+    traversal = _install_result_with_next_step(_file_edit_next_step("update", include_content=True))
+    traversal["next_steps"][0]["file_edit"]["path"] = "../../outside/install.md"
+    absolute = _install_result_with_next_step(_command_next_step())
+    absolute["next_steps"][0]["command"].append("C:\\private\\target")
+
+    validate_install_sop_report(traversal)
+    validate_install_sop_report(absolute)
+
+    guide = (REPO_ROOT / "docs" / "guide" / "adapter-install-sop.md").read_text(encoding="utf-8").lower()
+    for phrase in ("authorization boundary", "path traversal", "absolute paths", "command arguments"):
+        assert phrase in guide
 
 
 def test_install_sop_schema_allows_additive_adapter_fields() -> None:


### PR DESCRIPTION
## Summary
- expose `validate_install_sop_report()` with full Draft 2020-12 semantics backed by Core's Rust `jsonschema` implementation
- preserve instance/schema paths and failing keyword diagnostics
- keep `py37-lite` fail-explicit so adapters can drop Python `jsonschema` only after a native Core release

## Validation
- `cargo test -p dcc-mcp-models --features python-bindings --jobs 2`
- `cargo test -p dcc-mcp-core --features python-bindings --jobs 2`
- `cargo clippy --workspace -- -D warnings`
- 25 focused Python contract/architecture tests
- ABI3 wheel contract plus isolated `--no-deps` validation without Python `jsonschema`
- Python 3.7 support and syntax checks
- docs build

Full Python suite reached 10,989 passed; a Rez startup timing failure passed on retry, while an installed-CLI Maya version-filter mismatch remains unrelated to this change.

Skill guidance: no skill-pack change is required; the public Install SOP and adapter onboarding guidance is updated in this PR.