### PR TITLE
test: support MCP Python SDK stream tuple variants

### DIFF
--- a/tests/test_mcp_http_server.py
+++ b/tests/test_mcp_http_server.py
@@ -504,19 +504,21 @@ class TestMcpSdkClient:
 
         _, _, url = running_server
 
-        async with mcp.client.streamable_http.streamable_http_client(url) as (
-            read,
-            write,
-            _,
-        ), mcp.client.session.ClientSession(read, write) as session:
-            result = await session.initialize()
-            assert result.serverInfo.name == "e2e-test-server"
-            assert result.protocolVersion in ("2025-03-26", "2025-06-18", "2025-11-25")
+        # Python SDK 2.1.1 returns (read, write), while 1.x and early 2.x
+        # releases also returned a third session-id callback.  The transport
+        # contract only requires the two streams, so keep the fixture valid
+        # across both official SDK shapes.
+        async with mcp.client.streamable_http.streamable_http_client(url) as streams:
+            read, write = streams[:2]
+            async with mcp.client.session.ClientSession(read, write) as session:
+                result = await session.initialize()
+                assert result.serverInfo.name == "e2e-test-server"
+                assert result.protocolVersion in ("2025-03-26", "2025-06-18", "2025-11-25")
 
-            tools = await session.list_tools()
-            names = {t.name for t in tools.tools}
-            assert "get_scene_info" in names
-            assert "list_objects" in names
+                tools = await session.list_tools()
+                names = {t.name for t in tools.tools}
+                assert "get_scene_info" in names
+                assert "list_objects" in names
 
     @pytest.mark.anyio
     async def test_sdk_call_tool(self, running_server):
@@ -526,15 +528,13 @@ class TestMcpSdkClient:
 
         _, _, url = running_server
 
-        async with mcp.client.streamable_http.streamable_http_client(url) as (
-            read,
-            write,
-            _,
-        ), mcp.client.session.ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.call_tool("get_scene_info", {})
-            assert not result.isError
-            assert len(result.content) > 0
+        async with mcp.client.streamable_http.streamable_http_client(url) as streams:
+            read, write = streams[:2]
+            async with mcp.client.session.ClientSession(read, write) as session:
+                await session.initialize()
+                result = await session.call_tool("get_scene_info", {})
+                assert not result.isError
+                assert len(result.content) > 0
 
 
 # ── McpHttpServer Python API tests ───────────────────────────────────────


### PR DESCRIPTION
The official MCP Python SDK changed `streamable_http_client` from a three-item context value to the two transport streams used by 2.1.1. Update the Core SDK fixtures to consume the stable `(read, write)` prefix while retaining compatibility with earlier releases.

Validation:
- `python -m pytest tests/test_mcp_http_server.py -k 'sdk_initialize_and_list_tools or sdk_call_tool' -q`
- `python -m ruff check tests/test_mcp_http_server.py`

Related to #2436.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with multiple Python SDK versions when establishing streamable HTTP client connections.
  * Updated SDK-based test handling to support transports that return either two or three connection values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->