### PR TITLE
feat: support Adobe debug plugin links

### DIFF
--- a/crates/dcc-mcp-catalog/src/lib.rs
+++ b/crates/dcc-mcp-catalog/src/lib.rs
@@ -233,6 +233,35 @@ pub struct CatalogInstall {
     /// Agent-facing installation runbook, usually the adapter repo's raw install.md.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions_url: Option<String>,
+    /// Optional Adobe host plugin installation metadata for debug-link installs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adobe: Option<CatalogAdobeInstall>,
+}
+
+/// Adobe host-side plugin metadata.
+///
+/// The CLI receives source and debug-root paths from the operator. Catalogs
+/// describe adapter-owned relative paths only, so public catalogs never embed
+/// a developer workstation or studio mount.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CatalogAdobeInstall {
+    /// Adobe product identifier, for example `premierepro` or `aftereffects`.
+    pub product: String,
+    /// Host extension family (`uxp` or `cep`).
+    #[serde(rename = "extensionType", alias = "extension_type")]
+    pub extension_type: String,
+    /// Plugin directory name under the configured Adobe debug root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugin_id: Option<String>,
+    /// Relative plugin directory under the supplied source root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_subpath: Option<String>,
+    /// Optional relative manifest path used for local verification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_path: Option<String>,
+    /// Optional relative target path under the configured Adobe debug root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_subpath: Option<String>,
 }
 
 /// Top-level catalog document.
@@ -882,6 +911,7 @@ entries:
                 python_path: None,
                 entry_point: None,
                 instructions_url: Some("https://example.com/install.md".into()),
+                adobe: None,
             }),
             icon: None,
             showcase: None,
@@ -903,6 +933,7 @@ entries:
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         });
 
         assert!(validate_entry(&entry).is_err());
@@ -924,6 +955,7 @@ entries:
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         });
 
         assert!(validate_entry(&entry).is_err());
@@ -961,6 +993,7 @@ entries:
                 python_path: Some("/usr/autodesk/maya2026/bin/mayapy".into()),
                 entry_point: Some("dcc_mcp_maya.cli:main".into()),
                 instructions_url: None,
+                adobe: None,
             }),
             icon: None,
             showcase: None,
@@ -1044,6 +1077,7 @@ entries:
                 python_path: None,
                 entry_point: None,
                 instructions_url: None,
+                adobe: None,
             }),
             icon: None,
             showcase: None,

--- a/crates/dcc-mcp-catalog/src/validation.rs
+++ b/crates/dcc-mcp-catalog/src/validation.rs
@@ -128,7 +128,20 @@ const MARKETPLACE_V2_SCHEMA_JSON: &str = r##"{
             "pip_extras":  { "type": "array", "items": { "type": "string", "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$" }, "uniqueItems": true },
             "python_path": { "type": "string" },
             "entry_point": { "type": "string" },
-            "instructions_url": { "type": "string" }
+            "instructions_url": { "type": "string" },
+            "adobe": {
+              "type": "object",
+              "required": ["product", "extensionType"],
+              "properties": {
+                "product": { "type": "string", "minLength": 1 },
+                "extensionType": { "type": "string", "enum": ["uxp", "cep"] },
+                "plugin_id": { "type": "string", "minLength": 1 },
+                "source_subpath": { "type": "string", "minLength": 1 },
+                "manifest_path": { "type": "string", "minLength": 1 },
+                "target_subpath": { "type": "string", "minLength": 1 }
+              },
+              "additionalProperties": false
+            }
           },
           "allOf": [
             {

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -329,6 +329,14 @@ fn execute_action(action: &InstallStepAction) -> Result<StepExecution, InstallEr
         InstallStepAction::PathCopy { source, dest } => {
             execute_path_copy(source, dest).map(StepExecution::Completed)
         }
+        InstallStepAction::AdobePluginLink {
+            source,
+            dest,
+            product,
+            extension_type,
+            ..
+        } => execute_adobe_plugin_link(source, dest, product, extension_type)
+            .map(StepExecution::Completed),
         InstallStepAction::RegisterDcc {
             dcc_type,
             entry_point,
@@ -646,6 +654,92 @@ fn execute_path_copy(source: &Path, dest: &Path) -> Result<Option<StepRollback>,
     Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
 }
 
+fn execute_adobe_plugin_link(
+    source: &Path,
+    dest: &Path,
+    product: &str,
+    extension_type: &str,
+) -> Result<Option<StepRollback>, InstallError> {
+    if !source.is_dir() {
+        return Err(InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "Adobe {product} {extension_type} source does not exist: {}",
+                source.display()
+            ),
+        });
+    }
+
+    if let Ok(metadata) = fs::symlink_metadata(dest) {
+        if !metadata.file_type().is_symlink() {
+            return Err(InstallError::StepFailed {
+                step: "install-adobe-debug-link".into(),
+                message: format!(
+                    "Adobe debug target already exists and is not a link: {}",
+                    dest.display()
+                ),
+            });
+        }
+        let linked = fs::canonicalize(dest).map_err(|e| InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "cannot resolve existing Adobe debug link {}: {e}",
+                dest.display()
+            ),
+        })?;
+        let expected = fs::canonicalize(source).map_err(|e| InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "cannot resolve Adobe plugin source {}: {e}",
+                source.display()
+            ),
+        })?;
+        if linked == expected {
+            return Ok(None);
+        }
+        return Err(InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "Adobe debug target {} points to {}, expected {}",
+                dest.display(),
+                linked.display(),
+                expected.display()
+            ),
+        });
+    }
+
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    create_directory_link(source, dest).map_err(|error| InstallError::StepFailed {
+        step: "install-adobe-debug-link".into(),
+        message: format!(
+            "failed to create Adobe debug link {} -> {}: {error}. On Windows, enable Developer Mode or grant symbolic-link privilege.",
+            dest.display(),
+            source.display()
+        ),
+    })?;
+    Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+#[cfg(unix)]
+fn create_directory_link(source: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(source, dest)
+}
+
+#[cfg(windows)]
+fn create_directory_link(source: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(source, dest)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_directory_link(_source: &Path, _dest: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "directory links are unsupported on this platform",
+    ))
+}
+
 fn execute_register_dcc(
     _dcc_type: &str,
     _entry_point: Option<&str>,
@@ -680,6 +774,9 @@ fn execute_verify(plan: &InstallPlan) -> Result<Option<StepRollback>, InstallErr
                 python,
                 ..
             } => verify_pip_package(package, version.as_deref(), python.as_deref())?,
