### PR TITLE
fix: isolate generated lock workflow execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,9 @@ jobs:
           trusted_validator_generate_runs_from_stdin_on_windows or
           trusted_validator_verify_diff_preserves_unstaged_lock_status or
           trusted_validator_source_requires_confirmed_shallow_checkout"
+      - name: Run generated lock workflow Python 3.7 contract
+        if: runner.os == 'Windows'
+        run: python -m pytest tests/test_generated_lock_workflow_execution.py -q --tb=short --show-capture=no
       - name: Run full Python 3.7 test suite
         if: matrix.full_suite
         run: python -m pytest tests/ -q --tb=short --show-capture=no -n 4 --dist loadfile

--- a/.github/workflows/release-please-lock-sync.yml
+++ b/.github/workflows/release-please-lock-sync.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: pull-request
         run: |
           set -euo pipefail
-          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python - validate-remote
+          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python -I - validate-remote
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -90,7 +90,7 @@ jobs:
         working-directory: pull-request
         run: |
           set -euo pipefail
-          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python - generate
+          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python -I - generate
 
       - name: Revalidate pull request identity and generated diff
         env:
@@ -104,8 +104,8 @@ jobs:
         working-directory: pull-request
         run: |
           set -euo pipefail
-          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python - preflight
-          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python - verify-diff
+          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python -I - preflight
+          git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | python -I - verify-diff
 
       - name: Commit and push changes
         id: commit
@@ -140,9 +140,9 @@ jobs:
           set -euo pipefail
           # Re-capture remote identity without passing the write token to the
           # validation child processes, then enforce the immutable lease.
-          env -u PUSH_TOKEN git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | env -u PUSH_TOKEN python - validate-remote
-          env -u PUSH_TOKEN git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | env -u PUSH_TOKEN python - remote-preflight
-          env -u PUSH_TOKEN git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | env -u PUSH_TOKEN python - verify-commit
+          env -u PUSH_TOKEN git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | env -u PUSH_TOKEN python -I - validate-remote
+          env -u PUSH_TOKEN git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | env -u PUSH_TOKEN python -I - remote-preflight
+          env -u PUSH_TOKEN git -C ../trusted-lock-validator show "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py" | env -u PUSH_TOKEN python -I - verify-commit
           credential_file="$(mktemp)"
           trap 'rm -f "$credential_file"' EXIT
           chmod 600 "$credential_file"
@@ -157,6 +157,5 @@ jobs:
             -c core.gitProxy= \
             -c credential.helper= \
             -c credential.helper="store --file=${credential_file}" \
-            --no-verify \
-            push --force-with-lease="refs/heads/${HEAD_REF}:${EXPECTED_HEAD_SHA}" \
+            push --no-verify --force-with-lease="refs/heads/${HEAD_REF}:${EXPECTED_HEAD_SHA}" \
             "https://github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/tests/test_generated_lock_workflow_execution.py