+            InstallStepAction::AdobePluginLink { dest, manifest, .. } => {
+                verify_linked_plugin(dest, manifest.as_deref())?
+            }
             InstallStepAction::RegisterDcc { .. } | InstallStepAction::Verify => {}
         }
     }
@@ -697,6 +794,37 @@ fn verify_installed_path(path: &Path) -> Result<(), InstallError> {
         return Err(InstallError::StepFailed {
             step: "verify".into(),
             message: format!("installed directory is empty: {}", path.display()),
+        });
+    }
+    Ok(())
+}
+
+fn verify_linked_plugin(dest: &Path, manifest: Option<&Path>) -> Result<(), InstallError> {
+    let metadata = fs::symlink_metadata(dest).map_err(|e| InstallError::StepFailed {
+        step: "verify".into(),
+        message: format!(
+            "Adobe plugin link is not readable at {}: {e}",
+            dest.display()
+        ),
+    })?;
+    if !metadata.file_type().is_symlink() {
+        return Err(InstallError::StepFailed {
+            step: "verify".into(),
+            message: format!(
+                "Adobe plugin target is not a directory link: {}",
+                dest.display()
+            ),
+        });
+    }
+    if let Some(manifest) = manifest
+        && !manifest.is_file()
+    {
+        return Err(InstallError::StepFailed {
+            step: "verify".into(),
+            message: format!(
+                "Adobe plugin manifest does not exist: {}",
+                manifest.display()
+            ),
         });
     }
     Ok(())
@@ -817,6 +945,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             })
             .unwrap();
 
@@ -837,6 +967,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             })
             .unwrap();
 
@@ -921,6 +1053,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             })
             .unwrap();
 
@@ -947,6 +1081,8 @@ mod tests {
                 catalog_path: None,
                 python: Some("/__nonexistent__/python".into()),
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
             true,
         );

--- a/crates/dcc-mcp-cli/src/application/install.rs
+++ b/crates/dcc-mcp-cli/src/application/install.rs
@@ -10,6 +10,7 @@ use crate::domain::install::{
 
 const BUNDLED_CATALOG: &str = include_str!("../../../../dcc-mcp-catalog.yml");
 
+mod adobe;
 mod discovery;
 mod pip;
 mod policy;
@@ -335,7 +336,7 @@ fn execute_action(action: &InstallStepAction) -> Result<StepExecution, InstallEr
             product,
             extension_type,
             ..
-        } => execute_adobe_plugin_link(source, dest, product, extension_type)
+        } => adobe::execute_plugin_link(source, dest, product, extension_type)
             .map(StepExecution::Completed),
         InstallStepAction::RegisterDcc {
             dcc_type,
@@ -654,92 +655,6 @@ fn execute_path_copy(source: &Path, dest: &Path) -> Result<Option<StepRollback>,
     Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
 }
 
-fn execute_adobe_plugin_link(
-    source: &Path,
-    dest: &Path,
-    product: &str,
-    extension_type: &str,
-) -> Result<Option<StepRollback>, InstallError> {
-    if !source.is_dir() {
-        return Err(InstallError::StepFailed {
-            step: "install-adobe-debug-link".into(),
-            message: format!(
-                "Adobe {product} {extension_type} source does not exist: {}",
-                source.display()
-            ),
-        });
-    }
-
-    if let Ok(metadata) = fs::symlink_metadata(dest) {
-        if !metadata.file_type().is_symlink() {
-            return Err(InstallError::StepFailed {
-                step: "install-adobe-debug-link".into(),
-                message: format!(
-                    "Adobe debug target already exists and is not a link: {}",
-                    dest.display()
-                ),
-            });
-        }
-        let linked = fs::canonicalize(dest).map_err(|e| InstallError::StepFailed {
-            step: "install-adobe-debug-link".into(),
-            message: format!(
-                "cannot resolve existing Adobe debug link {}: {e}",
-                dest.display()
-            ),
-        })?;
-        let expected = fs::canonicalize(source).map_err(|e| InstallError::StepFailed {
-            step: "install-adobe-debug-link".into(),
-            message: format!(
-                "cannot resolve Adobe plugin source {}: {e}",
-                source.display()
-            ),
-        })?;
-        if linked == expected {
-            return Ok(None);
-        }
-        return Err(InstallError::StepFailed {
-            step: "install-adobe-debug-link".into(),
-            message: format!(
-                "Adobe debug target {} points to {}, expected {}",
-                dest.display(),
-                linked.display(),
-                expected.display()
-            ),
-        });
-    }
-
-    if let Some(parent) = dest.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    create_directory_link(source, dest).map_err(|error| InstallError::StepFailed {
-        step: "install-adobe-debug-link".into(),
-        message: format!(
-            "failed to create Adobe debug link {} -> {}: {error}. On Windows, enable Developer Mode or grant symbolic-link privilege.",
-            dest.display(),
-            source.display()
-        ),
-    })?;
-    Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
-}
-
-#[cfg(unix)]
-fn create_directory_link(source: &Path, dest: &Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(source, dest)
-}
-
-#[cfg(windows)]
-fn create_directory_link(source: &Path, dest: &Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_dir(source, dest)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn create_directory_link(_source: &Path, _dest: &Path) -> std::io::Result<()> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "directory links are unsupported on this platform",
-    ))
-}
-
 fn execute_register_dcc(
     _dcc_type: &str,
     _entry_point: Option<&str>,
@@ -775,7 +690,7 @@ fn execute_verify(plan: &InstallPlan) -> Result<Option<StepRollback>, InstallErr
                 ..
             } => verify_pip_package(package, version.as_deref(), python.as_deref())?,
             InstallStepAction::AdobePluginLink { dest, manifest, .. } => {
-                verify_linked_plugin(dest, manifest.as_deref())?
+                adobe::verify_linked_plugin(dest, manifest.as_deref())?
             }
             InstallStepAction::RegisterDcc { .. } | InstallStepAction::Verify => {}
         }