+++ b/tests/test_generated_lock_workflow_execution.py
@@ -1,0 +1,300 @@
+"""Execute the generated-lock workflow's command boundaries with local fixtures."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from conftest import REPO_ROOT
+from dcc_mcp_core import yaml_loads
+from test_uv_lock_consistency import _trusted_validator_source
+
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release-please-lock-sync.yml"
+
+
+def _workflow_steps():
+    workflow = yaml_loads(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return workflow["jobs"]["sync-cargo-metadata"]["steps"]
+
+
+def _logical_commands(step):
+    return [
+        line.strip()
+        for line in step.get("run", "").replace("\\\n", "").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _clean_environment(root: Path) -> dict[str, str]:
+    git = shutil.which("git")
+    assert git is not None
+    path = [str(Path(git).parent), str(Path(sys.executable).parent)]
+    env = {key: os.environ[key] for key in ("SYSTEMROOT", "WINDIR") if key in os.environ}
+    if os.name == "nt":
+        path.extend([str(Path(env["SYSTEMROOT"]) / "System32"), env["SYSTEMROOT"]])
+    else:
+        path.extend(os.defpath.split(os.pathsep))
+    env.update(
+        {
+            "PATH": os.pathsep.join(path),
+            "HOME": str(root),
+            "USERPROFILE": str(root),
+            "TEMP": str(root),
+            "TMP": str(root),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ALLOW_PROTOCOL": "file",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    return env
+
+
+def _git(cwd: Path, env: dict[str, str], *args: str) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=loonghao",
+            "-c",
+            "user.email=hal.long@outlook.com",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result.stdout.rstrip("\r\n")
+
+
+@pytest.fixture
+def push_repository(tmp_path: Path):
+    env = _clean_environment(tmp_path)
+    bare = tmp_path / "remote repository.git"
+    work = tmp_path / "candidate checkout"
+    _git(tmp_path, env, "init", "--bare", "-q", str(bare))
+    _git(tmp_path, env, "init", "-q", str(work))
+    (work / "Cargo.lock").write_bytes(b"baseline\n")
+    _git(work, env, "add", "Cargo.lock")
+    _git(work, env, "commit", "-qm", "test: seed lock fixture")
+    _git(work, env, "push", "-q", str(bare), "HEAD:main")
+    expected = _git(work, env, "rev-parse", "HEAD")
+    (work / "Cargo.lock").write_bytes(b"generated\n")
+    _git(work, env, "commit", "-qam", "test: generate lock fixture")
+    candidate = _git(work, env, "rev-parse", "HEAD")
+    marker = tmp_path / "candidate-hook-ran"
+    hook = work / ".git" / "hooks" / "pre-push"
+    hook.write_bytes(f"#!/bin/sh\nprintf 'synthetic' > '{marker.as_posix()}'\nexit 1\n".encode())
+    hook.chmod(0o755)
+    credential_file = tmp_path / "empty credential store"
+    credential_file.write_bytes(b"")
+    return SimpleNamespace(
+        root=tmp_path,
+        env=env,
+        bare=bare,
+        work=work,
+        expected=expected,
+        candidate=candidate,
+        marker=marker,
+        credential_file=credential_file,
+    )
+
+
+def _workflow_push_invocation(repository):
+    step = next(step for step in _workflow_steps() if step.get("name") == "Push fixed generated lock commit")
+    commands = [command for command in _logical_commands(step) if command.startswith("env -u http_proxy ")]
+    assert len(commands) == 1
+    argv = shlex.split(commands[0])
+    assert argv.pop(0) == "env"
+    env = dict(repository.env)
+    while argv[0] == "-u":
+        argv.pop(0)
+        env.pop(argv.pop(0), None)
+    assert argv[0] == "git"
+    # Only the destination and quoted fixture values change; Git option order
+    # is taken verbatim from the actual workflow, not rebuilt by this test.
+    assert argv[-2] == "https://github.com/${GITHUB_REPOSITORY}.git"
+    argv[-2] = str(repository.bare)
+    values = {
+        "${credential_file}": str(repository.credential_file),
+        "${HEAD_REF}": "main",
+        "${EXPECTED_HEAD_SHA}": repository.expected,
+    }
+    for index, argument in enumerate(argv):
+        for variable, value in values.items():
+            argument = argument.replace(variable, value)
+        assert "$" not in argument
+        argv[index] = argument
+    return argv, env
+
+
+def test_workflow_push_updates_expected_branch_without_candidate_hook(push_repository) -> None:
+    repository = push_repository
+    argv, env = _workflow_push_invocation(repository)
+    result = subprocess.run(argv, cwd=repository.work, env=env, capture_output=True, text=True, timeout=30)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(repository.bare, env, "rev-parse", "refs/heads/main") == repository.candidate
+    assert _git(repository.work, env, "ls-remote", str(repository.bare), "refs/heads/main") == (
+        f"{repository.candidate}\trefs/heads/main"
+    )
+    assert not repository.marker.exists()
+
+
+def test_workflow_push_hook_control_detects_omitted_no_verify(push_repository) -> None:
+    repository = push_repository
+    argv, env = _workflow_push_invocation(repository)
+    argv.remove("--no-verify")
+    result = subprocess.run(argv, cwd=repository.work, env=env, capture_output=True, text=True, timeout=30)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert repository.marker.read_bytes() == b"synthetic"
+    assert _git(repository.bare, env, "rev-parse", "refs/heads/main") == repository.expected
+
+
+def test_workflow_push_rejects_stale_lease_without_remote_mutation(push_repository) -> None:
+    repository = push_repository
+    other = repository.root / "concurrent checkout"
+    _git(repository.root, repository.env, "clone", "-q", "--branch", "main", str(repository.bare), str(other))
+    _git(other, repository.env, "commit", "--allow-empty", "-qm", "test: advance remote fixture")
+    _git(other, repository.env, "push", "-q", str(repository.bare), "HEAD:main")
+    advanced = _git(repository.bare, repository.env, "rev-parse", "refs/heads/main")
+    argv, env = _workflow_push_invocation(repository)
+    result = subprocess.run(argv, cwd=repository.work, env=env, capture_output=True, text=True, timeout=30)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "stale info" in result.stderr
+    assert _git(repository.bare, env, "rev-parse", "refs/heads/main") == advanced
+    assert not repository.marker.exists()
+
+
+def _workflow_validator_invocations():
+    invocations = []
+    for step in _workflow_steps():
+        for command in _logical_commands(step):
+            if "trusted-lock-validator show" not in command:
+                continue
+            pipeline = shlex.split(command)
+            assert pipeline.count("|") == 1
+            separator = pipeline.index("|")
+            source, argv = pipeline[:separator], pipeline[separator + 1 :]
+            removed = []
+            if source[:3] == ["env", "-u", "PUSH_TOKEN"]:
+                source = source[3:]
+            assert source == [
+                "git",
+                "-C",
+                "../trusted-lock-validator",
+                "show",
+                "$TRUSTED_VALIDATOR_REF:scripts/ci/generated_lock_sync.py",
+            ]
+            if argv[:3] == ["env", "-u", "PUSH_TOKEN"]:
+                removed.append("PUSH_TOKEN")
+                argv = argv[3:]
+            assert argv[0] == "python"
+            invocations.append((step["name"] + "/" + argv[-1], argv, removed))
+    assert len(invocations) == 7
+    return invocations
+
+
+def _shadow_fixture(root: Path, vector: str):
+    candidate = root / "candidate"
+    candidate.mkdir()
+    env = _clean_environment(root)
+    if vector == "cwd":
+        shadow_root = candidate
+    else:
+        shadow_root = root / "pythonpath"
+        shadow_root.mkdir()
+        env["PYTHONPATH"] = str(shadow_root)
+    (shadow_root / "argparse.py").write_bytes(b'raise SystemExit("SYNTHETIC_WORKFLOW_IMPORT_SHADOW")\n')
+    return candidate, env
+
+
+@pytest.mark.parametrize("invocation", _workflow_validator_invocations(), ids=lambda invocation: invocation[0])
+@pytest.mark.parametrize("vector", ["cwd", "pythonpath"])
+def test_workflow_validator_ignores_candidate_import_shadow(tmp_path: Path, invocation, vector: str) -> None:
+    source = _trusted_validator_source()
+    candidate, env = _shadow_fixture(tmp_path, vector)
+    _, argv, removed = invocation
+    for name in removed:
+        env.pop(name, None)
+    # Keep each real subcommand, but stop at argparse before any generation,
+    # network, identity checks, or writes can occur.
+    result = subprocess.run(
+        [sys.executable, *argv[1:], "--help"],
+        cwd=candidate,
+        env=env,
+        input=source,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "usage:" in result.stdout and "verify-commit" in result.stdout
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize("vector", ["cwd", "pythonpath"])
+def test_workflow_validator_shadow_control_detects_omitted_isolation(tmp_path: Path, vector: str) -> None:
+    source = _trusted_validator_source()
+    candidate, env = _shadow_fixture(tmp_path, vector)
+    _, argv, _ = _workflow_validator_invocations()[0]
+    assert "-I" in argv
+    ordinary = [argument for argument in argv[1:] if argument != "-I"]
+    result = subprocess.run(
+        [sys.executable, *ordinary, "--help"],
+        cwd=candidate,
+        env=env,
+        input=source,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr.strip() == "SYNTHETIC_WORKFLOW_IMPORT_SHADOW"
+
+
+def test_workflow_validator_verifies_real_diff_with_candidate_shadow(push_repository) -> None:
+    source = _trusted_validator_source()
+    repository = push_repository
+    (repository.work / "argparse.py").write_bytes(b'raise SystemExit("SYNTHETIC_WORKFLOW_IMPORT_SHADOW")\n')
+    _git(repository.work, repository.env, "add", "argparse.py")
+    _git(repository.work, repository.env, "commit", "-qm", "test: track candidate import fixture")
+    lock = repository.work / "Cargo.lock"
+    lock.write_bytes(b"regenerated\n")
+    status = _git(repository.work, repository.env, "status", "--porcelain=v1", "--untracked-files=all")
+    assert status == " M Cargo.lock"
+    _, argv, _ = next(
+        invocation for invocation in _workflow_validator_invocations() if invocation[1][-1] == "verify-diff"
+    )
+    result = subprocess.run(
+        [sys.executable, *argv[1:]],
+        cwd=repository.work,
+        env=repository.env,
+        input=source,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert lock.read_bytes() == b"regenerated\n"
+    assert _git(repository.work, repository.env, "status", "--porcelain=v1", "--untracked-files=all") == status
+    assert not repository.marker.exists()

--- a/tests/test_uv_lock_consistency.py
+++ b/tests/test_uv_lock_consistency.py
@@ -311,7 +311,9 @@ def test_release_workflows_regenerate_and_validate_uv_lock() -> None:
         job="sync-cargo-metadata",
         step_name="Sync generated lock metadata",
     )
-    assert any("trusted-lock-validator show" in command and "python - generate" in command for command in sync_commands)
+    assert any(
+        "trusted-lock-validator show" in command and "python -I - generate" in command for command in sync_commands
+    )
     commit_commands = _workflow_step_commands(
         sync_workflow,
         job="sync-cargo-metadata",
@@ -361,11 +363,11 @@ def test_generated_lock_workflow_is_read_only_until_fixed_push() -> None:
     remote_check = next(step for step in job["steps"] if step.get("name") == "Validate checkout remote")
     assert (
         "git -C ../trusted-lock-validator show" in remote_check["run"]
-        and "python - validate-remote" in remote_check["run"]
+        and "python -I - validate-remote" in remote_check["run"]
     )
     assert remote_check["working-directory"] == "pull-request"
     generation = next(step for step in job["steps"] if step.get("name") == "Sync generated lock metadata")
-    assert "../trusted-lock-validator show" in generation["run"] and "python - generate" in generation["run"]
+    assert "../trusted-lock-validator show" in generation["run"] and "python -I - generate" in generation["run"]
     assert generation["working-directory"] == "pull-request"
     assert "PUSH_TOKEN" not in generation.get("env", {})
     push = next(step for step in job["steps"] if step.get("name") == "Push fixed generated lock commit")
@@ -393,7 +395,7 @@ def test_generated_lock_workflow_is_read_only_until_fixed_push() -> None:
     assert "env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY" in push["run"]
     assert "validate-remote" in push["run"]
     assert "--no-verify" in push["run"]
-    assert "../trusted-lock-validator show" in push["run"] and "python - verify-commit" in push["run"]
+    assert "../trusted-lock-validator show" in push["run"] and "python -I - verify-commit" in push["run"]
 
 
 def test_trusted_validator_overwrite_is_detected_before_execution() -> None:
@@ -466,7 +468,7 @@ def test_trusted_validator_verify_diff_preserves_unstaged_lock_status(tmp_path: 
     assert status_before == " M Cargo.lock\n"
 
     result = subprocess.run(
-        [sys.executable, "-", "verify-diff", "--root", str(tmp_path)],
+        [sys.executable, "-I", "-", "verify-diff", "--root", str(tmp_path)],
         cwd=tmp_path,
         input=validator_source,
         capture_output=True,
@@ -481,7 +483,7 @@ def test_trusted_validator_verify_diff_preserves_unstaged_lock_status(tmp_path: 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows trusted-stdin execution contract")
 def test_trusted_validator_generate_runs_from_stdin_on_windows(tmp_path: Path) -> None:
-    """The exact validator object must remain executable through ``python -``."""
+    """The exact validator object must remain executable through ``python -I -``."""
     validator_source = _trusted_validator_source()
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -492,7 +494,7 @@ def test_trusted_validator_generate_runs_from_stdin_on_windows(tmp_path: Path) -
     env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
 
     result = subprocess.run(
-        [sys.executable, "-", "generate", "--root", str(tmp_path)],
+        [sys.executable, "-I", "-", "generate", "--root", str(tmp_path)],
         cwd=tmp_path,
         env=env,
         input=validator_source,
@@ -592,7 +594,7 @@ def test_trusted_validator_ref_attests_self_contained_job_object() -> None:
     assert "_kill_windows_tree" not in source
 
     result = subprocess.run(
-        [sys.executable, "-", "--help"],
+        [sys.executable, "-I", "-", "--help"],
         check=False,
         cwd=REPO_ROOT,
         input=source,
@@ -619,6 +621,11 @@ def test_native_python37_windows_executes_pinned_validator_contract() -> None:
     assert "trusted_validator_generate_runs_from_stdin_on_windows" in contract["run"]
     assert "trusted_validator_verify_diff_preserves_unstaged_lock_status" in contract["run"]
     assert "trusted_validator_source_requires_confirmed_shallow_checkout" in contract["run"]
+    execution = next(step for step in steps if step.get("name") == "Run generated lock workflow Python 3.7 contract")
+    assert execution["if"] == "runner.os == 'Windows'"
+    assert execution["run"] == (
+        "python -m pytest tests/test_generated_lock_workflow_execution.py -q --tb=short --show-capture=no"
+    )
 
 
 def test_generated_lock_contract_rejects_fork_and_identity_drift() -> None:


### PR DESCRIPTION
## Summary
- Correct the generated-lock push invocation and isolate trusted stdin helper execution.
- Add workflow-derived local execution regressions and explicit native Windows Python 3.7 coverage.
- Keep the immutable validator ref and existing credential permissions unchanged.

## Validation
- Reproduced both failures before the fixes; local regression suites: 97 passed, 7 platform skips.
- Ruff, Actionlint, Python support contract, diff checks, and push formatting passed.
- Full CI and independent review remain required.

Follow-up to #2451. No public runtime or Skill contract changes; no Skill update needed.