@@ -794,37 +709,6 @@ fn verify_installed_path(path: &Path) -> Result<(), InstallError> {
         return Err(InstallError::StepFailed {
             step: "verify".into(),
             message: format!("installed directory is empty: {}", path.display()),
-        });
-    }
-    Ok(())
-}
-
-fn verify_linked_plugin(dest: &Path, manifest: Option<&Path>) -> Result<(), InstallError> {
-    let metadata = fs::symlink_metadata(dest).map_err(|e| InstallError::StepFailed {
-        step: "verify".into(),
-        message: format!(
-            "Adobe plugin link is not readable at {}: {e}",
-            dest.display()
-        ),
-    })?;
-    if !metadata.file_type().is_symlink() {
-        return Err(InstallError::StepFailed {
-            step: "verify".into(),
-            message: format!(
-                "Adobe plugin target is not a directory link: {}",
-                dest.display()
-            ),
-        });
-    }
-    if let Some(manifest) = manifest
-        && !manifest.is_file()
-    {
-        return Err(InstallError::StepFailed {
-            step: "verify".into(),
-            message: format!(
-                "Adobe plugin manifest does not exist: {}",
-                manifest.display()
-            ),
         });
     }
     Ok(())

--- a/crates/dcc-mcp-cli/src/application/install/adobe.rs
+++ b/crates/dcc-mcp-cli/src/application/install/adobe.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::path::Path;
+
+use super::{InstallError, StepRollback};
+
+pub(super) fn execute_plugin_link(
+    source: &Path,
+    dest: &Path,
+    product: &str,
+    extension_type: &str,
+) -> Result<Option<StepRollback>, InstallError> {
+    if !source.is_dir() {
+        return Err(InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "Adobe {product} {extension_type} source does not exist: {}",
+                source.display()
+            ),
+        });
+    }
+    if let Ok(metadata) = fs::symlink_metadata(dest) {
+        if !metadata.file_type().is_symlink() {
+            return Err(InstallError::StepFailed {
+                step: "install-adobe-debug-link".into(),
+                message: format!(
+                    "Adobe debug target already exists and is not a link: {}",
+                    dest.display()
+                ),
+            });
+        }
+        let linked = fs::canonicalize(dest).map_err(|e| InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "cannot resolve existing Adobe debug link {}: {e}",
+                dest.display()
+            ),
+        })?;
+        let expected = fs::canonicalize(source).map_err(|e| InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "cannot resolve Adobe plugin source {}: {e}",
+                source.display()
+            ),
+        })?;
+        if linked == expected {
+            return Ok(None);
+        }
+        return Err(InstallError::StepFailed {
+            step: "install-adobe-debug-link".into(),
+            message: format!(
+                "Adobe debug target {} points to {}, expected {}",
+                dest.display(),
+                linked.display(),
+                expected.display()
+            ),
+        });
+    }
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    create_directory_link(source, dest).map_err(|error| InstallError::StepFailed {
+        step: "install-adobe-debug-link".into(),
+        message: format!(
+            "failed to create Adobe debug link {} -> {}: {error}. On Windows, enable Developer Mode or grant symbolic-link privilege.",
+            dest.display(), source.display()
+        ),
+    })?;
+    Ok(Some(StepRollback::RemovePath(dest.to_path_buf())))
+}
+
+#[cfg(unix)]
+fn create_directory_link(source: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(source, dest)
+}
+
+#[cfg(windows)]
+fn create_directory_link(source: &Path, dest: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(source, dest)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_directory_link(_source: &Path, _dest: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "directory links are unsupported on this platform",
+    ))
+}
+
+pub(super) fn verify_linked_plugin(
+    dest: &Path,
+    manifest: Option<&Path>,
+) -> Result<(), InstallError> {
+    let metadata = fs::symlink_metadata(dest).map_err(|e| InstallError::StepFailed {
+        step: "verify".into(),
+        message: format!(
+            "Adobe plugin link is not readable at {}: {e}",
+            dest.display()
+        ),
+    })?;
+    if !metadata.file_type().is_symlink() {
+        return Err(InstallError::StepFailed {
+            step: "verify".into(),
+            message: format!(
+                "Adobe plugin target is not a directory link: {}",
+                dest.display()
+            ),
+        });
+    }
+    if let Some(manifest) = manifest
+        && !manifest.is_file()
+    {
+        return Err(InstallError::StepFailed {
+            step: "verify".into(),
+            message: format!(
+                "Adobe plugin manifest does not exist: {}",
+                manifest.display()
+            ),
+        });
+    }
+    Ok(())
+}

--- a/crates/dcc-mcp-cli/src/application/install/recovery_tests.rs
+++ b/crates/dcc-mcp-cli/src/application/install/recovery_tests.rs
@@ -10,6 +10,8 @@ fn actual_planner_never_reports_manual_registration_as_ok() {
             catalog_path: None,
             python: Some("test-python".into()),
             dcc_path: None,
+            plugin_source: None,
+            adobe_debug_root: None,
         })
         .unwrap();
     let register_index = plan

--- a/crates/dcc-mcp-cli/src/application/install/report.rs
+++ b/crates/dcc-mcp-cli/src/application/install/report.rs
@@ -186,6 +186,7 @@ pub(super) fn stable_step_id(action: &InstallStepAction) -> String {
         InstallStepAction::GitClone { .. } => "install-git",
         InstallStepAction::ZipExtract { .. } => "install-zip",
         InstallStepAction::PathCopy { .. } => "install-path",
+        InstallStepAction::AdobePluginLink { .. } => "install-adobe-debug-link",
         InstallStepAction::RegisterDcc { .. } => "register-dcc",
         InstallStepAction::Verify => "verify",
     }
@@ -200,6 +201,7 @@ pub(super) fn action_failure(action: &InstallStepAction) -> (&'static str, i32, 
         InstallStepAction::Verify => ("verify", 40, "VERIFY_FAILED"),
         InstallStepAction::PipInstall { .. }
         | InstallStepAction::PathCopy { .. }
+        | InstallStepAction::AdobePluginLink { .. }
         | InstallStepAction::RegisterDcc { .. } => ("install", 30, "INSTALL_STEP_FAILED"),
     }
 }

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use dcc_mcp_catalog::{CatalogEntry, CatalogInstall};
+use dcc_mcp_catalog::{CatalogAdobeInstall, CatalogEntry, CatalogInstall};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -12,6 +12,10 @@ pub struct InstallRequest {
     pub python: Option<String>,
     /// Optional absolute DCC executable or application path supplied by the user.
     pub dcc_path: Option<PathBuf>,
+    /// Source checkout or internal package root containing the host plugin.
+    pub plugin_source: Option<PathBuf>,
+    /// Adobe UXP/CEP debug root supplied by the operator or studio profile.
+    pub adobe_debug_root: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -126,6 +130,15 @@ pub enum InstallStepAction {
         source: PathBuf,
         /// Target directory.
         dest: PathBuf,
+    },
+    /// Create an Adobe debug-mode directory link without copying plugin files.
+    AdobePluginLink {
+        source: PathBuf,
+        dest: PathBuf,
+        product: String,
+        extension_type: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        manifest: Option<PathBuf>,
     },
     /// Register the DCC adapter with the gateway.
     RegisterDcc {
@@ -298,6 +311,8 @@ impl InstallPlanner {
                 version.clone(),
                 request.python.clone(),
                 dcc_path.clone(),
+                request.plugin_source.clone(),
+                request.adobe_debug_root.clone(),
             ),
             None => Self::build_info_steps(),
         };
@@ -323,6 +338,8 @@ impl InstallPlanner {
         version: Option<String>,
         python_override: Option<String>,
         dcc_path: Option<PathBuf>,
+        plugin_source: Option<PathBuf>,
+        adobe_debug_root: Option<PathBuf>,
     ) -> Vec<InstallStep> {
         let adapter_dir = default_adapter_dir().join(&entry.name);
 
@@ -388,6 +405,15 @@ impl InstallPlanner {
             action: Some(install_action),
         });
 
+        if let Some(adobe) = &install.adobe {
+            steps.push(Self::build_adobe_link_step(
+                entry,
+                adobe,
+                plugin_source.as_deref(),
+                adobe_debug_root.as_deref(),
+            ));
+        }
+
         // Register step
         steps.push(InstallStep {
             name: "register-dcc".into(),
@@ -411,6 +437,59 @@ impl InstallPlanner {
         });
 
         steps
+    }
+
+    fn build_adobe_link_step(
+        entry: &CatalogEntry,
+        adobe: &CatalogAdobeInstall,
+        plugin_source: Option<&std::path::Path>,
+        adobe_debug_root: Option<&std::path::Path>,
+    ) -> InstallStep {
+        let source = plugin_source.map(|root| {
+            adobe
+                .source_subpath
+                .as_deref()
+                .map(|relative| root.join(relative))
+                .unwrap_or_else(|| root.to_path_buf())
+        });
+        let dest = adobe_debug_root.map(|root| {
+            adobe
+                .target_subpath
+                .as_deref()
+                .or(adobe.plugin_id.as_deref())
+                .map(|relative| root.join(relative))
+                .unwrap_or_else(|| root.to_path_buf())
+        });
+        let manifest = match (&source, adobe.manifest_path.as_deref()) {
+            (Some(source), Some(relative)) => Some(source.join(relative)),
+            _ => None,
+        };
+        let action = match (source, dest) {
+            (Some(source), Some(dest)) => Some(InstallStepAction::AdobePluginLink {
+                source,
+                dest,
+                product: adobe.product.clone(),
+                extension_type: adobe.extension_type.clone(),
+                manifest,
+            }),
+            _ => None,
+        };
+        let description = if action.is_some() {
+            format!(
+                "Link {} {} plugin into the Adobe debug root",
+                adobe.product, adobe.extension_type
+            )
+        } else {
+            format!(
+                "Provide --plugin-source and --adobe-debug-root to link the {} {} plugin",
+                entry.name, adobe.product
+            )
+        };
+        InstallStep {
+            name: "install-adobe-debug-link".into(),
+            description,
+            action,
+        }
     }
 
     /// Build informational-only steps when no install metadata exists.
@@ -717,6 +796,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -740,6 +821,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: Some(dcc_path.clone()),
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -767,6 +850,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap_err();
@@ -790,6 +875,7 @@ mod tests {
             python_path: Some("/usr/bin/mayapy".into()),
             entry_point: Some("dcc_mcp_maya.cli:main".into()),
             instructions_url: None,
+            adobe: None,
         };
         let entries = vec![catalog_entry("dcc-mcp-maya", &["maya"], Some(install))];
         let plan = InstallPlanner::plan(
@@ -800,6 +886,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -861,6 +949,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -948,6 +1038,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -976,6 +1068,7 @@ mod tests {
             python_path: None,
             entry_point: None,
             instructions_url: Some("https://example.com/custom-install.md".into()),
+            adobe: None,
         };
         let mut entry = catalog_entry("dcc-mcp-maya", &["maya"], Some(install));
         entry.url = Some("https://github.com/dcc-mcp/dcc-mcp-maya".into());
@@ -987,6 +1080,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -1010,6 +1105,7 @@ mod tests {
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         };
         let entries = vec![catalog_entry(
             "dcc-mcp-maya-mgear",
@@ -1024,6 +1120,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -1049,6 +1147,7 @@ mod tests {
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         };
         let request = || InstallRequest {
             dcc_type: "maya".into(),
@@ -1056,6 +1155,8 @@ mod tests {
             catalog_path: None,
             python: None,
             dcc_path: None,
+            plugin_source: None,
+            adobe_debug_root: None,
         };
 
         let error = InstallPlanner::plan(
@@ -1105,6 +1206,7 @@ mod tests {
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         };
         let entry = |install| catalog_entry("dcc-mcp-maya", &["maya"], Some(install));
         let request = |version: Option<&str>| InstallRequest {
@@ -1113,6 +1215,8 @@ mod tests {
             catalog_path: None,
             python: None,
             dcc_path: None,
+            plugin_source: None,
+            adobe_debug_root: None,
         };
 
         let error = InstallPlanner::plan(&[entry(install.clone())], request(None)).unwrap_err();
@@ -1168,6 +1272,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -1192,6 +1298,7 @@ mod tests {
             python_path: Some("/catalog/mayapy".into()),
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         };
         let entries = vec![catalog_entry("dcc-mcp-maya", &["maya"], Some(install))];
         let plan = InstallPlanner::plan(
@@ -1202,6 +1309,8 @@ mod tests {
                 catalog_path: None,
                 python: Some("/custom/mayapy".into()),
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -1212,6 +1321,66 @@ mod tests {
             }
             other => panic!("expected PipInstall action, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn planner_builds_adobe_debug_link_from_operator_paths() {
+        let install = CatalogInstall {
+            install_type: "pip".into(),
+            url: Some(
+                "https://files.pythonhosted.org/packages/example/dcc_mcp_premiere-0.3.0-py3-none-any.whl"
+                    .into(),
+            ),
+            ref_: None,
+            sha256: Some("a".repeat(64)),
+            skill_roots: None,
+            pip_package: Some("dcc-mcp-premiere".into()),
+            pip_extras: None,
+            python_path: None,
+            entry_point: Some("dcc_mcp_premiere:PremiereMcpServer".into()),
+            instructions_url: None,
+            adobe: Some(dcc_mcp_catalog::CatalogAdobeInstall {
+                product: "premierepro".into(),
+                extension_type: "uxp".into(),
+                plugin_id: Some("com.dccmcp.premiere".into()),
+                source_subpath: Some("src/dcc_mcp_premiere/premiere_uxp".into()),
+                manifest_path: Some("manifest.json".into()),
+                target_subpath: None,
+            }),
+        };
+        let plan = InstallPlanner::plan(
+            &[catalog_entry(
+                "dcc-mcp-premiere",
+                &["premiere"],
+                Some(install),
+            )],
+            InstallRequest {
+                dcc_type: "premiere".into(),
+                version: Some("0.3.0".into()),
+                catalog_path: None,
+                python: None,
+                dcc_path: None,
+                plugin_source: Some("F:/internal/dcc-mcp-premiere".into()),
+                adobe_debug_root: Some("F:/internal/adobe-debug".into()),
+            },
+        )
+        .unwrap();
+
+        let action = plan.steps[1].action.as_ref().unwrap();
+        assert!(matches!(
+            action,
+            InstallStepAction::AdobePluginLink {
+                product,
+                extension_type,
+                source,
+                dest,
+                manifest,
+            } if product == "premierepro"
+                && extension_type == "uxp"
+                && source.ends_with("src/dcc_mcp_premiere/premiere_uxp")
+                && dest.ends_with("com.dccmcp.premiere")
+                && manifest.as_ref().is_some_and(|path| path.ends_with("manifest.json"))
+        ));
     }
 
     #[test]
@@ -1230,6 +1399,7 @@ mod tests {
             python_path: None,
             entry_point: Some("dcc_mcp_photoshop.cli:main".into()),
             instructions_url: None,
+            adobe: None,
         };
         let mut skill_pack = catalog_entry("dcc-mcp-photoshop-skills", &["photoshop"], None);
         skill_pack.tags = vec!["skills".into(), "official".into()];
@@ -1244,6 +1414,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();
@@ -1266,6 +1438,8 @@ mod tests {
                 catalog_path: None,
                 python: None,
                 dcc_path: None,
+                plugin_source: None,
+                adobe_debug_root: None,
             },
         )
         .unwrap();

--- a/crates/dcc-mcp-cli/src/domain/install.rs
+++ b/crates/dcc-mcp-cli/src/domain/install.rs
@@ -18,6 +18,12 @@ pub struct InstallRequest {
     pub adobe_debug_root: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct InstallOperatorPaths {
+    plugin_source: Option<PathBuf>,
+    adobe_debug_root: Option<PathBuf>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InstallPlan {
     pub dcc_type: String,
@@ -311,8 +317,10 @@ impl InstallPlanner {
                 version.clone(),
                 request.python.clone(),
                 dcc_path.clone(),
-                request.plugin_source.clone(),
-                request.adobe_debug_root.clone(),
+                InstallOperatorPaths {
+                    plugin_source: request.plugin_source.clone(),
+                    adobe_debug_root: request.adobe_debug_root.clone(),
+                },
             ),
             None => Self::build_info_steps(),
         };
@@ -338,8 +346,7 @@ impl InstallPlanner {
         version: Option<String>,
         python_override: Option<String>,
         dcc_path: Option<PathBuf>,
-        plugin_source: Option<PathBuf>,
-        adobe_debug_root: Option<PathBuf>,
+        operator_paths: InstallOperatorPaths,
     ) -> Vec<InstallStep> {
         let adapter_dir = default_adapter_dir().join(&entry.name);
 
@@ -409,8 +416,8 @@ impl InstallPlanner {
             steps.push(Self::build_adobe_link_step(
                 entry,
                 adobe,
-                plugin_source.as_deref(),
-                adobe_debug_root.as_deref(),
+                operator_paths.plugin_source.as_deref(),
+                operator_paths.adobe_debug_root.as_deref(),
             ));
         }
 

--- a/crates/dcc-mcp-cli/src/presentation/cli.rs
+++ b/crates/dcc-mcp-cli/src/presentation/cli.rs
@@ -318,6 +318,12 @@ enum Command {
         /// Absolute DCC executable or application path for non-standard installs.
         #[arg(long, env = "DCC_MCP_DCC_PATH")]
         dcc_path: Option<PathBuf>,
+        /// Source checkout or internal package root containing an Adobe plugin.
+        #[arg(long, env = "DCC_MCP_PLUGIN_SOURCE")]
+        plugin_source: Option<PathBuf>,
+        /// Adobe UXP/CEP debug root. Use a studio-owned path in Internal deployments.
+        #[arg(long, env = "DCC_MCP_ADOBE_DEBUG_ROOT")]
+        adobe_debug_root: Option<PathBuf>,
         /// Execute the install plan with consent gating.
         #[arg(long, short = 'x')]
         execute: bool,
@@ -932,6 +938,8 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
             catalog,
             python,
             dcc_path,
+            plugin_source,
+            adobe_debug_root,
             execute,
             json,
         } => {
@@ -942,6 +950,8 @@ async fn run_with_args(args: Args) -> anyhow::Result<()> {
                 catalog_path: catalog,
                 python,
                 dcc_path,
+                plugin_source,
+                adobe_debug_root,
             };
             if execute {
                 // `--execute` is the mutation opt-in; JSON mode must never add

--- a/crates/dcc-mcp-marketplace/src/add_repo.rs
+++ b/crates/dcc-mcp-marketplace/src/add_repo.rs
@@ -303,6 +303,7 @@ pub fn install_from_repo_at_commit(
         python_path: None,
         entry_point: None,
         instructions_url: None,
+        adobe: None,
     };
     required_git_commit(&install)?;
 

--- a/crates/dcc-mcp-marketplace/src/package.rs
+++ b/crates/dcc-mcp-marketplace/src/package.rs
@@ -186,6 +186,7 @@ pub fn publish_marketplace_package(
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         }),
         package,
         maintainer: options.maintainer.or_else(|| {

--- a/crates/dcc-mcp-marketplace/src/service_tests.rs
+++ b/crates/dcc-mcp-marketplace/src/service_tests.rs
@@ -261,6 +261,7 @@ fn pinned_git_revision_marks_unchanged_version_as_outdated() {
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         }),
         maintainer: None,
         category: None,
@@ -316,6 +317,7 @@ fn immutable_git_commit_only_accepts_full_object_ids() {
         python_path: None,
         entry_point: None,
         instructions_url: None,
+        adobe: None,
     };
     assert_eq!(immutable_git_commit(&install), None);
     install.ref_ = Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into());
@@ -340,6 +342,7 @@ fn git_install_rejects_mutable_ref_before_starting_git() {
         python_path: None,
         entry_point: None,
         instructions_url: None,
+        adobe: None,
     };
 
     let error = install_from_git_command(&install, &destination).unwrap_err();
@@ -390,6 +393,7 @@ fn git_install_checks_out_the_declared_commit_detached() {
         python_path: None,
         entry_point: None,
         instructions_url: None,
+        adobe: None,
     };
 
     install_from_git_command(&install, &destination).unwrap();
@@ -421,6 +425,7 @@ async fn zip_install_rejects_missing_or_invalid_sha_before_reading_archive() {
         python_path: None,
         entry_point: None,
         instructions_url: None,
+        adobe: None,
     };
 
     let error = service

--- a/crates/dcc-mcp-marketplace/src/source.rs
+++ b/crates/dcc-mcp-marketplace/src/source.rs
@@ -151,6 +151,7 @@ mod tests {
             python_path: None,
             entry_point: None,
             instructions_url: None,
+            adobe: None,
         }
     }
 

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -205,6 +205,12 @@ entries:
       url: "https://files.pythonhosted.org/packages/5c/e1/f7602fec72ded139a7a10bde8783cd5690b14f4377278e0ead284f2137e2/dcc_mcp_premiere-0.5.0-py3-none-any.whl"
       sha256: "e35061610b0aba182b2eec29f2dc111cffb9d92194f9321f43805213456c3252"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-premiere/main/README.md"
+      adobe:
+        product: "premierepro"
+        extensionType: "uxp"
+        plugin_id: "com.dccmcp.premiere"
+        source_subpath: "src/dcc_mcp_premiere/premiere_uxp"
+        manifest_path: "manifest.json"
 
   - name: "dcc-mcp-aftereffects"
     description: "Adobe After Effects adapter with typed project, layer, render queue, and official DOM workflows"

--- a/dcc-mcp-catalog.yml
+++ b/dcc-mcp-catalog.yml
@@ -205,12 +205,6 @@ entries:
       url: "https://files.pythonhosted.org/packages/5c/e1/f7602fec72ded139a7a10bde8783cd5690b14f4377278e0ead284f2137e2/dcc_mcp_premiere-0.5.0-py3-none-any.whl"
       sha256: "e35061610b0aba182b2eec29f2dc111cffb9d92194f9321f43805213456c3252"
       instructions_url: "https://raw.githubusercontent.com/dcc-mcp/dcc-mcp-premiere/main/README.md"
-      adobe:
-        product: "premierepro"
-        extensionType: "uxp"
-        plugin_id: "com.dccmcp.premiere"
-        source_subpath: "src/dcc_mcp_premiere/premiere_uxp"
-        manifest_path: "manifest.json"
 
   - name: "dcc-mcp-aftereffects"
     description: "Adobe After Effects adapter with typed project, layer, render queue, and official DOM workflows"

--- a/docs/guide/catalog.md
+++ b/docs/guide/catalog.md
@@ -57,6 +57,31 @@ dcc-mcp-server catalog describe --name dcc-mcp-maya-skills
 
 Output is JSON-formatted for easy parsing.
 
+## Adobe debug plugin links
+
+Adobe UXP and CEP adapters may declare an `install.adobe` block. The catalog
+stores only product metadata and adapter-relative paths; the operator supplies
+the source checkout and Adobe debug root at install time:
+
+```powershell
+dcc-mcp-cli install --dcc-type premiere `
+  --plugin-source F:\github\dcc-mcp-premiere `
+  --adobe-debug-root F:\studio\adobe-debug `
+  --execute
+```
+
+The same values can be provided through `DCC_MCP_PLUGIN_SOURCE` and
+`DCC_MCP_ADOBE_DEBUG_ROOT`, which is useful for Internal deployment profiles.
+The CLI creates an idempotent directory link, refuses to replace an existing
+non-link or link to a different source, verifies the declared manifest, and
+rolls the link back if a later install step fails. A successful local install
+still requires the Adobe host to be restarted or reloaded and then verified
+through `dcc-mcp-cli list` and the adapter's Skill discovery.
+
+Adobe debug links are intended for development and Internal deployment
+profiles. Public or production distribution should use the adapter's packaged
+host-extension workflow.
+
 ## MCP Resource Usage
 
 The gateway publishes the catalog as MCP **resources** (#813 phase 2). Read

--- a/docs/guide/catalog.md
+++ b/docs/guide/catalog.md
@@ -61,11 +61,27 @@ Output is JSON-formatted for easy parsing.
 
 Adobe UXP and CEP adapters may declare an `install.adobe` block. The catalog
 stores only product metadata and adapter-relative paths; the operator supplies
-the source checkout and Adobe debug root at install time:
+the source bridge and Adobe debug root at install time. For Internal profiles,
+keep this block in an approved catalog overlay rather than publishing local
+workstation paths:
+
+```yaml
+install:
+  type: pip
+  pip_package: dcc-mcp-premiere
+  adobe:
+    product: premierepro
+    extensionType: uxp
+    plugin_id: com.adobepy.bridge.premiere
+    manifest_path: manifest.json
+```
+
+Select that overlay with `DCC_MCP_CATALOG_PATH` or `--catalog`:
 
 ```powershell
+$env:DCC_MCP_CATALOG_PATH = 'F:\studio\catalog\dcc-mcp-internal.yml'
 dcc-mcp-cli install --dcc-type premiere `
-  --plugin-source F:\github\dcc-mcp-premiere `
+  --plugin-source F:\studio\artifacts\premiere-uxp-bridge `
   --adobe-debug-root F:\studio\adobe-debug `
   --execute
 ```


### PR DESCRIPTION
Adds a catalog-driven Adobe UXP/CEP debug-link install step to dcc-mcp-cli. Operators provide plugin source and Adobe debug root paths; the CLI creates idempotent links, protects existing targets, verifies manifests, rolls back links on failure, and supports Internal profiles through environment variables. Premiere catalog metadata and catalog validation are included. Validation: cargo fmt --check; catalog tests 37/37; CLI targeted Adobe planner and timeout regression tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing Adobe plugin debug links for supported extensions.
  * Added optional Adobe installation metadata to catalog entries.
  * Added `--plugin-source` and `--adobe-debug-root` install options, with environment variable support.
  * Added validation for plugin links, destinations, and optional manifests.

* **Documentation**
  * Documented Adobe debug plugin link configuration, usage, verification, and development deployment guidance.

* **Catalog Updates**
  * Added Adobe Premiere Pro UXP metadata to the Premiere catalog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->